### PR TITLE
Fix links to nested files not showing in search or working

### DIFF
--- a/app/server/data/fs/notes.fs.ts
+++ b/app/server/data/fs/notes.fs.ts
@@ -178,15 +178,12 @@ export function makeFsNoteStore(repoRoot: string): NoteStore {
       for (const dir of SCAN_DIRS) {
         const dirPath = join(repoRoot, dir);
         if (!(await pathExists(dirPath))) continue;
-        const files = await fs.readdir(dirPath);
-        for (const f of files) {
-          if (!f.endsWith('.md') || f === 'README.md') continue;
-          const full = join(dirPath, f);
-          const stat = await fs.stat(full);
-          if (!stat.isFile()) continue;
+        const entries = await scanMdFiles(dirPath, dir);
+        for (const e of entries) {
+          if (e.kind !== 'note') continue;
           out.push({
-            path: `${dir}/${f}`,
-            title: await extractTitleFromFile(full),
+            path: e.path,
+            title: e.title,
             type: TYPE_BY_DIR[dir] ?? 'other',
           });
         }

--- a/app/src/notes/LiveEditor.tsx
+++ b/app/src/notes/LiveEditor.tsx
@@ -18,12 +18,11 @@ function kindFromPath(
 ): string {
   if (!href) return 'broken';
   let folder = currentFolder;
-  let m = /^\.\.\/([^/]+)\/(.+)$/.exec(href);
+  const m = /^\.\.\/([^/]+)\//.exec(href);
   if (m) { folder = m[1]; }
-  else if ((m = /^([^/]+)\/(.+)$/.exec(href))) { folder = m[1]; }
-  // Check existence via link index
-  const target = href.replace(/^\.\.\//, '');
-  const found = linkIndex.some(e => e.path === target || e.path === `${folder}/${href.split('/').pop()}`);
+  // Resolve href to a repo-relative path for index lookup
+  const target = href.startsWith('../') ? href.slice(3) : `${currentFolder}/${href}`;
+  const found = linkIndex.some(e => e.path === target);
   if (!found && href.includes('/')) return 'broken';
   return folder;
 }


### PR DESCRIPTION
## Summary

- **`scanLinkIndex` was non-recursive** (`fs.readdir` without recursion), so `.md` files inside subdirectories of note folders were never added to the link index and never appeared in `@`-mention search results. Fixed by reusing the existing `scanMdFiles` recursive helper.
- **`kindFromPath` in `LiveEditor.tsx` computed wrong target paths** for same-folder relative links (e.g. `enemies/orc.md` from a file in `npcs/`). It was treating the first path segment as the folder name, so `enemies/orc.md` → target `enemies/orc.md` (not found), marking the link as broken. Fixed by resolving non-`../` hrefs relative to `currentFolder` (e.g. `npcs/enemies/orc.md`).

Fixes #8

## Test plan

- [ ] Create a note inside a subfolder of any note folder (e.g. `npcs/enemies/orc.md`)
- [ ] In another note, type `@` and confirm the nested file appears in the autocomplete dropdown
- [ ] Pick the nested file from the picker; confirm the inserted link is not styled as broken in the live editor
- [ ] Click the inserted link; confirm the peek preview opens the correct file

https://claude.ai/code/session_01519KeCrJTdeoTy2QBX7SE8

---
_Generated by [Claude Code](https://claude.ai/code/session_01519KeCrJTdeoTy2QBX7SE8)_