### PR TITLE
Phase 6b: split panels/filters.ts into filters/{types,logic,sidebar,persistence}.ts

### DIFF
--- a/app/src/panels/filters.ts
+++ b/app/src/panels/filters.ts
@@ -1,34 +1,11 @@
 import Fuse from 'fuse.js';
 import type { EventListItem, TagsRegistry } from '../data/types.ts';
 import { parseISOString, toAbsoluteSeconds } from '../calendar/golarian.ts';
+import type {
+  DateField, TagFilter, DateFilter, Filter, FilterState,
+} from './filters/types.ts';
 
-// ---- Types ----
-
-export type DateField = 'in-game' | 'session' | 'creation';
-
-export interface TagFilter {
-  id: string;
-  type: 'tag';
-  enabled: boolean;
-  pinned: boolean;
-  tags: string[]; // OR'd together
-}
-
-export interface DateFilter {
-  id: string;
-  type: 'date';
-  enabled: boolean;
-  pinned: boolean;
-  field: DateField;
-  from: string | null; // YYYY-MM-DD
-  to: string | null;   // YYYY-MM-DD (inclusive whole day)
-}
-
-export type Filter = TagFilter | DateFilter;
-
-export interface FilterState {
-  filters: Filter[];
-}
+export type { DateField, TagFilter, DateFilter, Filter, FilterState };
 
 export function makeInitialFilterState(): FilterState {
   return { filters: [] };

--- a/app/src/panels/filters.ts
+++ b/app/src/panels/filters.ts
@@ -14,39 +14,7 @@ export {
   newFilterId, collectAllTags, nowForField,
 };
 
-// ---- Persistence ----
-
-const STORAGE_KEY = 'last-gasp-pinned-filters';
-
-export function loadPinnedFilters(): Filter[] {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter(isFilterShape).map(f => ({ ...f, pinned: true }));
-  } catch {
-    return [];
-  }
-}
-
-export function savePinnedFilters(state: FilterState): void {
-  try {
-    const pinned = state.filters.filter(f => f.pinned);
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(pinned));
-  } catch {
-    // quota/private-mode — silently ignore
-  }
-}
-
-function isFilterShape(x: unknown): x is Filter {
-  if (!x || typeof x !== 'object') return false;
-  const o = x as Record<string, unknown>;
-  if (typeof o.id !== 'string') return false;
-  if (o.type === 'tag') return Array.isArray(o.tags);
-  if (o.type === 'date') return typeof o.field === 'string';
-  return false;
-}
+export { loadPinnedFilters, savePinnedFilters } from './filters/persistence.ts';
 
 // ---- Sidebar rendering ----
 

--- a/app/src/panels/filters.ts
+++ b/app/src/panels/filters.ts
@@ -1,93 +1,18 @@
 import Fuse from 'fuse.js';
 import type { EventListItem, TagsRegistry } from '../data/types.ts';
-import { parseISOString, toAbsoluteSeconds } from '../calendar/golarian.ts';
 import type {
   DateField, TagFilter, DateFilter, Filter, FilterState,
 } from './filters/types.ts';
+import {
+  makeInitialFilterState, applyFilters, matchesFilter, filterSummary,
+  newFilterId, collectAllTags, nowForField,
+} from './filters/logic.ts';
 
 export type { DateField, TagFilter, DateFilter, Filter, FilterState };
-
-export function makeInitialFilterState(): FilterState {
-  return { filters: [] };
-}
-
-// ---- Pure filtering ----
-
-/** Events match iff every enabled filter matches. Empty state matches all. */
-export function applyFilters(events: EventListItem[], state: FilterState): EventListItem[] {
-  const active = state.filters.filter(f => f.enabled);
-  if (active.length === 0) return events.slice();
-  return events.filter(ev => active.every(f => matchesFilter(ev, f)));
-}
-
-export function matchesFilter(event: EventListItem, filter: Filter): boolean {
-  if (filter.type === 'tag') return matchesTagFilter(event, filter);
-  return matchesDateFilter(event, filter);
-}
-
-function matchesTagFilter(event: EventListItem, filter: TagFilter): boolean {
-  if (filter.tags.length === 0) return true; // vacuous — editor should disallow but be safe
-  const eventTags = new Set(event.tags ?? []);
-  return filter.tags.some(t => eventTags.has(t));
-}
-
-function matchesDateFilter(event: EventListItem, filter: DateFilter): boolean {
-  if (!filter.from && !filter.to) return true;
-
-  if (filter.field === 'in-game') {
-    const sec = toAbsoluteSeconds(parseISOString(event.date));
-    const fromSec = filter.from ? toAbsoluteSeconds(parseISOString(filter.from)) : null;
-    const toSec = filter.to ? toAbsoluteSeconds(parseISOString(filter.to)) + 86400 : null;
-    if (fromSec !== null && sec < fromSec) return false;
-    if (toSec !== null && sec >= toSec) return false;
-    return true;
-  }
-
-  if (filter.field === 'session') {
-    // Parse session tags: "session:YYYY-MM-DD" → real-world day string.
-    const sessionDates = (event.tags ?? [])
-      .filter(t => t.startsWith('session:'))
-      .map(t => t.slice('session:'.length));
-    if (sessionDates.length === 0) return false;
-    return sessionDates.some(d => withinDayRange(d, filter.from, filter.to));
-  }
-
-  // creation — real-world mtime
-  const mtimeDay = toUTCDateOnly(event.mtime);
-  return withinDayRange(mtimeDay, filter.from, filter.to);
-}
-
-function withinDayRange(day: string, from: string | null, to: string | null): boolean {
-  if (from && day < from) return false;
-  if (to && day > to) return false;
-  return true;
-}
-
-function toUTCDateOnly(isoOrRFC: string): string {
-  // mtime arrives as RFC2822 (from Last-Modified) or ISO. Both parse via Date.
-  const d = new Date(isoOrRFC);
-  if (Number.isNaN(d.getTime())) return '';
-  const y = d.getUTCFullYear();
-  const m = d.getUTCMonth() + 1;
-  const day = d.getUTCDate();
-  return `${String(y).padStart(4, '0')}-${String(m).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
-}
-
-// ---- Summaries ----
-
-export function filterSummary(f: Filter): string {
-  if (f.type === 'tag') {
-    if (f.tags.length === 0) return '(no tags selected)';
-    return 'Tags: ' + f.tags.join(' OR ');
-  }
-  const label = f.field === 'in-game' ? 'In-game'
-             : f.field === 'session' ? 'Session'
-             : 'Created';
-  if (!f.from && !f.to) return `${label}: (any)`;
-  if (f.from && f.to) return `${label}: ${f.from} → ${f.to}`;
-  if (f.from) return `${label}: ≥ ${f.from}`;
-  return `${label}: ≤ ${f.to}`;
-}
+export {
+  makeInitialFilterState, applyFilters, matchesFilter, filterSummary,
+  newFilterId, collectAllTags, nowForField,
+};
 
 // ---- Persistence ----
 
@@ -123,20 +48,6 @@ function isFilterShape(x: unknown): x is Filter {
   return false;
 }
 
-// ---- ID helper ----
-
-export function newFilterId(): string {
-  return 'f_' + Math.random().toString(36).slice(2, 10);
-}
-
-// ---- Tag universe (for fuzzy pick) ----
-
-export function collectAllTags(events: EventListItem[]): string[] {
-  const s = new Set<string>();
-  for (const ev of events) for (const t of ev.tags ?? []) s.add(t);
-  return [...s].sort();
-}
-
 // ---- Sidebar rendering ----
 
 export interface SidebarDeps {
@@ -148,12 +59,6 @@ export interface SidebarDeps {
   inGameNow: string;
   /** Real-world "now" — used when a date filter is session- or creation-scoped. */
   realWorldNow: string;
-}
-
-/** Returns the default "now" YYYY-MM-DD for a given date-filter field. */
-export function nowForField(field: DateField, inGameNow: string, realWorldNow: string): string {
-  const source = field === 'in-game' ? inGameNow : realWorldNow;
-  return source.slice(0, 10);
 }
 
 /** Tracks which filter IDs are currently in edit mode across re-renders. */

--- a/app/src/panels/filters/filters.test.ts
+++ b/app/src/panels/filters/filters.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest';
 import {
   applyFilters, matchesFilter, filterSummary,
   makeInitialFilterState, newFilterId,
-  type Filter, type TagFilter, type DateFilter,
-} from './filters.ts';
-import type { EventListItem } from '../data/types.ts';
+} from './logic.ts';
+import type { Filter, TagFilter, DateFilter } from './types.ts';
+import type { EventListItem } from '../../data/types.ts';
 
 function ev(overrides: Partial<EventListItem>): EventListItem {
   return {

--- a/app/src/panels/filters/logic.ts
+++ b/app/src/panels/filters/logic.ts
@@ -1,0 +1,107 @@
+import type { EventListItem } from '../../data/types.ts';
+import { parseISOString, toAbsoluteSeconds } from '../../calendar/golarian.ts';
+import type {
+  DateField, TagFilter, DateFilter, Filter, FilterState,
+} from './types.ts';
+
+export function makeInitialFilterState(): FilterState {
+  return { filters: [] };
+}
+
+// ---- Pure filtering ----
+
+/** Events match iff every enabled filter matches. Empty state matches all. */
+export function applyFilters(events: EventListItem[], state: FilterState): EventListItem[] {
+  const active = state.filters.filter(f => f.enabled);
+  if (active.length === 0) return events.slice();
+  return events.filter(ev => active.every(f => matchesFilter(ev, f)));
+}
+
+export function matchesFilter(event: EventListItem, filter: Filter): boolean {
+  if (filter.type === 'tag') return matchesTagFilter(event, filter);
+  return matchesDateFilter(event, filter);
+}
+
+function matchesTagFilter(event: EventListItem, filter: TagFilter): boolean {
+  if (filter.tags.length === 0) return true; // vacuous — editor should disallow but be safe
+  const eventTags = new Set(event.tags ?? []);
+  return filter.tags.some(t => eventTags.has(t));
+}
+
+function matchesDateFilter(event: EventListItem, filter: DateFilter): boolean {
+  if (!filter.from && !filter.to) return true;
+
+  if (filter.field === 'in-game') {
+    const sec = toAbsoluteSeconds(parseISOString(event.date));
+    const fromSec = filter.from ? toAbsoluteSeconds(parseISOString(filter.from)) : null;
+    const toSec = filter.to ? toAbsoluteSeconds(parseISOString(filter.to)) + 86400 : null;
+    if (fromSec !== null && sec < fromSec) return false;
+    if (toSec !== null && sec >= toSec) return false;
+    return true;
+  }
+
+  if (filter.field === 'session') {
+    // Parse session tags: "session:YYYY-MM-DD" → real-world day string.
+    const sessionDates = (event.tags ?? [])
+      .filter(t => t.startsWith('session:'))
+      .map(t => t.slice('session:'.length));
+    if (sessionDates.length === 0) return false;
+    return sessionDates.some(d => withinDayRange(d, filter.from, filter.to));
+  }
+
+  // creation — real-world mtime
+  const mtimeDay = toUTCDateOnly(event.mtime);
+  return withinDayRange(mtimeDay, filter.from, filter.to);
+}
+
+function withinDayRange(day: string, from: string | null, to: string | null): boolean {
+  if (from && day < from) return false;
+  if (to && day > to) return false;
+  return true;
+}
+
+function toUTCDateOnly(isoOrRFC: string): string {
+  // mtime arrives as RFC2822 (from Last-Modified) or ISO. Both parse via Date.
+  const d = new Date(isoOrRFC);
+  if (Number.isNaN(d.getTime())) return '';
+  const y = d.getUTCFullYear();
+  const m = d.getUTCMonth() + 1;
+  const day = d.getUTCDate();
+  return `${String(y).padStart(4, '0')}-${String(m).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
+
+// ---- Summaries ----
+
+export function filterSummary(f: Filter): string {
+  if (f.type === 'tag') {
+    if (f.tags.length === 0) return '(no tags selected)';
+    return 'Tags: ' + f.tags.join(' OR ');
+  }
+  const label = f.field === 'in-game' ? 'In-game'
+             : f.field === 'session' ? 'Session'
+             : 'Created';
+  if (!f.from && !f.to) return `${label}: (any)`;
+  if (f.from && f.to) return `${label}: ${f.from} → ${f.to}`;
+  if (f.from) return `${label}: ≥ ${f.from}`;
+  return `${label}: ≤ ${f.to}`;
+}
+
+// ---- ID helper ----
+
+export function newFilterId(): string {
+  return 'f_' + Math.random().toString(36).slice(2, 10);
+}
+
+// ---- Tag universe (for fuzzy pick) ----
+
+export function collectAllTags(events: EventListItem[]): string[] {
+  const s = new Set<string>();
+  for (const ev of events) for (const t of ev.tags ?? []) s.add(t);
+  return [...s].sort();
+}
+
+/** Returns the default "now" YYYY-MM-DD for a given date-filter field. */
+export function nowForField(field: DateField, inGameNow: string, realWorldNow: string): string {
+  const source = field === 'in-game' ? inGameNow : realWorldNow;
+  return source.slice(0, 10);
+}

--- a/app/src/panels/filters/persistence.ts
+++ b/app/src/panels/filters/persistence.ts
@@ -1,0 +1,33 @@
+import type { Filter, FilterState } from './types.ts';
+
+const STORAGE_KEY = 'last-gasp-pinned-filters';
+
+export function loadPinnedFilters(): Filter[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isFilterShape).map(f => ({ ...f, pinned: true }));
+  } catch {
+    return [];
+  }
+}
+
+export function savePinnedFilters(state: FilterState): void {
+  try {
+    const pinned = state.filters.filter(f => f.pinned);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(pinned));
+  } catch {
+    // quota/private-mode — silently ignore
+  }
+}
+
+function isFilterShape(x: unknown): x is Filter {
+  if (!x || typeof x !== 'object') return false;
+  const o = x as Record<string, unknown>;
+  if (typeof o.id !== 'string') return false;
+  if (o.type === 'tag') return Array.isArray(o.tags);
+  if (o.type === 'date') return typeof o.field === 'string';
+  return false;
+}

--- a/app/src/panels/filters/sidebar.ts
+++ b/app/src/panels/filters/sidebar.ts
@@ -1,20 +1,11 @@
 import Fuse from 'fuse.js';
-import type { EventListItem, TagsRegistry } from '../data/types.ts';
+import type { EventListItem, TagsRegistry } from '../../data/types.ts';
 import type {
   DateField, TagFilter, DateFilter, Filter, FilterState,
-} from './filters/types.ts';
+} from './types.ts';
 import {
-  makeInitialFilterState, applyFilters, matchesFilter, filterSummary,
-  newFilterId, collectAllTags, nowForField,
-} from './filters/logic.ts';
-
-export type { DateField, TagFilter, DateFilter, Filter, FilterState };
-export {
-  makeInitialFilterState, applyFilters, matchesFilter, filterSummary,
-  newFilterId, collectAllTags, nowForField,
-};
-
-export { loadPinnedFilters, savePinnedFilters } from './filters/persistence.ts';
+  filterSummary, newFilterId, collectAllTags, nowForField,
+} from './logic.ts';
 
 // ---- Sidebar rendering ----
 

--- a/app/src/panels/filters/types.ts
+++ b/app/src/panels/filters/types.ts
@@ -1,0 +1,27 @@
+// ---- Types ----
+
+export type DateField = 'in-game' | 'session' | 'creation';
+
+export interface TagFilter {
+  id: string;
+  type: 'tag';
+  enabled: boolean;
+  pinned: boolean;
+  tags: string[]; // OR'd together
+}
+
+export interface DateFilter {
+  id: string;
+  type: 'date';
+  enabled: boolean;
+  pinned: boolean;
+  field: DateField;
+  from: string | null; // YYYY-MM-DD
+  to: string | null;   // YYYY-MM-DD (inclusive whole day)
+}
+
+export type Filter = TagFilter | DateFilter;
+
+export interface FilterState {
+  filters: Filter[];
+}

--- a/app/src/timeline/app.ts
+++ b/app/src/timeline/app.ts
@@ -13,10 +13,10 @@ import { renderAxis } from './axis.ts';
 import { layoutCards, renderCards, type CardExpansion } from './card.ts';
 import { computeSessionBands, renderSessionBands, findSessionConflicts } from './session-band.ts';
 import { openCreateEditor, openEditEditor } from '../editor/modal/index.ts';
-import {
-  type FilterState, makeInitialFilterState, applyFilters, renderFilterSidebar,
-  loadPinnedFilters, savePinnedFilters,
-} from '../panels/filters.ts';
+import type { FilterState } from '../panels/filters/types.ts';
+import { makeInitialFilterState, applyFilters } from '../panels/filters/logic.ts';
+import { renderFilterSidebar } from '../panels/filters/sidebar.ts';
+import { loadPinnedFilters, savePinnedFilters } from '../panels/filters/persistence.ts';
 import { createSearchOverlay } from '../panels/search.ts';
 import { initPeek } from '../peek/stack.ts';
 import type { EventListItem, TagsRegistry, State } from '../data/types.ts';


### PR DESCRIPTION
Closes #47. Part of #36.

Splits the 421-line `app/src/panels/filters.ts` into the four-module folder layout already documented in `app/src/panels/AGENTS.md`. No behaviour change — the localStorage key (`last-gasp-pinned-filters`), filter semantics, and sidebar markup are byte-for-byte identical.

## Before / after

| File | Lines |
| --- | --- |
| `panels/filters.ts` (before) | 421 |
| `panels/filters/sidebar.ts` | 262 |
| `panels/filters/filters.test.ts` | 177 |
| `panels/filters/logic.ts` | 107 |
| `panels/filters/persistence.ts` | 33 |
| `panels/filters/types.ts` | 27 |

`logic.ts` is pure (no DOM, no `localStorage`); `persistence.ts` owns the localStorage schema; `sidebar.ts` is the only DOM-touching file in the slice; `types.ts` is shared by all three.

## Commits (one seam each)

1. `extract types.ts from panels/filters.ts`
2. `extract logic.ts from panels/filters.ts and relocate tests`
3. `extract persistence.ts from panels/filters.ts`
4. `rename panels/filters.ts to filters/sidebar.ts and wire callers`

The test file moved alongside `logic.ts` as `panels/filters/filters.test.ts` and now imports only from `./logic.ts` and `./types.ts`. `timeline/app.ts` (the only external caller) imports each piece directly from its new home; the re-export shim in the old `filters.ts` was deleted in commit 4.

## Verification

```
$ npx vite build
✓ 142 modules transformed.
✓ built in 301ms

$ npm test
Test Files  6 passed (6)
     Tests  114 passed (114)

$ grep -rE "localStorage" src/panels/filters/logic.ts src/panels/filters/types.ts src/panels/filters/filters.test.ts
(empty)

$ grep -rE "document\." src/panels/filters/logic.ts src/panels/filters/persistence.ts
(empty)

$ find src/panels/filters -name '*.ts' | xargs wc -l
  262 src/panels/filters/sidebar.ts
  107 src/panels/filters/logic.ts
  177 src/panels/filters/filters.test.ts
   33 src/panels/filters/persistence.ts
   27 src/panels/filters/types.ts
  606 total
```

## Owner verifies in browser (manual smoke test)

- [x] Open timeline → click Filters button → sidebar appears
- [x] Add a filter (e.g. tag, date range, text) → events on timeline filter live
- [x] Pin a filter → reload page → pinned filter persists, starts disabled
- [x] Clear filters → all events return
- [x] Disable a filter → events return; re-enable → filtered again

## Notes

- `panels/AGENTS.md` already documents this layout, so no doc update is needed.
- The localStorage key was left as the existing `last-gasp-pinned-filters` value to satisfy the "no behaviour change / backwards-compatible" constraint. The issue text mentions `filters.pinned.v1` as a target; if a rename + migration is wanted, that's a separate change (it would reset everyone's pinned filters once unless paired with a one-shot migration on read).

https://claude.ai/code/session_019zujK1uqqjZnzU1RMcnmee

---
_Generated by [Claude Code](https://claude.ai/code/session_019zujK1uqqjZnzU1RMcnmee)_