### PR TITLE
Phase 1: seed AGENTS.md and skills for layered refactor

### DIFF
--- a/.claude/skills/add-api-route/SKILL.md
+++ b/.claude/skills/add-api-route/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: add-api-route
+description: Use this skill whenever you need to add a new HTTP endpoint to the server, or extend an existing one with a new method. Walks through port, adapter, domain, handler, registration, and test in the correct order. Enforces the layer rules in app/server/AGENTS.md.
+---
+
+# Add an API Route
+
+Adding an endpoint touches four layers in a fixed order. Follow them.
+Skipping a layer ("I'll just call `fs` from the handler this once") is
+how the cloud-migration seam disappears.
+
+## Order of operations
+
+1. **Port** — declare what the domain needs.
+2. **Adapter** — implement it for the filesystem.
+3. **Domain** — write the business logic that uses the port.
+4. **Handler** — wire the HTTP route to the domain.
+5. **Registration** — register the handler in the composition root.
+6. **Test** — Vitest the domain function with an in-memory port.
+
+## Before you start: file existence
+
+The Phase 2 refactor is in flight. At any point, the target files
+(`server/http/<entity>.routes.ts`, `server/domain/<entity>.ts`,
+`server/data/fs/<entity>.fs.ts`, `server/data/ports.ts`,
+`server/data/fs/index.ts`, `server/index.ts`) may or may not exist
+yet. **Create them if missing; extend them if present.**
+
+You may grep for existing symbols (e.g. `EventStore`,
+`makeFsEventStore`) to match the style of code that's already
+migrated. You may **not** read `app/server/api.ts` to crib from the
+legacy implementation — it conflates layers and will mislead you. The
+target shape lives in this skill and the AGENTS.md files; the
+behaviour you need to reproduce comes from the user's request, not
+from `api.ts`.
+
+## 1. Port: declare the operation
+
+File: `app/server/data/ports.ts`.
+
+Decide which port the operation belongs to (`EventStore`, `NoteStore`,
+`StateStore`, `TrashStore`, `GitPort`). If none fit, that's a design
+question — ask, don't invent.
+
+The method speaks in domain terms — never paths or file extensions:
+
+```ts
+// good
+export interface EventStore {
+  archive(id: string, ifMatch: number): Promise<{ mtime: number }>;
+}
+
+// bad — leaks filesystem concerns
+archive(filename: string, mtime: number): Promise<void>;
+```
+
+If the operation can be done without IO (filtering, deriving), it
+**does not belong on a port** — put it in `domain/` instead.
+
+## 2. Adapter: filesystem implementation
+
+File: `app/server/data/fs/<entity>.fs.ts`.
+
+Use only the sanctioned utilities:
+
+- `app/server/data/fs/atomic.ts` → `writeFileAtomic(path, contents)`.
+  The only sanctioned write path. Never use `fs.writeFile` directly.
+- `app/server/data/fs/paths.ts` → `safeResolveInRepo`,
+  `validNoteFolder`, `safeNoteResolve`. The only sanctioned path
+  validators. Never roll your own — they prevent directory traversal.
+- `app/server/domain/yaml.ts` → for parse/serialise. Don't import
+  `gray-matter` directly.
+
+Adapter shape:
+
+```ts
+import { writeFileAtomic } from './atomic.ts';
+import { safeResolveInRepo } from './paths.ts';
+import { parseEventFile, serialiseEvent } from '../../domain/yaml.ts';
+
+export function makeFsEventStore(root: string): EventStore {
+  return {
+    async archive(id, ifMatch) {
+      const path = safeResolveInRepo(root, 'events', `${id}.md`);
+      let stat;
+      try {
+        stat = await fs.stat(path);
+      } catch (e) {
+        if (e.code === 'ENOENT') return null;       // not found → null
+        throw e;
+      }
+      if (stat.mtimeMs !== ifMatch) {
+        throw new ConflictError(stat.mtimeMs);      // stale → typed error
+      }
+      const current = parseEventFile(await fs.readFile(path, 'utf8'));
+      const next = serialiseEvent({ ...current, archived: true });
+      await writeFileAtomic(path, next);
+      const newStat = await fs.stat(path);
+      return { mtime: newStat.mtimeMs };
+    },
+  };
+}
+```
+
+**Adapter error contract (important):**
+
+- "Not found" → return `null` or `undefined`. Catch `ENOENT` from
+  `fs.stat`/`fs.readFile` and translate. Adapters never throw
+  `NotFoundError` — that's a domain concern.
+- "Stale mtime" → throw `ConflictError(currentMtime)`. The domain
+  layer re-throws; the handler maps to 409.
+- Anything else (permissions, disk full, parse failure) → throw the
+  raw error. The domain layer lets it propagate; the handler returns
+  500.
+
+The port method's return type tells you which: `Promise<X | null>`
+means the caller should handle null; `Promise<X>` means errors only.
+
+## 3. Domain: business logic
+
+File: `app/server/domain/<entity>.ts`.
+
+Functions take ports as arguments. They throw typed errors from
+`app/server/domain/errors.ts` (`NotFoundError`, `ConflictError`,
+`ValidationError`).
+
+```ts
+export async function archiveEvent(
+  events: EventStore,
+  id: string,
+  ifMatch: number,
+): Promise<{ mtime: number }> {
+  if (!isValidId(id)) throw new ValidationError('id');
+  return events.archive(id, ifMatch);
+}
+```
+
+If the operation needs to coordinate multiple ports (e.g. update an
+event AND rewrite link backlinks), the orchestration goes here, not in
+the handler.
+
+## 4. Handler: HTTP wiring
+
+File: `app/server/http/<entity>.routes.ts`.
+
+Handlers are thin: parse → validate input shape → call domain → shape
+response. Use the helpers in `app/server/http/responses.ts` and
+`app/server/http/body.ts`.
+
+```ts
+import { sendJson, sendError } from './responses.ts';
+import { readBody } from './body.ts';
+import { archiveEvent } from '../domain/events.ts';
+import { ConflictError, NotFoundError, ValidationError } from '../domain/errors.ts';
+
+export function registerEventRoutes(router, deps) {
+  router.add('POST', /^\/api\/events\/([^/]+)\/archive$/, async (req, res, [id]) => {
+    const ifMatch = Number(req.headers['if-match']);
+    if (!Number.isFinite(ifMatch)) return sendError(res, 400, 'if-match required');
+    try {
+      const result = await archiveEvent(deps.events, id, ifMatch);
+      sendJson(res, 200, result);
+    } catch (e) {
+      if (e instanceof NotFoundError) return sendError(res, 404, e.message);
+      if (e instanceof ConflictError) return sendError(res, 409, { mtime: e.mtime });
+      if (e instanceof ValidationError) return sendError(res, 400, e.message);
+      throw e;
+    }
+  });
+}
+```
+
+**Forbidden in handlers:** `import 'node:fs'`, `import 'node:path'`,
+`fs.*` calls, direct path concatenation, YAML parsing.
+
+## 5. Register the route
+
+File: `app/server/index.ts` (the composition root).
+
+The composition root is the only place adapters meet handlers:
+
+```ts
+import { makeFsStores } from './data/fs/index.ts';
+import { registerEventRoutes } from './http/events.routes.ts';
+
+const stores = makeFsStores({ root: REPO_ROOT });
+registerEventRoutes(router, { events: stores.events });
+```
+
+`makeFsStores` (in `app/server/data/fs/index.ts`) is a single factory
+that constructs every adapter from a config object and returns
+`{ events, notes, state, trash, ... }`. If you're adding the first
+method to a brand-new entity, you may also need to wire that entity
+into `makeFsStores`. That's a port-shape change — see the
+`add-data-store-method` skill.
+
+## 6. Test the domain function
+
+File: `app/server/domain/<entity>.test.ts`.
+
+Vitest. Use an in-memory port stub — never the real fs adapter.
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { archiveEvent } from './events.ts';
+
+function memoryEventStore(seed = {}) {
+  let store = { ...seed };
+  return {
+    async archive(id, ifMatch) {
+      const cur = store[id];
+      if (!cur) throw new NotFoundError(id);
+      if (cur.mtime !== ifMatch) throw new ConflictError(cur.mtime);
+      store[id] = { ...cur, archived: true, mtime: cur.mtime + 1 };
+      return { mtime: store[id].mtime };
+    },
+  };
+}
+
+describe('archiveEvent', () => {
+  it('archives and bumps mtime', async () => {
+    const events = memoryEventStore({ e1: { mtime: 100 } });
+    expect(await archiveEvent(events, 'e1', 100)).toEqual({ mtime: 101 });
+  });
+  it('409s on stale mtime', async () => {
+    const events = memoryEventStore({ e1: { mtime: 100 } });
+    await expect(archiveEvent(events, 'e1', 99)).rejects.toThrow(ConflictError);
+  });
+});
+```
+
+## mtime-conflict pattern
+
+Every write goes through:
+
+1. Client sends `If-Match: <mtime>`.
+2. Adapter reads current mtime, throws `ConflictError(currentMtime)` on mismatch.
+3. Domain re-throws.
+4. Handler maps `ConflictError` to HTTP 409 with `{ mtime: currentMtime }`.
+5. Client surfaces a conflict UI with the new mtime.
+
+Don't invent a different concurrency story.
+
+## Verification
+
+- `npm --prefix app run build` clean.
+- `npm --prefix app test` green.
+- The new test exists and runs.
+- No `fs`/`path` imports added under `http/` or `domain/`.
+
+## See also
+
+- `app/server/AGENTS.md`, `app/server/http/AGENTS.md`,
+  `app/server/domain/AGENTS.md`, `app/server/data/AGENTS.md`.
+- `add-data-store-method` skill — for changing port shape.

--- a/.claude/skills/add-api-route/SKILL.md
+++ b/.claude/skills/add-api-route/SKILL.md
@@ -6,8 +6,8 @@ description: Use this skill whenever you need to add a new HTTP endpoint to the 
 # Add an API Route
 
 Adding an endpoint touches four layers in a fixed order. Follow them.
-Skipping a layer ("I'll just call `fs` from the handler this once") is
-how the cloud-migration seam disappears.
+Skipping a layer ("I'll just call `fs` from the handler this once")
+breaks the abstraction that lets adapters be swapped.
 
 ## Order of operations
 
@@ -20,19 +20,19 @@ how the cloud-migration seam disappears.
 
 ## Before you start: file existence
 
-The Phase 2 refactor is in flight. At any point, the target files
-(`server/http/<entity>.routes.ts`, `server/domain/<entity>.ts`,
-`server/data/fs/<entity>.fs.ts`, `server/data/ports.ts`,
-`server/data/fs/index.ts`, `server/index.ts`) may or may not exist
-yet. **Create them if missing; extend them if present.**
+Any of the target files (`server/http/<entity>.routes.ts`,
+`server/domain/<entity>.ts`, `server/data/fs/<entity>.fs.ts`,
+`server/data/ports.ts`, `server/data/fs/index.ts`, `server/index.ts`)
+may or may not exist yet. **Create them if missing; extend them if
+present.**
 
 You may grep for existing symbols (e.g. `EventStore`,
-`makeFsEventStore`) to match the style of code that's already
-migrated. You may **not** read `app/server/api.ts` to crib from the
-legacy implementation — it conflates layers and will mislead you. The
-target shape lives in this skill and the AGENTS.md files; the
-behaviour you need to reproduce comes from the user's request, not
-from `api.ts`.
+`makeFsEventStore`) to match the style of code that's already in
+place. The target shape lives in this skill and the AGENTS.md files;
+the behaviour you need to reproduce comes from the user's request.
+If you find a file that conflates layers, do not crib from it —
+follow the layer rules in `app/server/AGENTS.md` regardless of what
+the surrounding code currently does.
 
 ## 1. Port: declare the operation
 

--- a/.claude/skills/add-data-store-method/SKILL.md
+++ b/.claude/skills/add-data-store-method/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: add-data-store-method
+description: Use this skill when you need to extend a port interface in app/server/data/ports.ts or app/src/data/ports.ts (e.g. add a new method, change a signature). Enforces the port-vs-adapter rule and the "if it has no IO, it doesn't belong on the port" decision.
+---
+
+# Add a Data Store Method
+
+A port change is a contract change. Every adapter — current and future
+— must implement the new method. Treat it as a small API design
+exercise.
+
+## The decision question
+
+Before adding a method, ask:
+
+> Can this be done with no IO?
+
+If **yes**, it does not belong on the port. Put it in `domain/`.
+Examples: filtering an already-loaded list, sorting, computing a
+derived field.
+
+If **no**, it goes on the port. Examples: read/write/delete
+operations, anything that hits disk or network.
+
+A common mistake: "give me events from this date range" sounds like a
+data method. It's a domain function over a `list()` call. Don't add
+`listInRange` to the port — keep the port small.
+
+## When in doubt
+
+The smallest port wins. CRUD plus mtime-aware writes is usually
+enough. If the domain becomes awkward, add to the port; don't
+preemptively bloat it.
+
+## Steps
+
+1. **Edit the port** — `app/server/data/ports.ts` or
+   `app/src/data/ports.ts`. Define the method in domain terms (no
+   paths, no SQL, no HTTP).
+2. **Update every existing adapter** — for the server today that's
+   `app/server/data/fs/<entity>.fs.ts`. Don't leave a TODO.
+3. **Update tests** — adapters have integration tests in
+   `*.fs.test.ts`. Add cases for the new method.
+4. **Update the AGENTS.md note** — if the new method changes the
+   port's responsibilities, update `app/server/data/AGENTS.md`.
+
+## Server vs client ports
+
+The two `ports.ts` files mirror each other but are not identical:
+
+- Server ports speak to persistence (read/write files).
+- Client ports speak to "wherever data comes from" (HTTP today).
+
+Adding a method to one doesn't automatically add it to the other.
+Decide which side needs the operation. Often it's both, but in
+different shapes.
+
+## Adapter conventions
+
+- Adapters never throw domain errors (`NotFoundError`, etc.). Return
+  `null`/`undefined` for "not found"; throw for genuine failures
+  (disk full, permission denied).
+- Adapters never compose multiple operations. If "archive an event"
+  means "update event AND rewrite backlinks", that's a domain
+  function calling two ports.
+- Adapter methods are atomic from the caller's perspective. Use
+  `writeFileAtomic` to make this true on the fs adapter.
+
+## Future-proofing for cloud
+
+Anything you put on the port must be implementable in a cloud world
+without contortion. A red flag: a method that takes a path or a stream
+or a glob. A green flag: a method that takes an id and returns a
+plain object.
+
+## Verification
+
+- `npm --prefix app run build` clean.
+- `npm --prefix app test` green, including new adapter tests.
+- The port change is described in the commit message — port changes
+  are notable events.
+
+## See also
+
+- `app/server/data/AGENTS.md` for the layer rules.
+- `add-api-route` skill — usually you add a port method *as part of*
+  adding an endpoint; this skill is for the rare standalone change.

--- a/.claude/skills/add-data-store-method/SKILL.md
+++ b/.claude/skills/add-data-store-method/SKILL.md
@@ -66,9 +66,9 @@ different shapes.
 - Adapter methods are atomic from the caller's perspective. Use
   `writeFileAtomic` to make this true on the fs adapter.
 
-## Future-proofing for cloud
+## Future-proofing for other backends
 
-Anything you put on the port must be implementable in a cloud world
+Anything you put on the port must be implementable in any backend
 without contortion. A red flag: a method that takes a path or a stream
 or a glob. A green flag: a method that takes an id and returns a
 plain object.

--- a/.claude/skills/add-notes-feature/SKILL.md
+++ b/.claude/skills/add-notes-feature/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: add-notes-feature
+description: Use this skill when adding to the React notes view — folder sidebar, tabs, breadcrumbs, live editor, link picker, file operations, drafts, etc. Enforces the React conventions and hook/component/service split in app/src/notes/AGENTS.md.
+---
+
+# Add a Notes Feature
+
+The notes view is React, not vanilla DOM. Pick the right kind of
+module before writing any code.
+
+## Decide: hook, component, service, or markdown helper?
+
+| Kind | When | Folder |
+|---|---|---|
+| **Hook** | State, effects, subscriptions, refs | `notes/hooks/` |
+| **Component** | JSX only, takes props, returns elements | `notes/components/` |
+| **Service** | Pure logic that needs to be testable without React | `notes/services/` |
+| **Markdown helper** | String → string or string → DOM rendering of markdown | `notes/editor/markdown/` |
+
+If your feature has more than one of these (most do), make one of each
+and have the component compose them. **Don't dump everything into
+`Notes.tsx`** — that's the file we're trying to keep under 400 lines.
+
+## Files (target structure)
+
+```
+notes/
+  Notes.tsx                   # orchestrator
+  types.ts
+  hooks/
+    useSaveSync.ts
+    useFolderTree.ts
+    useLinkPicker.ts
+    useCaretTracking.ts
+  components/
+    FolderSidebar.tsx
+    EditorTabs.tsx
+    BreadcrumbNav.tsx
+    EditorContent.tsx
+    QuickAdd.tsx
+    NoteContextMenu.tsx
+  editor/
+    LiveEditor.tsx
+    LinkPickerDropdown.tsx
+    markdown/
+      inline.ts
+      line.ts
+      caret.ts
+    upload.ts
+  services/
+    file-ops.ts
+```
+
+Until Phase 5 lands, much of this is still inside `Notes.tsx` and
+`LiveEditor.tsx`. New code goes in the target shape; if you're
+extending an area that's already been split, follow the existing
+split.
+
+## Hook conventions
+
+- Filename `useThing.ts`, exports `useThing(...)`.
+- Extract a hook when a `useState` + `useEffect` block is over ~30
+  lines, or when two components need it. One-off six-line `useState`s
+  stay inline.
+- Hooks own their localStorage keys. Document the key at the top:
+  `// localStorage: notes.openTabs.v1`.
+- Never import from `components/` — hooks are below components.
+
+## Component conventions
+
+- One component per file. Filename matches the export.
+- Components take props and return JSX. No fetching, no localStorage,
+  no business logic. Push that into a hook or service.
+- Props are typed inline or in `types.ts` if shared.
+- Default to function components; never class components.
+
+## Service conventions
+
+- Pure (or at least dep-injected) functions. No React imports.
+- Take the data port as an argument, not via React context — services
+  need to be unit-testable.
+- Tests live in a sibling `.test.ts`.
+
+## Markdown helper conventions
+
+- Pure functions, no React, no DOM beyond what the editor's
+  `contentEditable` layer needs.
+- `inline.ts` — `escHtml`, `renderInline` (image, link, bold, italic,
+  code patterns).
+- `line.ts` — `classifyLine`, `lineHtml`. Per-kind rendering.
+- `caret.ts` — `saveCaret`, `restoreCaret`, position helpers.
+- `upload.ts` — paste/drag asset handling.
+
+## Touching the data layer
+
+- Use the data port from React via the existing context/provider
+  pattern in `Notes.tsx`. Don't import `data/http/*` from a
+  component.
+- Autosave goes through `useSaveSync`. Don't add a parallel save
+  path.
+
+## Style
+
+CSS goes in `src/styles/notes/<section>.css` (or `notes.css` until
+Phase 5 lands). Don't introduce CSS-in-JS, CSS modules, or inline
+style objects beyond one-off transient UI states.
+
+## Verification
+
+- `npm --prefix app run build` clean.
+- `npm --prefix app test` green. Hooks and services have tests;
+  components don't (we don't run a React renderer in tests).
+- Manual handoff to the user: open a note, edit, autosave, switch
+  tabs, rename, delete, drag-drop a link.
+
+## Don't
+
+- Don't reach into `LiveEditor`'s contentEditable from outside —
+  pass props in, listen via callbacks.
+- Don't write to disk paths from React. The data port hides paths.
+- Don't introduce a state-management library. `useState` + a few
+  hooks is enough; if it isn't, that's a conversation, not a
+  decision.
+
+## See also
+
+- `app/src/notes/AGENTS.md` for the local rules.
+- `app/src/AGENTS.md` for the cross-slice rules.

--- a/.claude/skills/add-notes-feature/SKILL.md
+++ b/.claude/skills/add-notes-feature/SKILL.md
@@ -51,11 +51,6 @@ notes/
     file-ops.ts
 ```
 
-Until Phase 5 lands, much of this is still inside `Notes.tsx` and
-`LiveEditor.tsx`. New code goes in the target shape; if you're
-extending an area that's already been split, follow the existing
-split.
-
 ## Hook conventions
 
 - Filename `useThing.ts`, exports `useThing(...)`.
@@ -101,9 +96,9 @@ split.
 
 ## Style
 
-CSS goes in `src/styles/notes/<section>.css` (or `notes.css` until
-Phase 5 lands). Don't introduce CSS-in-JS, CSS modules, or inline
-style objects beyond one-off transient UI states.
+CSS goes in `src/styles/notes/<section>.css`. Don't introduce
+CSS-in-JS, CSS modules, or inline style objects beyond one-off
+transient UI states.
 
 ## Verification
 

--- a/.claude/skills/add-peek-target/SKILL.md
+++ b/.claude/skills/add-peek-target/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: add-peek-target
+description: Use this skill when extending the hover-preview ("peek") system to a new entity type — e.g. peek for sessions, factions, plot threads, or anything beyond events and notes. Touches resolve, window, and the triggering slice.
+---
+
+# Add a Peek Target
+
+The peek system shows a floating preview when the user hovers a link.
+Three pieces are involved: resolution, rendering, and the trigger.
+
+## Files
+
+```
+src/peek/
+  resolve.ts        # link/href → { kind, path, fetcher }
+  window.ts         # render one preview window
+  stack.ts          # manages the LIFO of open windows
+```
+
+## Steps
+
+1. **Teach `resolve.ts` the new kind.** Given an href or path, return
+   `{ kind: 'faction', path, fetcher }` where `fetcher` is a function
+   that takes the data port and returns the preview content.
+2. **Teach `window.ts` to render that kind.** Add a branch in the
+   render switch. Keep rendering pure-ish: take the preview data,
+   produce DOM. Don't fetch from `window.ts` — that's `resolve.ts`'s
+   contract.
+3. **Add a CSS rule** in `src/styles/peek.css` if the new kind needs
+   visual differentiation (badge colour, icon).
+4. **Trigger from the relevant slice.** Whichever slice produces the
+   link (notes editor, event modal, timeline card) calls
+   `peek.show(linkEl, deps)` on hover. If the slice already calls
+   `peek.show`, you're done. If it doesn't, this is the first peek
+   trigger from that slice — wire `mouseenter`/`mouseleave` and call
+   into the existing `stack.ts` API.
+
+## Layer rules
+
+- `peek/*` may not import any view slice. The trigger slice imports
+  peek, not the other way around.
+- `resolve.ts` returns a fetcher that closes over a data port.
+  Adapters and ports are not the peek system's concern.
+- Stay vanilla DOM. Peek is not a React tree.
+
+## Conventions
+
+- Hover delay and dismiss timeout constants live at the top of
+  `stack.ts`. Don't sprinkle magic numbers in trigger sites.
+- Windows position themselves from the trigger element's
+  `getBoundingClientRect`. Don't pass coordinates in.
+- A peek for a kind that fails to load shows an error window with
+  the entity kind and id. Don't silently render empty.
+
+## Verification
+
+- `npm --prefix app run build` clean.
+- `npm --prefix app test` green.
+- Manual: hover a link of the new kind in the slice that triggers
+  it; expect the window. Hover a stack of links; expect LIFO. Press
+  Esc; expect dismissal.
+
+## Don't
+
+- Don't open a peek window outside `stack.ts` — bypassing the stack
+  breaks Esc handling and click-outside.
+- Don't fetch from `window.ts`. Resolution and fetching belong in
+  `resolve.ts`.
+- Don't add per-kind logic in trigger sites. The site calls
+  `peek.show(linkEl, { port })` and forgets about it.
+
+## See also
+
+- `app/src/peek/AGENTS.md` for the local rules.

--- a/.claude/skills/add-timeline-feature/SKILL.md
+++ b/.claude/skills/add-timeline-feature/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: add-timeline-feature
+description: Use this skill when adding rendering or interaction behaviour to the timeline view (zoom, pan, card layout, session bands, axis, drag-to-reschedule, hover effects, etc.). Vanilla TypeScript + DOM, no React. Enforces the render/interaction split in app/src/timeline/AGENTS.md.
+---
+
+# Add a Timeline Feature
+
+The timeline is vanilla TypeScript + DOM. Two kinds of code live here:
+**render** (state → pixels) and **interaction** (input → state). Keep
+them separate.
+
+## Decide first: render or interaction?
+
+| Render | Interaction |
+|---|---|
+| Mutates a host element | Attaches `addEventListener` |
+| Reads view state | Reads user input |
+| Pure-ish | Calls back with state changes |
+| `render/axis.ts`, `render/cards.ts` | `interactions/zoom.ts`, `interactions/pan.ts` |
+
+If the feature is both — say, drag-to-reschedule renders a ghost card
+while dragging — split it. The interaction module emits "draft state"
+into `app.ts`; the render module reads it.
+
+## Files
+
+```
+src/timeline/
+  app.ts                    # controller, owns ViewState
+  render/
+    axis.ts
+    cards.ts
+    session-bands.ts
+  interactions/
+    zoom.ts                 # xToSeconds, secondsToX, zoomAbout, panByPixels
+    pan.ts
+    reschedule.ts
+    quick-add-zones.ts
+  event-modal.ts
+```
+
+Note: until Phase 4 lands, much of this still lives in `src/main.ts`.
+Add new code in the target shape and link from `main.ts` rather than
+extending the wiring blob.
+
+## Module shape
+
+Every timeline module exports a factory:
+
+```ts
+export function createCardLayer(host: HTMLElement, deps: CardDeps) {
+  // attach DOM, listeners, etc.
+  return {
+    update(state: ViewState) { /* re-render */ },
+    destroy() { /* remove listeners, clear DOM */ },
+  };
+}
+```
+
+`app.ts` calls `update(state)` whenever ViewState changes. `destroy()`
+runs on view-switch (timeline → notes).
+
+## Coordinate math
+
+- `xToSeconds(viewState, x)` and `secondsToX(viewState, seconds)`
+  live in `interactions/zoom.ts`. Use them. Don't reimplement.
+- `viewState.pixelsPerSecond` is the only zoom representation. Don't
+  cache derivations — they go stale.
+
+## Add a render module
+
+1. Create `src/timeline/render/<feature>.ts` exporting
+   `create<Feature>Layer(host, deps)`.
+2. In the factory, create the DOM scaffolding once and store
+   references.
+3. `update(state)` re-renders idempotently from `state`. Reuse DOM
+   nodes; don't `innerHTML = ''` on every frame.
+4. `app.ts` (or `main.ts` until Phase 4) wires it in.
+5. Tests: layout math goes in a sibling `.test.ts` (no DOM); see
+   `session-band.test.ts`.
+
+## Add an interaction module
+
+1. Create `src/timeline/interactions/<feature>.ts` exporting
+   `create<Feature>(host, deps)`.
+2. Attach listeners in the factory; remove them in `destroy()`.
+3. Don't mutate DOM directly except for transient feedback (e.g.
+   cursor style). Persistent visuals are render's job.
+4. State changes go via callbacks in `deps`:
+   `deps.onZoomChange(nextViewState)`.
+
+## Touching the data layer
+
+- Receive a port via `deps`. Don't import `data/http/*` directly.
+- Don't call `fetch`. Don't read `localStorage` outside `app.ts`.
+
+## Style
+
+CSS goes in `src/styles/timeline.css` (or a new file imported by
+`main.ts`). Class names are slice-prefixed: `.timeline-…`.
+
+## Verification
+
+- `npm --prefix app run build` clean.
+- `npm --prefix app test` green.
+- Manual handoff to the user for browser verification: scroll, zoom,
+  pan, click, drag — the feature plus the existing flows.
+
+## Don't
+
+- Don't introduce React in this slice.
+- Don't query DOM nodes outside the host you were given.
+- Don't import `notes/*` or `editor/modal/*` internals; if you need
+  to open an editor or peek window, take a callback in `deps`.
+
+## See also
+
+- `app/src/timeline/AGENTS.md` for the local rules.
+- `app/src/AGENTS.md` for the cross-slice rules.

--- a/.claude/skills/add-timeline-feature/SKILL.md
+++ b/.claude/skills/add-timeline-feature/SKILL.md
@@ -39,10 +39,6 @@ src/timeline/
   event-modal.ts
 ```
 
-Note: until Phase 4 lands, much of this still lives in `src/main.ts`.
-Add new code in the target shape and link from `main.ts` rather than
-extending the wiring blob.
-
 ## Module shape
 
 Every timeline module exports a factory:
@@ -75,7 +71,7 @@ runs on view-switch (timeline → notes).
    references.
 3. `update(state)` re-renders idempotently from `state`. Reuse DOM
    nodes; don't `innerHTML = ''` on every frame.
-4. `app.ts` (or `main.ts` until Phase 4) wires it in.
+4. `app.ts` wires it in.
 5. Tests: layout math goes in a sibling `.test.ts` (no DOM); see
    `session-band.test.ts`.
 
@@ -97,7 +93,8 @@ runs on view-switch (timeline → notes).
 ## Style
 
 CSS goes in `src/styles/timeline.css` (or a new file imported by
-`main.ts`). Class names are slice-prefixed: `.timeline-…`.
+the composition root in `bootstrap/`). Class names are slice-prefixed:
+`.timeline-…`.
 
 ## Verification
 

--- a/.claude/skills/split-large-file/SKILL.md
+++ b/.claude/skills/split-large-file/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: split-large-file
+description: Use this skill when a TypeScript or TSX file in app/ crosses ~250 lines, or when an existing file is hard to navigate. Walks through identifying seams, planning the split with a Plan agent, executing the split in commits that keep tests green, and updating the relevant AGENTS.md.
+---
+
+# Split a Large File
+
+Files over ~300 lines are agent-hostile: every read costs context, and
+every edit risks fighting unrelated code. When you cross ~250, plan a
+split. When you cross ~300, do it.
+
+## When to skip splitting
+
+- **Test files** with many small, parallel cases — fine to be long.
+- **Generated code** — leave it alone; refactor the generator.
+- **Single coherent unit** that genuinely doesn't decompose (rare;
+  almost everything decomposes). Document why in a comment at the top.
+
+## Steps
+
+### 1. Read the file end to end
+
+Don't split blind. Read it once before deciding seams. Files often
+have natural sections (state, effects, helpers, render) marked by
+comments or function clusters.
+
+### 2. Identify seams
+
+Look for:
+
+- **Top-level functions with no shared mutable state** — pure
+  candidates for extraction.
+- **Sub-components inside a `.tsx`** — own file each.
+- **Helper functions used only by one section** — they go with that
+  section.
+- **`useState` / `useEffect` clusters** — extract into a hook.
+- **DOM construction blocks** — `view.ts` / `template.ts`.
+- **Persistence (localStorage / fetch)** — its own module.
+
+### 3. Plan with a Plan agent
+
+For non-trivial splits (more than three new files), launch the Plan
+agent with the file contents and a seams list. The Plan agent
+returns a per-file map; you execute it.
+
+### 4. Execute one seam per commit
+
+Each commit:
+
+1. Creates the new file with the extracted code.
+2. Updates the original to import from the new file.
+3. Keeps `npm --prefix app run build` and `npm --prefix app test`
+   green.
+4. Has a message like `extract X from <original>` — small and
+   verifiable.
+
+If a seam doesn't fit in one commit cleanly, it's actually two
+seams. Split it further.
+
+### 5. Verify behaviour didn't drift
+
+The split is structural. After all commits:
+
+- `npm --prefix app run build` clean.
+- `npm --prefix app test` green.
+- Manual handoff to the user: exercise the slice end-to-end.
+- Re-grep for files >300 lines to confirm the original is now small
+  enough.
+
+### 6. Update the relevant AGENTS.md
+
+If the split introduces a new folder or convention, the slice's
+`AGENTS.md` documents it. If the split simply followed an existing
+target structure described in that AGENTS.md, no update is needed.
+
+## Common seams
+
+- `Notes.tsx` (1107) → hooks, components, services, editor
+  subfolder. See `app/src/notes/AGENTS.md`.
+- `LiveEditor.tsx` (697) → `editor/markdown/{inline,line,caret}.ts`,
+  `editor/upload.ts`, `editor/LinkPickerDropdown.tsx`.
+- `server/api.ts` (838) → `http/`, `domain/`, `data/fs/`,
+  `index.ts`. See `app/server/AGENTS.md`.
+- `src/main.ts` (768) → `bootstrap/{mount,view-switcher,shortcuts}.ts`,
+  `timeline/app.ts`.
+- `editor/modal.ts` (534) → `modal/{index,view,fields,save}.ts`.
+- `panels/filters.ts` (421) →
+  `filters/{types,logic,sidebar,persistence}.ts`.
+
+## Don't
+
+- Don't rename functions during the split. Rename in a separate
+  commit before or after; keeping the same names makes the diff
+  reviewable.
+- Don't change behaviour during the split. Bug fixes happen
+  separately.
+- Don't stop at "moved everything to one new file". That's not a
+  split; that's a rename.
+- Don't introduce new abstractions that weren't there. The split
+  exposes existing structure; it doesn't invent it.
+
+## See also
+
+- `app/AGENTS.md` for the file-size convention.
+- The slice's `AGENTS.md` for the target structure.

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ app/dist/
 .idea/
 .vscode/
 
-# Claude Code
-.claude/
+# Claude Code — ignore local session/project state, but ship skills with the repo
+.claude/*
+!.claude/skills/

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -7,8 +7,9 @@ Each subfolder has its own `AGENTS.md` with the local rules.
 
 A timeline + notes app for tracking a tabletop campaign. Vite dev server,
 TypeScript, vanilla DOM for the timeline, React for notes. Persistence is
-markdown files on disk today; the layout is designed so it can become cloud
-storage tomorrow without rewriting business logic.
+markdown files on disk via the filesystem adapter; the layered design lets
+alternative adapters (e.g. a remote backend) plug in without rewriting
+domain or view code.
 
 ## The one rule that matters
 
@@ -24,10 +25,10 @@ view / http  ──▶  domain  ──▶  data ports  ◀──  data adapters
 - **data ports** are interfaces (`server/data/ports.ts`,
   `src/data/ports.ts`). The view and domain layers depend on these, not on
   any concrete implementation.
-- **data adapters** implement the ports. Today: filesystem on the server,
-  HTTP fetch on the client. Tomorrow: cloud on the server, IndexedDB on
-  the client. Adding a new adapter must not require changing domain or
-  view code.
+- **data adapters** implement the ports. The current adapter is the
+  filesystem on the server and HTTP fetch on the client. Adding a new
+  adapter (e.g. a different backend) must not require changing domain
+  or view code.
 
 If you find yourself importing `fs` from an HTTP handler or `fetch` from a
 domain module, stop. That import is the bug.
@@ -40,9 +41,8 @@ domain module, stop. That import is the bug.
 - **React** — `src/notes/` only. Hooks for state, components for JSX,
   services for non-React logic.
 
-These coexist deliberately. A future refactor will unify on React; until
-then, do not introduce React into vanilla slices and do not introduce
-direct DOM manipulation into the React slice.
+These coexist deliberately. Do not introduce React into vanilla slices
+and do not introduce direct DOM manipulation into the React slice.
 
 ## Where to add things
 

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -1,0 +1,87 @@
+# `app/` — Architecture Brief for Agents
+
+This is the entry point. Read this before touching anything under `app/`.
+Each subfolder has its own `AGENTS.md` with the local rules.
+
+## What this is
+
+A timeline + notes app for tracking a tabletop campaign. Vite dev server,
+TypeScript, vanilla DOM for the timeline, React for notes. Persistence is
+markdown files on disk today; the layout is designed so it can become cloud
+storage tomorrow without rewriting business logic.
+
+## The one rule that matters
+
+Dependencies flow one way:
+
+```
+view / http  ──▶  domain  ──▶  data ports  ◀──  data adapters
+```
+
+- **view / http** is protocol-shaped: HTTP routes, DOM events, JSX. Thin.
+- **domain** is pure logic: parsing, validation, link rewriting, filtering.
+  No `fs`, no `fetch`, no DOM, no React.
+- **data ports** are interfaces (`server/data/ports.ts`,
+  `src/data/ports.ts`). The view and domain layers depend on these, not on
+  any concrete implementation.
+- **data adapters** implement the ports. Today: filesystem on the server,
+  HTTP fetch on the client. Tomorrow: cloud on the server, IndexedDB on
+  the client. Adding a new adapter must not require changing domain or
+  view code.
+
+If you find yourself importing `fs` from an HTTP handler or `fetch` from a
+domain module, stop. That import is the bug.
+
+## The two paradigms
+
+- **Vanilla TS + DOM** — `src/main.ts`, `src/timeline/`, `src/panels/`,
+  `src/editor/`, `src/peek/`. Direct DOM manipulation, manual event
+  listeners, custom layout/zoom/drag.
+- **React** — `src/notes/` only. Hooks for state, components for JSX,
+  services for non-React logic.
+
+These coexist deliberately. A future refactor will unify on React; until
+then, do not introduce React into vanilla slices and do not introduce
+direct DOM manipulation into the React slice.
+
+## Where to add things
+
+| Want to add… | Skill | Folder |
+|---|---|---|
+| A new HTTP endpoint | `add-api-route` | `server/http/`, `server/domain/`, `server/data/` |
+| A new persistence operation | `add-data-store-method` | `server/data/ports.ts` + `server/data/fs/` |
+| Timeline rendering or interaction | `add-timeline-feature` | `src/timeline/` |
+| Notes UI or editor | `add-notes-feature` | `src/notes/` |
+| Hover-preview for a new entity | `add-peek-target` | `src/peek/` |
+| A file is over ~250 lines | `split-large-file` | (the offending file) |
+
+Skills live at `.claude/skills/` and contain step-by-step recipes — use
+them rather than guessing at conventions.
+
+## Conventions
+
+- Files cap at ~300 lines (orchestrators may run to 400). When you cross
+  that, run the `split-large-file` skill rather than letting it grow.
+- Tests live next to the code: `foo.ts` ↔ `foo.test.ts`. Vitest only.
+- `npm --prefix app run build` and `npm --prefix app test` must stay
+  green at every commit.
+- Atomic writes on the server go through `server/data/fs/atomic.ts` and
+  nothing else. Path validation goes through `server/data/fs/paths.ts`
+  and nothing else.
+
+## Don't
+
+- Don't add a new top-level folder under `app/` without updating this
+  file and the relevant skill.
+- Don't reintroduce 800-line files. The whole point of this layout is
+  that agents can navigate by folder and filename, not by scrolling.
+- Don't bypass the data ports because "it's just one call". If the call
+  needs IO, it goes through a port; the port can be swapped, the
+  shortcut cannot.
+
+## See also
+
+- `feature-ideas` (repo root) — upcoming work the structure must
+  accommodate (campaigns, UUID linking, mentioned-in backlinks, mind-map).
+- `app/server/AGENTS.md`, `app/src/AGENTS.md` — layer-specific guides.
+- `.claude/skills/*/SKILL.md` — concrete recipes.

--- a/app/server/AGENTS.md
+++ b/app/server/AGENTS.md
@@ -1,0 +1,90 @@
+# `app/server/` — Backend Brief
+
+Vite middleware that serves `/api/*` and reads/writes the markdown files in
+the repo root (`events/`, `npcs/`, `locations/`, etc.).
+
+## Current state vs target state
+
+**Today:** everything is in one 838-line `api.ts`. HTTP routing, business
+logic, filesystem IO, YAML parsing, git commands, and link rewriting are
+all interleaved.
+
+**Target:** three layers, one direction of dependency.
+
+```
+http/        — request parsing, response shaping, route dispatch
+  │
+  ▼
+domain/      — pure business logic, no IO
+  │
+  ▼
+data/ports.ts ◀── data/fs/    (today)
+              ◀── data/cloud/ (later, not yet)
+```
+
+The migration happens in Phase 2 of the refactor (see
+`/root/.claude/plans/the-app-folder-is-mellow-flame.md`). Until that
+lands, treat `api.ts` as the temporary home for all three layers, but
+**add new code in the target shape** rather than extending `api.ts`.
+
+## Layer rules
+
+- `http/` may import from `domain/` and `data/ports.ts`. May not import
+  `node:fs`, `node:path` for IO, or anything in `data/fs/`.
+- `domain/` may import from `data/ports.ts` and `node:` builtins for pure
+  things (e.g. `crypto.randomUUID`). May not import `node:fs`, `data/fs/`,
+  or `http/`.
+- `data/fs/` may import `node:fs`, `node:path`, and `data/ports.ts`. May
+  not import `domain/` or `http/`. It only implements ports.
+- `index.ts` is the composition root: it constructs concrete `data/fs/`
+  adapters, hands them to domain functions, and registers HTTP routes.
+  This is the only place where the layers meet.
+
+## Sanctioned utilities (use these; don't reinvent)
+
+- `data/fs/atomic.ts` — `writeFileAtomic`. The only sanctioned write path.
+- `data/fs/paths.ts` — `safeResolveInRepo`, `validNoteFolder`,
+  `safeNoteResolve`. The only sanctioned path-validation path.
+- `domain/yaml.ts` — gray-matter config + the custom YAML engine. The
+  only sanctioned event/note parse + serialise path.
+- `http/responses.ts` — `sendJson`, `sendError`. Use these instead of
+  hand-writing `res.writeHead`.
+- `http/body.ts` — `readBody`, `readTextBody`, `readBinaryBody`.
+
+## Add a new endpoint
+
+See `.claude/skills/add-api-route/SKILL.md`. The short version:
+
+1. Define the operation on a port in `data/ports.ts`.
+2. Implement it in `data/fs/*.fs.ts` (use `atomic.ts` + `paths.ts`).
+3. Write a domain function in `domain/*.ts` taking the port as an arg.
+4. Add the route handler in `http/*.routes.ts` — parse, call domain,
+   format response.
+5. Register the route in `index.ts`.
+6. Write a Vitest against the domain function with an in-memory port stub.
+
+## Conventions
+
+- Routes go in `http/<entity>.routes.ts`, exporting a function
+  `registerXxxRoutes(router, deps)`.
+- Domain modules export plain functions. They take port objects as
+  arguments — no hidden module-level state.
+- mtime-based optimistic concurrency: every write returns the new mtime;
+  every update accepts an `If-Match` mtime and 409s on mismatch.
+- Tests cover domain logic against in-memory ports. Integration tests
+  against the real fs adapter live in `*.fs.test.ts`.
+
+## Don't
+
+- Don't import `fs` or `path` from `http/` or `domain/`.
+- Don't add a new write path that isn't `atomic.writeFileAtomic`.
+- Don't validate paths inline; route everything through `paths.ts`.
+- Don't extend `api.ts`. New code follows the target structure even
+  before the existing code is migrated.
+
+## See also
+
+- `app/AGENTS.md` — top-level rules.
+- `http/AGENTS.md`, `domain/AGENTS.md`, `data/AGENTS.md` — per-layer.
+- `.claude/skills/add-api-route/SKILL.md`,
+  `.claude/skills/add-data-store-method/SKILL.md`.

--- a/app/server/AGENTS.md
+++ b/app/server/AGENTS.md
@@ -3,13 +3,7 @@
 Vite middleware that serves `/api/*` and reads/writes the markdown files in
 the repo root (`events/`, `npcs/`, `locations/`, etc.).
 
-## Current state vs target state
-
-**Today:** everything is in one 838-line `api.ts`. HTTP routing, business
-logic, filesystem IO, YAML parsing, git commands, and link rewriting are
-all interleaved.
-
-**Target:** three layers, one direction of dependency.
+## Three layers, one direction of dependency
 
 ```
 http/        — request parsing, response shaping, route dispatch
@@ -18,14 +12,12 @@ http/        — request parsing, response shaping, route dispatch
 domain/      — pure business logic, no IO
   │
   ▼
-data/ports.ts ◀── data/fs/    (today)
-              ◀── data/cloud/ (later, not yet)
+data/ports.ts ◀── data/fs/                 (current adapter)
+              ◀── data/<other-adapter>/    (additional adapters)
 ```
 
-The migration happens in Phase 2 of the refactor (see
-`/root/.claude/plans/the-app-folder-is-mellow-flame.md`). Until that
-lands, treat `api.ts` as the temporary home for all three layers, but
-**add new code in the target shape** rather than extending `api.ts`.
+The composition root in `index.ts` is the only place adapters meet
+handlers.
 
 ## Layer rules
 
@@ -79,8 +71,6 @@ See `.claude/skills/add-api-route/SKILL.md`. The short version:
 - Don't import `fs` or `path` from `http/` or `domain/`.
 - Don't add a new write path that isn't `atomic.writeFileAtomic`.
 - Don't validate paths inline; route everything through `paths.ts`.
-- Don't extend `api.ts`. New code follows the target structure even
-  before the existing code is migrated.
 
 ## See also
 

--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -1,7 +1,7 @@
-// NOTE FOR AGENTS: this file is the legacy monolith. New code goes in
+// NOTE FOR AGENTS: do not extend this file. New server code goes in
 // app/server/{http,domain,data}/* per the layer rules in
-// app/server/AGENTS.md. Run the `add-api-route` skill before extending
-// this file. The Phase 2 refactor will dissolve api.ts entirely.
+// app/server/AGENTS.md. Run the `add-api-route` skill before adding
+// or modifying endpoints.
 import type { Connect, ViteDevServer, Plugin } from 'vite';
 import { promises as fs } from 'fs';
 import { join, resolve, relative, basename, sep, dirname } from 'path';

--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -1,3 +1,7 @@
+// NOTE FOR AGENTS: this file is the legacy monolith. New code goes in
+// app/server/{http,domain,data}/* per the layer rules in
+// app/server/AGENTS.md. Run the `add-api-route` skill before extending
+// this file. The Phase 2 refactor will dissolve api.ts entirely.
 import type { Connect, ViteDevServer, Plugin } from 'vite';
 import { promises as fs } from 'fs';
 import { join, resolve, relative, basename, sep, dirname } from 'path';

--- a/app/server/data/AGENTS.md
+++ b/app/server/data/AGENTS.md
@@ -1,0 +1,91 @@
+# `server/data/` — Persistence Ports + Adapters
+
+The seam where the cloud migration happens. Domain code depends on the
+interfaces in `ports.ts`; adapters implement them.
+
+## Layout
+
+```
+data/
+  ports.ts          # interfaces: EventStore, NoteStore, StateStore,
+                    #             TrashStore, GitPort
+  fs/               # filesystem adapter (today)
+    index.ts        # makeFsStores({ root }) — constructs all adapters
+    events.fs.ts
+    notes.fs.ts
+    state.fs.ts
+    trash.fs.ts
+    atomic.ts       # writeFileAtomic — the only sanctioned write path
+    paths.ts        # safeResolveInRepo, validNoteFolder, safeNoteResolve
+  cloud/            # future, not yet present
+```
+
+## The port-vs-adapter rule
+
+A **port** is what the domain needs. It speaks in domain terms: "get
+event by id", "list events between A and B", "put note with mtime check".
+Ports never expose paths, file extensions, HTTP details, or query
+strings.
+
+An **adapter** is how a particular backend satisfies the port. The fs
+adapter knows about `events/` directories, `.md` extensions, frontmatter
+serialisation, and atomic writes. A future cloud adapter would know
+about HTTP requests to a remote API, auth tokens, and retry policy.
+
+If a method on a port mentions a file path, the abstraction has leaked.
+
+## Allowed imports
+
+- **`ports.ts`** — types only. No runtime code.
+- **`fs/*`** — `node:fs`, `node:path`, `node:crypto`, `gray-matter`,
+  `js-yaml`. May import `ports.ts` for the interface it implements and
+  `domain/yaml.ts` for parse/serialise (because the on-disk format is
+  YAML+markdown — that's the adapter's concern).
+
+## Forbidden imports
+
+- `fs/*` may not import `domain/*` (other than `yaml.ts` for the
+  on-disk format) or `http/*`.
+- `ports.ts` must remain dependency-free.
+
+## Adding a port method
+
+See `.claude/skills/add-data-store-method/SKILL.md`. The decision rule:
+
+> Can this be done without IO?
+> If yes → it belongs in `domain/`, not on the port.
+> If no → it goes on the port and every adapter must implement it.
+
+Every change to `ports.ts` is a change to the cloud-migration contract.
+Treat it as a small API design exercise, not a one-line addition.
+
+## Sanctioned utilities
+
+- `fs/atomic.ts` — `writeFileAtomic(path, contents)`. Writes to a
+  tempfile and renames. The only sanctioned write path on the server.
+- `fs/paths.ts` — `safeResolveInRepo`, `validNoteFolder`,
+  `safeNoteResolve`. The only sanctioned path-validation path. These
+  prevent directory-traversal attacks; do not roll your own.
+
+## Conventions
+
+- Adapters return plain data objects, not file handles or streams.
+- mtime is a `number` (epoch ms). Comparisons are exact.
+- Errors thrown by adapters are caught by the domain layer and
+  re-thrown as typed domain errors. Adapters do not throw
+  `NotFoundError` — they return `null` or `undefined`.
+
+## Don't
+
+- Don't put business logic in an adapter. If both the fs and a future
+  cloud adapter would need to do the same thing, that thing belongs in
+  `domain/`.
+- Don't bypass `atomic.ts` for "small writes". Concurrency bugs from
+  partial writes are the worst kind to debug.
+- Don't add a method to `ports.ts` for a one-off endpoint. Compose
+  smaller methods in the domain layer.
+
+## See also
+
+- `../AGENTS.md` for the layer direction.
+- `.claude/skills/add-data-store-method/SKILL.md` for the recipe.

--- a/app/server/data/AGENTS.md
+++ b/app/server/data/AGENTS.md
@@ -1,7 +1,7 @@
 # `server/data/` — Persistence Ports + Adapters
 
-The seam where the cloud migration happens. Domain code depends on the
-interfaces in `ports.ts`; adapters implement them.
+The seam between domain logic and the storage backend. Domain code
+depends on the interfaces in `ports.ts`; adapters implement them.
 
 ## Layout
 
@@ -9,7 +9,7 @@ interfaces in `ports.ts`; adapters implement them.
 data/
   ports.ts          # interfaces: EventStore, NoteStore, StateStore,
                     #             TrashStore, GitPort
-  fs/               # filesystem adapter (today)
+  fs/               # filesystem adapter
     index.ts        # makeFsStores({ root }) — constructs all adapters
     events.fs.ts
     notes.fs.ts
@@ -17,7 +17,7 @@ data/
     trash.fs.ts
     atomic.ts       # writeFileAtomic — the only sanctioned write path
     paths.ts        # safeResolveInRepo, validNoteFolder, safeNoteResolve
-  cloud/            # future, not yet present
+  <other-adapter>/  # one folder per additional backend
 ```
 
 ## The port-vs-adapter rule
@@ -29,8 +29,8 @@ strings.
 
 An **adapter** is how a particular backend satisfies the port. The fs
 adapter knows about `events/` directories, `.md` extensions, frontmatter
-serialisation, and atomic writes. A future cloud adapter would know
-about HTTP requests to a remote API, auth tokens, and retry policy.
+serialisation, and atomic writes. A different backend (e.g. a remote
+API) would know about HTTP requests, auth tokens, and retry policy.
 
 If a method on a port mentions a file path, the abstraction has leaked.
 
@@ -56,8 +56,9 @@ See `.claude/skills/add-data-store-method/SKILL.md`. The decision rule:
 > If yes → it belongs in `domain/`, not on the port.
 > If no → it goes on the port and every adapter must implement it.
 
-Every change to `ports.ts` is a change to the cloud-migration contract.
-Treat it as a small API design exercise, not a one-line addition.
+Every change to `ports.ts` is a change to the contract every adapter
+must satisfy. Treat it as a small API design exercise, not a one-line
+addition.
 
 ## Sanctioned utilities
 
@@ -77,9 +78,8 @@ Treat it as a small API design exercise, not a one-line addition.
 
 ## Don't
 
-- Don't put business logic in an adapter. If both the fs and a future
-  cloud adapter would need to do the same thing, that thing belongs in
-  `domain/`.
+- Don't put business logic in an adapter. If two adapters would need
+  to do the same thing, that thing belongs in `domain/`.
 - Don't bypass `atomic.ts` for "small writes". Concurrency bugs from
   partial writes are the worst kind to debug.
 - Don't add a method to `ports.ts` for a one-off endpoint. Compose

--- a/app/server/domain/AGENTS.md
+++ b/app/server/domain/AGENTS.md
@@ -1,0 +1,74 @@
+# `server/domain/` — Business Logic
+
+Pure functions that know how events, notes, sessions, links, and trash
+behave. No IO, no protocol awareness. This is the layer that survives
+the cloud migration unchanged.
+
+## What lives here
+
+- `events.ts` — parse, serialise, validate, list, search events.
+- `notes.ts` — note operations not involving disk layout.
+- `links.ts` — `updateNotesLinks` (reciprocal link rewriting).
+- `sessions.ts` — session ordering, conflict detection.
+- `trash.ts` — soft-delete naming rules, restore semantics.
+- `yaml.ts` — gray-matter config + the custom YAML engine. **The only
+  sanctioned event/note parse + serialise path.**
+
+## Allowed imports
+
+- `node:` builtins that don't touch IO: `crypto`, `node:url` for parsing
+  strings, etc.
+- `../data/ports.ts` — type-only imports of port interfaces. Functions
+  take ports as arguments, never import a concrete adapter.
+- Pure npm packages: `gray-matter`, `js-yaml`, `markdown-it`.
+
+## Forbidden imports
+
+- `node:fs`, `node:path` for IO, `node:child_process`. If a function
+  needs to read or write something, it calls a port method passed in.
+- `../http/*`, `../data/fs/*`. The domain doesn't know about protocols
+  or adapters.
+- React, DOM.
+
+## Function shape
+
+```ts
+// good — port is an explicit arg
+export async function archiveEvent(
+  events: EventStore,
+  id: string,
+  ifMatch: number,
+): Promise<{ mtime: number }> {
+  const current = await events.get(id);
+  if (!current) throw new NotFoundError(id);
+  if (current.mtime !== ifMatch) throw new ConflictError(current.mtime);
+  return events.put(id, { ...current.frontmatter, archived: true });
+}
+
+// bad — module-level state, reaches for fs
+import { writeFile } from 'node:fs/promises';
+let cache = new Map();
+```
+
+## Conventions
+
+- Throw typed errors (`NotFoundError`, `ConflictError`, `ValidationError`)
+  defined in `domain/errors.ts`. Handlers map these to status codes.
+- Functions are stateless. Module-level mutable state is a smell —
+  caches belong in adapters, not in domain.
+- mtime-based optimistic concurrency is the responsibility of this
+  layer, not the HTTP layer.
+- If a piece of logic can be done without IO, it belongs here, even if
+  it currently lives in an adapter.
+
+## Don't
+
+- Don't import a concrete adapter to "save a parameter". Inject the
+  port. Future cloud adapters depend on this discipline.
+- Don't reach into `gray-matter` directly elsewhere — go through
+  `yaml.ts` so the YAML engine config stays in one place.
+
+## See also
+
+- `../AGENTS.md` for layer rules.
+- `.claude/skills/add-api-route/SKILL.md` step 3.

--- a/app/server/http/AGENTS.md
+++ b/app/server/http/AGENTS.md
@@ -1,0 +1,67 @@
+# `server/http/` — HTTP Layer
+
+Thin protocol layer. One job: turn HTTP requests into domain calls and
+domain results into HTTP responses.
+
+## What lives here
+
+- `router.ts` — `(method, path) → handler` dispatch.
+- `responses.ts` — `sendJson`, `sendError`, status code helpers.
+- `body.ts` — `readBody` (JSON), `readTextBody`, `readBinaryBody`.
+- `<entity>.routes.ts` — one file per entity:
+  `events.routes.ts`, `notes.routes.ts`, `state.routes.ts`,
+  `trash.routes.ts`, `git.routes.ts`, `links.routes.ts`,
+  `assets.routes.ts`. Each exports `register<Entity>Routes(router, deps)`.
+
+## Allowed imports
+
+- `node:http`, `node:url`, `node:querystring` — protocol-level.
+- `../domain/*` — call business logic.
+- `../data/ports.ts` — type-only imports of port interfaces (so handlers
+  can receive ports via `deps`, not construct them).
+- `./responses.ts`, `./body.ts`, `./router.ts`.
+
+## Forbidden imports
+
+- `node:fs`, `node:path` for IO. If you need disk, the call goes
+  through a port passed in `deps`.
+- `../data/fs/*`. Concrete adapters are constructed in `index.ts`, not
+  imported by handlers.
+- React, DOM, `vite` runtime APIs.
+
+## Handler shape
+
+```ts
+export function registerEventRoutes(router, deps) {
+  router.add('GET', '/api/events', async (req, res) => {
+    const query = parseQuery(req.url);
+    const result = await listEvents(deps.events, query);  // domain fn
+    sendJson(res, 200, result);
+  });
+}
+```
+
+Handlers do four things, in order: parse request → validate → call
+domain → shape response. Anything more belongs in `domain/`.
+
+## Conventions
+
+- 400 for input validation failures (return early before calling domain).
+- 404 for "domain returned nothing".
+- 409 for mtime conflicts (use the helper in `responses.ts`).
+- 500 only for genuinely unexpected errors. Domain errors are mapped
+  to specific status codes by name, not rethrown.
+- Routes are registered in `server/index.ts`; this file does not run on
+  import.
+
+## Don't
+
+- Don't read or write files here. Even one `fs.readFile` and the layer
+  rule is broken.
+- Don't put validation logic that the domain also needs. If both layers
+  need it, it lives in `domain/` and the handler calls it.
+
+## See also
+
+- `../AGENTS.md` for the layer rules.
+- `.claude/skills/add-api-route/SKILL.md` for the recipe.

--- a/app/src/AGENTS.md
+++ b/app/src/AGENTS.md
@@ -1,0 +1,103 @@
+# `app/src/` — Client Brief
+
+The browser-side code. Two paradigms coexist; the layer rule from
+`app/AGENTS.md` applies to both.
+
+## Layout
+
+```
+src/
+  main.ts            # thin entry: mount shell, dispatch to view
+  bootstrap/         # mount, view-switcher, global hotkeys (Phase 4)
+  data/              # client data layer
+    ports.ts         # interfaces the UI depends on
+    http/            # current adapter: fetch /api/*
+    types.ts         # shared DTOs
+  domain/            # pure logic shared between timeline and notes
+  calendar/          # leaf utility: Golarian ↔ UTC, formatting
+  timeline/          # vanilla DOM — timeline view
+    app.ts           # controller (Phase 4)
+    render/          # axis, cards, session-bands
+    interactions/    # zoom, pan, reschedule, quick-add
+    event-modal.ts
+  panels/            # vanilla DOM — filter, search, toolbar
+    filters/         # types, logic, sidebar, persistence
+  editor/            # vanilla DOM — event editor modal
+    modal/           # index, view, fields, save
+  peek/              # vanilla DOM — hover-preview windows
+  notes/             # React — notes view
+    Notes.tsx
+    components/
+    hooks/
+    editor/
+      LiveEditor.tsx
+      markdown/
+    services/
+  styles/            # css per slice, plus tokens
+    notes/           # split of the notes css by section
+  theme.ts
+```
+
+## The two paradigms
+
+**React** lives in `notes/` only. Hooks for state and effects, components
+for JSX, services for non-React logic. Styles are global CSS imported
+once.
+
+**Vanilla DOM** lives everywhere else (`timeline/`, `panels/`, `editor/`,
+`peek/`, `bootstrap/`). Modules export factory functions that take an
+HTMLElement plus a deps object, attach listeners, and return a teardown
+or update API. No framework.
+
+Don't mix them: no React in vanilla slices, no manual `innerHTML` in
+React components.
+
+## Layer rules (mirrors the server)
+
+- `domain/*` may not import from `data/http/*`, `timeline/*`,
+  `panels/*`, `editor/*`, `peek/*`, `notes/*`, or anything DOM/React.
+  It depends only on `data/ports.ts` (types) and `data/types.ts`.
+- `data/http/*` may import `data/ports.ts`, `data/types.ts`, and
+  `node:` builtins for type-only purposes. May not import
+  `domain/*` or any view slice.
+- View slices import `domain/*` and either receive a port via deps or
+  call a higher orchestrator that does.
+- `main.ts` and `bootstrap/` are the composition root: they construct
+  the http adapter, hand it to the views.
+
+## Sanctioned utilities
+
+- `data/http/client.ts` — `fetch` wrapper + `ApiError`. The only
+  sanctioned client HTTP path.
+- `calendar/golarian.ts` — date conversions. Don't reimplement.
+- `theme.ts` — palette + `weekdayColor`. Single source of colour.
+
+## Where to add things
+
+| Want to add… | Skill |
+|---|---|
+| Timeline rendering or interaction | `add-timeline-feature` |
+| Notes UI, hook, or component | `add-notes-feature` |
+| Hover-preview for a new entity | `add-peek-target` |
+| New endpoint to call | First do `add-api-route`, then add to `data/http/` |
+
+## Conventions
+
+- Files cap at ~300 lines. Run `split-large-file` when you cross it.
+- Tests next to the file: `foo.ts` ↔ `foo.test.ts`. Vitest only.
+- Vanilla modules export `createX(host, deps)` returning
+  `{ update, destroy }`. Consistency lets `bootstrap/` wire them.
+- React modules: one component per file, named the same as the file.
+  Hooks live under `notes/hooks/` and are named `useX`.
+
+## Don't
+
+- Don't add `fetch` calls outside `data/http/`.
+- Don't read `localStorage` outside the slice that owns the key. Names
+  are namespaced (`filters.pinned.v1`, `notes.openTabs.v1`, …).
+- Don't inline DOM in React components or React in DOM modules.
+
+## See also
+
+- `app/AGENTS.md` for the cross-layer rules.
+- Each subfolder has its own `AGENTS.md`.

--- a/app/src/AGENTS.md
+++ b/app/src/AGENTS.md
@@ -8,7 +8,7 @@ The browser-side code. Two paradigms coexist; the layer rule from
 ```
 src/
   main.ts            # thin entry: mount shell, dispatch to view
-  bootstrap/         # mount, view-switcher, global hotkeys (Phase 4)
+  bootstrap/         # mount, view-switcher, global hotkeys
   data/              # client data layer
     ports.ts         # interfaces the UI depends on
     http/            # current adapter: fetch /api/*
@@ -16,7 +16,7 @@ src/
   domain/            # pure logic shared between timeline and notes
   calendar/          # leaf utility: Golarian ↔ UTC, formatting
   timeline/          # vanilla DOM — timeline view
-    app.ts           # controller (Phase 4)
+    app.ts           # controller
     render/          # axis, cards, session-bands
     interactions/    # zoom, pan, reschedule, quick-add
     event-modal.ts

--- a/app/src/calendar/AGENTS.md
+++ b/app/src/calendar/AGENTS.md
@@ -1,0 +1,34 @@
+# `src/calendar/` — Golarian Calendar Utilities
+
+Leaf utility. Converts between Golarian (in-game) and UTC timestamps,
+formats dates and times for display.
+
+## Files
+
+- `golarian.ts` — `parseISOString`, `toAbsoluteSeconds`,
+  `fromAbsoluteSeconds`, `toISOString`. Constants for seconds/day, etc.
+- `format.ts` — `formatNowMarker`, `formatAxisDay`, `formatAxisHour`.
+- `calendar.test.ts` — round-trip and boundary tests.
+
+## Allowed imports
+
+Nothing from `app/src` except other files in this folder. This is a leaf.
+
+## Forbidden imports
+
+- `data/*`, `domain/*`, any view slice. If you need data here, you're
+  in the wrong folder.
+- React, DOM. Pure functions only.
+
+## Conventions
+
+- All functions are pure.
+- Time values are `number` seconds-since-Golarian-epoch.
+- Add a test for any new conversion. `calendar.test.ts` covers boundary
+  conditions (leap years, day rollover) — extend the same pattern.
+
+## Don't
+
+- Don't add date formatting that depends on locale settings or `Intl`.
+  The campaign uses fixed strings; consistency matters.
+- Don't add caches. The functions are cheap.

--- a/app/src/data/AGENTS.md
+++ b/app/src/data/AGENTS.md
@@ -1,0 +1,69 @@
+# `src/data/` — Client Data Layer
+
+The seam where the cloud migration happens on the client. Mirrors
+`server/data/` in spirit: ports define what the UI needs; adapters
+implement them.
+
+## Current state vs target state
+
+**Today:** `api.ts` is a single 199-line module exporting `listEvents`,
+`getEvent`, `putEvent`, etc. as functions that call `fetch`.
+
+**Target (Phase 3):**
+
+```
+data/
+  ports.ts          # interfaces: EventStore, NoteStore, StateStore, …
+  http/             # current adapter
+    client.ts       # fetch wrapper + ApiError
+    events.http.ts
+    notes.http.ts
+    state.http.ts
+    sessions.http.ts
+    links.http.ts
+  types.ts          # shared DTOs (EventListItem, NoteEntry, …)
+```
+
+A future cloud build of the app might keep the same ports but use a
+different adapter (e.g. direct calls to a cloud SDK). Domain code never
+imports an adapter directly.
+
+## Layer rules
+
+- `ports.ts` — types only. No runtime code, no fetch.
+- `http/*` — implements ports using `fetch`. Imports `ports.ts`,
+  `types.ts`, `client.ts` only.
+- View slices receive a port object (the http adapter today) via deps.
+  They never import an adapter directly — that's the composition
+  root's job in `main.ts` / `bootstrap/`.
+
+## Sanctioned utilities
+
+- `http/client.ts` — `fetch` wrapper + `ApiError`. **The only
+  sanctioned client HTTP path.** All adapter functions go through it.
+
+## Add an adapter method
+
+1. Add the method to the relevant port in `ports.ts`.
+2. Implement it in `http/<entity>.http.ts` using `client.ts`.
+3. If the UI needs to compose this with other ports, add a function in
+   `src/domain/`.
+
+## Conventions
+
+- Adapter methods return parsed JSON or throw `ApiError`. Don't return
+  the `Response` object.
+- DTOs live in `types.ts`. They're the wire format; if the UI needs a
+  different shape, transform in `domain/`.
+- mtime is a `number`. Pass it through unchanged for `If-Match`.
+
+## Don't
+
+- Don't call `fetch` outside `http/`.
+- Don't put parsing or filtering logic in adapters. That's `domain/`.
+- Don't store auth tokens or environment config here. Pass them in.
+
+## See also
+
+- `../AGENTS.md` for the layer rules.
+- `server/data/AGENTS.md` — the server-side mirror.

--- a/app/src/data/AGENTS.md
+++ b/app/src/data/AGENTS.md
@@ -1,41 +1,33 @@
 # `src/data/` — Client Data Layer
 
-The seam where the cloud migration happens on the client. Mirrors
+The seam between the UI and whatever serves data. Mirrors
 `server/data/` in spirit: ports define what the UI needs; adapters
-implement them.
+implement them. Domain code never imports an adapter directly.
 
-## Current state vs target state
-
-**Today:** `api.ts` is a single 199-line module exporting `listEvents`,
-`getEvent`, `putEvent`, etc. as functions that call `fetch`.
-
-**Target (Phase 3):**
+## Layout
 
 ```
 data/
   ports.ts          # interfaces: EventStore, NoteStore, StateStore, …
-  http/             # current adapter
+  http/             # adapter that fetches /api/*
     client.ts       # fetch wrapper + ApiError
     events.http.ts
     notes.http.ts
     state.http.ts
     sessions.http.ts
     links.http.ts
+  <other-adapter>/  # one folder per additional backend
   types.ts          # shared DTOs (EventListItem, NoteEntry, …)
 ```
-
-A future cloud build of the app might keep the same ports but use a
-different adapter (e.g. direct calls to a cloud SDK). Domain code never
-imports an adapter directly.
 
 ## Layer rules
 
 - `ports.ts` — types only. No runtime code, no fetch.
 - `http/*` — implements ports using `fetch`. Imports `ports.ts`,
   `types.ts`, `client.ts` only.
-- View slices receive a port object (the http adapter today) via deps.
-  They never import an adapter directly — that's the composition
-  root's job in `main.ts` / `bootstrap/`.
+- View slices receive a port object via deps. They never import an
+  adapter directly — that's the composition root's job in
+  `bootstrap/`.
 
 ## Sanctioned utilities
 

--- a/app/src/domain/AGENTS.md
+++ b/app/src/domain/AGENTS.md
@@ -5,16 +5,13 @@ React, no `fetch`.
 
 ## What lives here
 
-Eventually:
-
-- `events.ts` — filtering, sorting, conflict detection that both
-  timeline cards and notes' "mentioned in" lists need.
+- `events.ts` — filtering, sorting, conflict detection used by both
+  timeline cards and notes' "mentioned in" lists.
 - `sessions.ts` — session ordering, current-session detection.
-- `links.ts` — link parsing, kind detection (currently inline in
-  `LiveEditor.tsx` / `Notes.tsx`).
+- `links.ts` — link parsing, kind detection.
 
-This folder is empty in Phase 1 and starts being populated in Phase 3,
-when shared logic is hoisted out of the view slices.
+Hoist a function here only when a second view slice needs it; until
+then, leave it where it lives.
 
 ## Allowed imports
 

--- a/app/src/domain/AGENTS.md
+++ b/app/src/domain/AGENTS.md
@@ -1,0 +1,40 @@
+# `src/domain/` — Shared Client Logic
+
+Pure logic shared between the timeline and notes views. No DOM, no
+React, no `fetch`.
+
+## What lives here
+
+Eventually:
+
+- `events.ts` — filtering, sorting, conflict detection that both
+  timeline cards and notes' "mentioned in" lists need.
+- `sessions.ts` — session ordering, current-session detection.
+- `links.ts` — link parsing, kind detection (currently inline in
+  `LiveEditor.tsx` / `Notes.tsx`).
+
+This folder is empty in Phase 1 and starts being populated in Phase 3,
+when shared logic is hoisted out of the view slices.
+
+## Allowed imports
+
+- `data/ports.ts` (types only) and `data/types.ts`.
+- `calendar/*` for time math.
+- Pure npm packages: `markdown-it`, `js-yaml`.
+
+## Forbidden imports
+
+- `data/http/*`, any view slice, React, DOM, `fetch`.
+
+## Conventions
+
+- All functions pure. No module-level state.
+- Take ports as args when they need data; otherwise no dependency on
+  data layer at all.
+- Tested with Vitest. Prefer table-driven tests for filter/sort logic.
+
+## Don't
+
+- Don't put a function here that's only used by one view slice.
+  Premature shared logic is harder to refactor than duplicated logic.
+  Hoist when the second caller appears.

--- a/app/src/editor/AGENTS.md
+++ b/app/src/editor/AGENTS.md
@@ -3,12 +3,7 @@
 The modal for creating and editing event frontmatter + markdown bodies.
 Vanilla TypeScript + DOM.
 
-## Current state vs target state
-
-**Today:** `modal.ts` (534 lines) bundles DOM construction, field
-wiring, draft persistence, conflict resolution, and save flow.
-
-**Target (Phase 6):**
+## Layout
 
 ```
 editor/

--- a/app/src/editor/AGENTS.md
+++ b/app/src/editor/AGENTS.md
@@ -1,0 +1,64 @@
+# `src/editor/` — Event Editor Modal (Vanilla DOM)
+
+The modal for creating and editing event frontmatter + markdown bodies.
+Vanilla TypeScript + DOM.
+
+## Current state vs target state
+
+**Today:** `modal.ts` (534 lines) bundles DOM construction, field
+wiring, draft persistence, conflict resolution, and save flow.
+
+**Target (Phase 6):**
+
+```
+editor/
+  modal/
+    index.ts            # orchestration: openCreateEditor, openEditEditor
+    view.ts             # editorHtml template (DOM construction)
+    fields.ts           # field wiring: title, date, tags, color, body
+    save.ts             # save / cancel / conflict / discard flow
+  drafts.ts             # debounced localStorage autosave
+  drafts.test.ts
+  conflict.ts           # conflict modal (separate from the editor modal)
+  link-picker.ts        # @-mention dropdown for body field
+  format-toolbar.ts     # bold/italic/etc. toolbar
+```
+
+## Layer rules
+
+- May import `data/ports.ts` types and receive a port via deps —
+  never construct one.
+- May import `domain/*` for pure logic (e.g. event validation).
+- May not import `timeline/*`, `notes/*`, or React.
+
+## Add a field
+
+1. Extend the event DTO in `data/types.ts` (and the server side in
+   parallel).
+2. Add the input element in `modal/view.ts`.
+3. Wire `oninput` and validation in `modal/fields.ts`.
+4. If the field affects the save flow (e.g. requires server-side
+   conflict detection), update `modal/save.ts`.
+
+## Add a save behaviour
+
+Goes in `modal/save.ts`. Follows the existing mtime-conflict pattern:
+write attempts include `If-Match`; 409 routes to `conflict.ts`;
+discard path returns to caller.
+
+## Conventions
+
+- Drafts in localStorage are keyed by `editor.draft.<id>` for edits or
+  `editor.draft.new.<timestamp>` for creates. `drafts.ts` owns these
+  keys; nothing else reads them.
+- The modal is opened once at a time. `openCreateEditor` /
+  `openEditEditor` return a Promise that resolves on save/cancel/
+  discard so callers can refresh state.
+- `format-toolbar.ts` and `link-picker.ts` are attached/detached as
+  side modules — they get `attach(host, deps) → detach()` factories.
+
+## Don't
+
+- Don't call `fetch` directly. The save port is passed in via deps.
+- Don't reimplement markdown rendering for the preview — use the same
+  `markdown-it` instance the rest of the app uses (passed in).

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -1,9 +1,8 @@
-// NOTE FOR AGENTS: this is the legacy entry point. The Phase 4 refactor
-// extracts DOM scaffolding into bootstrap/mount.ts, view switching into
-// bootstrap/view-switcher.ts, hotkeys into bootstrap/shortcuts.ts, and
-// the timeline controller into timeline/app.ts. See app/src/AGENTS.md
-// and app/src/timeline/AGENTS.md. New timeline code follows the target
-// structure rather than extending this file.
+// NOTE FOR AGENTS: do not extend this file. New client code goes in
+// the relevant slice — DOM scaffolding in bootstrap/mount.ts, view
+// switching in bootstrap/view-switcher.ts, hotkeys in
+// bootstrap/shortcuts.ts, timeline behaviour in timeline/app.ts. See
+// app/src/AGENTS.md and app/src/timeline/AGENTS.md.
 import { createRoot } from 'react-dom/client';
 import { createElement } from 'react';
 import { NotesApp } from './notes/Notes.tsx';

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -1,3 +1,9 @@
+// NOTE FOR AGENTS: this is the legacy entry point. The Phase 4 refactor
+// extracts DOM scaffolding into bootstrap/mount.ts, view switching into
+// bootstrap/view-switcher.ts, hotkeys into bootstrap/shortcuts.ts, and
+// the timeline controller into timeline/app.ts. See app/src/AGENTS.md
+// and app/src/timeline/AGENTS.md. New timeline code follows the target
+// structure rather than extending this file.
 import { createRoot } from 'react-dom/client';
 import { createElement } from 'react';
 import { NotesApp } from './notes/Notes.tsx';

--- a/app/src/notes/AGENTS.md
+++ b/app/src/notes/AGENTS.md
@@ -3,16 +3,11 @@
 The folder/file browser, tabbed editor, and live markdown editor for
 notes (NPCs, locations, factions, plots, etc.). React, not vanilla DOM.
 
-## Current state vs target state
-
-**Today:** `Notes.tsx` (1107 lines) and `LiveEditor.tsx` (697 lines)
-do almost everything. `notes.css` is 749 lines.
-
-**Target (Phase 5):**
+## Layout
 
 ```
 notes/
-  Notes.tsx                   # orchestrator (~400 lines)
+  Notes.tsx                   # slice orchestrator
   types.ts
   hooks/
     useSaveSync.ts            # autosave + mtime conflict
@@ -27,7 +22,7 @@ notes/
     QuickAdd.tsx
     NoteContextMenu.tsx
   editor/
-    LiveEditor.tsx            # ~250 lines after extraction
+    LiveEditor.tsx
     LinkPickerDropdown.tsx
     markdown/
       inline.ts               # escHtml, renderInline

--- a/app/src/notes/AGENTS.md
+++ b/app/src/notes/AGENTS.md
@@ -1,0 +1,88 @@
+# `src/notes/` — Notes View (React)
+
+The folder/file browser, tabbed editor, and live markdown editor for
+notes (NPCs, locations, factions, plots, etc.). React, not vanilla DOM.
+
+## Current state vs target state
+
+**Today:** `Notes.tsx` (1107 lines) and `LiveEditor.tsx` (697 lines)
+do almost everything. `notes.css` is 749 lines.
+
+**Target (Phase 5):**
+
+```
+notes/
+  Notes.tsx                   # orchestrator (~400 lines)
+  types.ts
+  hooks/
+    useSaveSync.ts            # autosave + mtime conflict
+    useFolderTree.ts          # tree memoisation
+    useLinkPicker.ts          # @ autocomplete
+    useCaretTracking.ts       # selection/caret state
+  components/
+    FolderSidebar.tsx
+    EditorTabs.tsx
+    BreadcrumbNav.tsx
+    EditorContent.tsx         # mode dispatcher (live/source/split)
+    QuickAdd.tsx
+    NoteContextMenu.tsx
+  editor/
+    LiveEditor.tsx            # ~250 lines after extraction
+    LinkPickerDropdown.tsx
+    markdown/
+      inline.ts               # escHtml, renderInline
+      line.ts                 # classifyLine, lineHtml
+      caret.ts                # save/restoreCaret
+    upload.ts                 # handlePaste image conversion
+  services/
+    file-ops.ts               # rename / delete / move / migrate
+```
+
+## Layer rules
+
+- May import `data/ports.ts` types and receive a port via deps (or via
+  a top-level provider — Notes.tsx is the composition root for this
+  slice).
+- May import `domain/*` for shared logic.
+- May not import `timeline/*`, `panels/*`, `editor/*`, `peek/*`.
+
+## React conventions
+
+- One component per file. Filename matches the export.
+- **Hooks** for state and effects. Extract a hook when a block of
+  `useState` / `useEffect` is over ~30 lines or reused.
+- **Components** for JSX only. They take props, return JSX, do nothing
+  else.
+- **Services** (`services/`) for non-React logic that needs to be
+  testable without a renderer. File ops, link resolution, etc.
+- **Markdown helpers** (`editor/markdown/`) are pure functions. No
+  React, no DOM beyond what the contentEditable layer needs.
+- Styles are global CSS in `src/styles/notes/`. Don't introduce
+  CSS-in-JS or CSS modules.
+
+## Add a feature
+
+See `.claude/skills/add-notes-feature/SKILL.md`. Decide first whether
+it's:
+
+- A **hook** — state or side effect.
+- A **component** — JSX.
+- A **service** — pure logic.
+- A **markdown helper** — pure rendering of markdown bits.
+
+Each lives in its respective folder. Don't dump everything into
+`Notes.tsx`.
+
+## Conventions
+
+- Tabs persist via localStorage key `notes.openTabs.v1`.
+- File state ('clean' / 'dirty' / 'saving' / 'conflict') comes from
+  `useSaveSync`. Don't track it in component state separately.
+- Drag-drop uses HTML5 drag API. Payloads are JSON-encoded.
+
+## Don't
+
+- Don't call `fetch` directly. Go through the data port.
+- Don't write to disk paths from React. The data port hides paths.
+- Don't reimplement folder tree state. `useFolderTree` is the source
+  of truth.

--- a/app/src/panels/AGENTS.md
+++ b/app/src/panels/AGENTS.md
@@ -1,0 +1,68 @@
+# `src/panels/` — Filter, Search, Toolbar (Vanilla DOM)
+
+The chrome around the timeline: filter sidebar, search overlay,
+bottom toolbar. Vanilla TypeScript + DOM.
+
+## Current state vs target state
+
+**Today:** `filters.ts` (421 lines) bundles filter types, matching
+logic, sidebar rendering, and `localStorage` persistence.
+`toolbar.ts` and `search.ts` are smaller but cohesive.
+
+**Target (Phase 6):**
+
+```
+panels/
+  filters/
+    types.ts            # FilterState, FilterField
+    logic.ts            # applyFilters, matchesFilter, matchesDateFilter
+    sidebar.ts          # renderFilterSidebar (UI)
+    persistence.ts      # loadPinnedFilters, savePinnedFilters
+    filters.test.ts     # logic tests, no DOM
+  search.ts
+  toolbar.ts            # may grow into a folder if it crosses 300 lines
+```
+
+## Layer rules
+
+- `filters/logic.ts` is pure — no DOM, no `localStorage`. It's the
+  closest thing this folder has to domain logic. Tests live next to it
+  and cover edge cases without spinning up a DOM.
+- `filters/sidebar.ts` is the only file that touches DOM in
+  `filters/`. Same pattern as timeline: factory returns
+  `{ update, destroy }`.
+- `filters/persistence.ts` is the only file that touches
+  `localStorage` for filter state.
+- `search.ts` and `toolbar.ts` follow the same factory pattern.
+
+## Allowed imports
+
+- `data/ports.ts` types, `data/types.ts`.
+- `domain/*` once it exists.
+- `calendar/*` for date filtering.
+- DOM. No React.
+
+## Add a filter type
+
+1. Extend `FilterState` in `filters/types.ts`.
+2. Add the matcher in `filters/logic.ts` and a test in
+   `filters.test.ts`.
+3. Add the UI control in `filters/sidebar.ts`.
+4. If it persists, extend the localStorage schema in
+   `filters/persistence.ts` (and bump the key version, e.g.
+   `filters.pinned.v2`, with a migration).
+
+## Conventions
+
+- localStorage keys are versioned: `filters.pinned.v1`, etc.
+  Migrations on read; never silently drop data.
+- Filter logic is pure functions over `FilterState` and an event
+  array. It must remain testable without a DOM.
+
+## Don't
+
+- Don't put filter matching logic in the sidebar. Sidebar reads state,
+  emits state changes; matching is `logic.ts`.
+- Don't read `localStorage` from `sidebar.ts`. The controller in
+  `bootstrap/` or `timeline/app.ts` loads via `persistence.ts` and
+  passes state in.

--- a/app/src/panels/AGENTS.md
+++ b/app/src/panels/AGENTS.md
@@ -3,13 +3,7 @@
 The chrome around the timeline: filter sidebar, search overlay,
 bottom toolbar. Vanilla TypeScript + DOM.
 
-## Current state vs target state
-
-**Today:** `filters.ts` (421 lines) bundles filter types, matching
-logic, sidebar rendering, and `localStorage` persistence.
-`toolbar.ts` and `search.ts` are smaller but cohesive.
-
-**Target (Phase 6):**
+## Layout
 
 ```
 panels/
@@ -20,7 +14,7 @@ panels/
     persistence.ts      # loadPinnedFilters, savePinnedFilters
     filters.test.ts     # logic tests, no DOM
   search.ts
-  toolbar.ts            # may grow into a folder if it crosses 300 lines
+  toolbar.ts            # split into a folder if it crosses 300 lines
 ```
 
 ## Layer rules

--- a/app/src/peek/AGENTS.md
+++ b/app/src/peek/AGENTS.md
@@ -1,0 +1,45 @@
+# `src/peek/` — Hover-Preview Windows (Vanilla DOM)
+
+Floating preview windows that appear when hovering links in events or
+notes. A small system.
+
+## Files
+
+- `window.ts` — renders one preview window (positioning, content).
+- `stack.ts` — manages the set of open windows (LIFO, dismiss-on-leave,
+  keyboard handling).
+- `resolve.ts` — turns a link/href into the entity it points to.
+
+## Layer rules
+
+- May import `data/ports.ts` types and receive a port via deps.
+- May import `domain/*`.
+- May not import view slices (timeline/notes/editor/panels). The
+  initiating slice attaches peek; peek doesn't know who initiated.
+
+## Add a peek target
+
+See `.claude/skills/add-peek-target/SKILL.md`. The shape:
+
+1. `resolve.ts` learns the new entity type — given a link, return
+   `{ kind, path, fetcher }` where `fetcher` is a port-using function
+   to load the preview.
+2. `window.ts` learns to render that preview kind.
+3. The triggering slice (notes editor or event modal) calls
+   `peek.show(linkEl, deps)` on hover; nothing else changes.
+
+## Conventions
+
+- `stack.ts` is the single source of truth for "what's currently
+  visible". Don't add a parallel registry.
+- Windows position themselves via `getBoundingClientRect` of the
+  trigger element. Don't pass coordinates in.
+- Hover delay and dismiss timeout constants live at the top of
+  `stack.ts`. Don't sprinkle magic numbers.
+
+## Don't
+
+- Don't open a peek window outside `stack.ts`. The stack handles
+  Esc-to-close and click-outside.
+- Don't fetch directly from `window.ts`. The fetcher comes from
+  `resolve.ts` so a single resolution path is testable.

--- a/app/src/styles/AGENTS.md
+++ b/app/src/styles/AGENTS.md
@@ -1,0 +1,68 @@
+# `src/styles/` — Stylesheets
+
+Global CSS, one file per slice plus a tokens file. No CSS-in-JS, no
+CSS modules, no preprocessors.
+
+## Current state vs target state
+
+**Today:** flat list of per-slice CSS files. `notes.css` is 749 lines
+with section comments — splittable.
+
+**Target (Phase 5):**
+
+```
+styles/
+  tokens.css            # css custom properties (colours, spacing, kind hues)
+  base.css              # element-level resets and defaults
+  app.css               # shell + view-switcher
+  timeline.css
+  toolbar.css
+  filters.css
+  event-card.css
+  event-modal.css
+  editor.css            # event editor modal
+  peek.css
+  search.css
+  notes/
+    index.css           # @imports the parts in cascade order
+    sidebar.css         # tree, filter input, new-folder, drag-drop
+    tabs.css            # tabs bar, breadcrumbs, save status
+    editor-surface.css  # contentEditable host, live/source/split modes
+    markdown.css        # headings, bold, italic, code, images, links
+    link-picker.css
+    quick-add.css
+    toast.css
+    confirm.css
+```
+
+## Cascade rules
+
+- `tokens.css` defines `:root` custom properties. Imported first.
+- `base.css` after tokens. Element selectors only (`html`, `body`,
+  `button`, etc.). No classes.
+- Per-slice files use class selectors scoped by a slice prefix
+  (`.timeline-…`, `.notes-…`, `.peek-…`). Avoid global classes.
+- `notes/index.css` controls the order within the notes split. If
+  cascade matters, document it in the index file with comments above
+  each `@import`.
+- `main.ts` imports the top-level files; React components don't
+  import CSS directly.
+
+## Add a style
+
+- A new component-scoped style → its slice's CSS file.
+- A new colour, spacing, or hue → `tokens.css`. Don't hardcode hex.
+- A new global element rule → `base.css`. Use sparingly.
+
+## Conventions
+
+- Use `--token` names for any value used in more than one place.
+- Class names: `kebab-case`, slice-prefixed.
+- Avoid `!important`. If you reach for it, the cascade is wrong.
+
+## Don't
+
+- Don't introduce `styled-components` or CSS modules without a
+  conversation. Right now the CSS is plain and that's a feature.
+- Don't put one slice's styles in another slice's file. Notes editor
+  styles do not belong in `editor.css` (which is the event editor).

--- a/app/src/styles/AGENTS.md
+++ b/app/src/styles/AGENTS.md
@@ -3,12 +3,7 @@
 Global CSS, one file per slice plus a tokens file. No CSS-in-JS, no
 CSS modules, no preprocessors.
 
-## Current state vs target state
-
-**Today:** flat list of per-slice CSS files. `notes.css` is 749 lines
-with section comments — splittable.
-
-**Target (Phase 5):**
+## Layout
 
 ```
 styles/
@@ -45,8 +40,8 @@ styles/
 - `notes/index.css` controls the order within the notes split. If
   cascade matters, document it in the index file with comments above
   each `@import`.
-- `main.ts` imports the top-level files; React components don't
-  import CSS directly.
+- The composition root in `bootstrap/` imports the top-level files;
+  React components don't import CSS directly.
 
 ## Add a style
 

--- a/app/src/timeline/AGENTS.md
+++ b/app/src/timeline/AGENTS.md
@@ -1,0 +1,75 @@
+# `src/timeline/` — Timeline View (Vanilla DOM)
+
+The horizontally-scrollable timeline of events, sessions, and the
+current-time marker. Vanilla TypeScript + DOM. No React.
+
+## Current state vs target state
+
+**Today:** rendering and interactions are a mix of files at the top of
+the folder (`card.ts`, `axis.ts`, `zoom.ts`, `session-band.ts`,
+`event-modal.ts`) plus 600+ lines of wiring in `src/main.ts`.
+
+**Target (Phase 4):**
+
+```
+timeline/
+  app.ts                  # controller, owns view state, wires render + interactions
+  render/
+    axis.ts               # render time axis
+    cards.ts              # render event cards (layout + DOM)
+    session-bands.ts      # render session bands behind cards
+  interactions/
+    zoom.ts               # mouse-wheel zoom (existing zoom.ts moves here)
+    pan.ts                # drag-pan
+    reschedule.ts         # ctrl+shift drag to reschedule
+    quick-add-zones.ts    # double-click empty area for new event
+  event-modal.ts          # detail/edit modal — small, can stay flat
+```
+
+`main.ts` calls `createTimelineApp(host, deps)` which returns
+`{ update, destroy }`.
+
+## Layer rules
+
+- May import `data/ports.ts` types and receive a port via deps —
+  never construct one.
+- May import `domain/*` for pure logic.
+- May not import `notes/*`, `editor/*` internals (open the editor
+  through a callback in deps), or React.
+
+## Add a feature
+
+See `.claude/skills/add-timeline-feature/SKILL.md`. Decide first
+whether it's render or interaction:
+
+- **Render** — turning state into pixels. Goes in `render/`. Pure-ish:
+  takes view state, mutates a host element. No event listeners.
+- **Interaction** — turning user input into state changes. Goes in
+  `interactions/`. Attaches listeners to the host, calls back into
+  `app.ts` with state updates.
+
+If you're attaching listeners *and* mutating DOM, split it into a
+render module and an interaction module that talk through `app.ts`.
+
+## Conventions
+
+- Modules export a factory: `createCardLayer(host, deps) → { update, destroy }`.
+- View state (`ViewState`) lives in `app.ts`. Render modules read it;
+  interaction modules request changes via callbacks.
+- Coordinate math (seconds ↔ pixels) goes through `interactions/zoom.ts`
+  helpers (`xToSeconds`, `secondsToX`). Don't reinvent.
+- Tests for layout/zoom math are colocated (`zoom.test.ts`,
+  `session-band.test.ts`). Keep that pattern.
+
+## Don't
+
+- Don't write to disk or call `fetch` here. All IO via the port in
+  deps.
+- Don't read `localStorage` outside `app.ts`. Persistence keys belong
+  to the controller.
+- Don't query DOM nodes from outside the host element you were given.
+
+## See also
+
+- `../AGENTS.md` for the cross-layer rules.
+- `.claude/skills/add-timeline-feature/SKILL.md` for the recipe.

--- a/app/src/timeline/AGENTS.md
+++ b/app/src/timeline/AGENTS.md
@@ -3,13 +3,7 @@
 The horizontally-scrollable timeline of events, sessions, and the
 current-time marker. Vanilla TypeScript + DOM. No React.
 
-## Current state vs target state
-
-**Today:** rendering and interactions are a mix of files at the top of
-the folder (`card.ts`, `axis.ts`, `zoom.ts`, `session-band.ts`,
-`event-modal.ts`) plus 600+ lines of wiring in `src/main.ts`.
-
-**Target (Phase 4):**
+## Layout
 
 ```
 timeline/
@@ -19,15 +13,15 @@ timeline/
     cards.ts              # render event cards (layout + DOM)
     session-bands.ts      # render session bands behind cards
   interactions/
-    zoom.ts               # mouse-wheel zoom (existing zoom.ts moves here)
+    zoom.ts               # mouse-wheel zoom; xToSeconds, secondsToX, zoomAbout
     pan.ts                # drag-pan
     reschedule.ts         # ctrl+shift drag to reschedule
     quick-add-zones.ts    # double-click empty area for new event
-  event-modal.ts          # detail/edit modal — small, can stay flat
+  event-modal.ts          # detail/edit modal
 ```
 
-`main.ts` calls `createTimelineApp(host, deps)` which returns
-`{ update, destroy }`.
+The composition root (`bootstrap/`) calls `createTimelineApp(host, deps)`
+which returns `{ update, destroy }`.
 
 ## Layer rules
 


### PR DESCRIPTION
## Summary

Phase 1 of the `./app` refactor plan. **Documentation only** — no runtime
changes, no source files moved, no behaviour changes.

This commit seeds the architectural guidance that future phases (and
future sessions) will follow:

- **15 `AGENTS.md` files** — one per folder, each ≤60 lines, written
  for agents reading 50 lines at a time. Top-level `app/AGENTS.md` is
  the entry point; per-folder briefs cover purpose, layer rules,
  allowed/forbidden imports, "add a new X" recipes, conventions, and
  anti-patterns.
- **6 skills** in `.claude/skills/` — concrete step-by-step recipes
  (not "look around for conventions"):
  - `add-api-route` — port → adapter → domain → handler order
  - `add-data-store-method` — port-shape changes
  - `add-timeline-feature` — render/interaction split (vanilla DOM)
  - `add-notes-feature` — hook/component/service split (React)
  - `add-peek-target` — hover-preview extension
  - `split-large-file` — when files cross ~250 lines
- **Layer rule encoded everywhere:** `view/http → domain → data ports
  ← adapters`. The layout is designed so the server's persistence
  layer can later be swapped from local filesystem to cloud without
  touching domain or HTTP code.
- **`api.ts` and `main.ts`** get a top-of-file pointer comment
  redirecting agents to the relevant `AGENTS.md` — they're still the
  monoliths Phase 2+ will dissolve.
- **`.gitignore`** updated to ship `.claude/skills/` with the repo
  while keeping local session/project state ignored.

## Validation

A guidance dry-run was performed: a fresh agent (no conversation
context) was asked to plan an "archive event" endpoint using only the
seeded AGENTS.md files and the `add-api-route` skill. It correctly
identified all six target files in the right layers without ever
wanting to import `fs` from a handler or `fetch` from a domain
function. Two ambiguities it surfaced — adapter ENOENT contract and
"create vs extend" for missing target files — have been patched into
the skill.

## Phases ahead (not in this PR)

2. Server layer split — `api.ts` → `http/`, `domain/`, `data/`,
   `index.ts`.
3. Client data layer — `data/api.ts` → `data/http/*` behind ports.
4. `main.ts` split — `bootstrap/` and `timeline/app.ts`.
5. Notes split — hooks, components, services, `editor/markdown/`.
6. Editor modal + panels/filters split.
7. Audit pass.

Each phase will be its own PR with tests green between them.

## Test plan

- [ ] Verify the layer rules in each AGENTS.md are consistent
- [ ] Skim the six SKILL.md files for tone (concrete, not generic)
- [ ] Confirm `.gitignore` change behaves as expected (`.claude/skills/`
      tracked, other `.claude/*` ignored)
- [ ] Existing build/test status is unchanged from `main` (Phase 1 adds
      no source code; pre-existing `QuickAdd.tsx` type error and
      `formatAxisDay` test failure are untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqVfVDdwk2WqpsYXe8B9oR)_