### PR TITLE
Timeline time dividers and 10-minute quick-add snap (#12)

### DIFF
--- a/app/src/calendar/format.ts
+++ b/app/src/calendar/format.ts
@@ -53,14 +53,22 @@ export function formatCardFace(date: GolarianDate): string {
   return s;
 }
 
-/** "Wed 4 Desnus" — axis major tick */
+/** "Wed 4 Desnus" — axis major tick (used by tooltips/labels outside the axis) */
 export function formatAxisDay(date: GolarianDate): string {
   return `${weekday(date).slice(0, 3)} ${date.day} ${monthName(date.month)}`;
 }
 
+/** "Wed 4" / "4" — axis tick label, detail level driven by zoom */
+export function formatAxisDayTick(date: GolarianDate, level: 'full' | 'short'): string {
+  if (level === 'short') return `${date.day}`;
+  return `${weekday(date).slice(0, 3)} ${date.day}`;
+}
+
 /** "09:00" — axis minor tick */
-export function formatAxisHour(date: GolarianDate): string {
-  return `${String(date.hour).padStart(2, '0')}:${String(date.minute).padStart(2, '0')}`;
+export function formatAxisHour(date: GolarianDate, shorten: boolean = false): string {
+  const hour = String(date.hour).padStart(2, '0');
+  if (shorten && date.minute == 0) return hour;
+  return `${hour}:${String(date.minute).padStart(2, '0')}`;
 }
 
 /** "Desnus 4th, Wednesday, 4726 AR" — floating header (day) */

--- a/app/src/styles/timeline.css
+++ b/app/src/styles/timeline.css
@@ -211,7 +211,7 @@
   position: absolute;
   left: 0;
   right: 0;
-  height: 1px;
+  height: 2px;
   background: var(--theme-border-strong, #5a4530);
 }
 
@@ -221,18 +221,26 @@
 }
 
 .axis-tick-mark {
-  width: 1px;
-  height: 8px;
+  width: 2px;
+  height: 21px;
   background: var(--theme-border-strong, #5a4530);
   margin-top: -4px;
 }
 
 .axis-tick-label {
-  margin-top: 6px;
   font-size: 15px;
   color: var(--theme-text-secondary, #a89a80);
   font-family: ui-monospace, 'Consolas', monospace;
   white-space: nowrap;
+}
+
+.axis-day-pin {
+  position: absolute;
+  font-size: 15px;
+  color: var(--theme-text-secondary, #a89a80);
+  font-family: ui-monospace, 'Consolas', monospace;
+  white-space: nowrap;
+  pointer-events: none;
 }
 
 .axis-month-band {
@@ -278,6 +286,7 @@
   font-family: ui-monospace, 'Consolas', monospace;
   white-space: nowrap;
   margin-top: 2px;
+  transform: translateX(-50%);
 }
 
 

--- a/app/src/styles/timeline.css
+++ b/app/src/styles/timeline.css
@@ -263,6 +263,88 @@
   white-space: nowrap;
 }
 
+/* ===== Time dividers (intraday tick marks) ===== */
+
+.axis-time-tick {
+  position: absolute;
+  pointer-events: none;
+}
+
+.axis-time-mark {
+  width: 1px;
+}
+
+.axis-time-label {
+  font-family: ui-monospace, 'Consolas', monospace;
+  white-space: nowrap;
+  margin-top: 2px;
+}
+
+
+/* Midday (12:00) — most prominent intraday marker */
+.axis-time-midday .axis-time-mark {
+  height: 12px;
+  margin-top: -6px;
+  background: var(--theme-border-strong, #5a4530);
+  opacity: 0.9;
+}
+.axis-time-midday .axis-time-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--theme-text-secondary, #a89a80);
+}
+
+/* Hours */
+.axis-time-hour .axis-time-mark {
+  height: 8px;
+  margin-top: -4px;
+  background: var(--theme-border-strong, #5a4530);
+  opacity: 0.65;
+}
+.axis-time-hour .axis-time-label {
+  font-size: 10px;
+  color: var(--theme-text-secondary, #a89a80);
+  opacity: 0.85;
+}
+
+/* Half-hours */
+.axis-time-half .axis-time-mark {
+  height: 5px;
+  margin-top: -2px;
+  background: var(--theme-text-muted, #7a6f58);
+  opacity: 0.6;
+}
+.axis-time-half .axis-time-label {
+  font-size: 9px;
+  color: var(--theme-text-muted, #7a6f58);
+}
+
+/* Quarter-hours */
+.axis-time-quarter .axis-time-mark {
+  height: 3px;
+  margin-top: -1px;
+  background: var(--theme-text-muted, #7a6f58);
+  opacity: 0.5;
+}
+.axis-time-quarter .axis-time-label {
+  font-size: 9px;
+  color: var(--theme-text-muted, #7a6f58);
+  opacity: 0.75;
+}
+
+/* Minutes */
+.axis-time-minute .axis-time-mark {
+  height: 2px;
+  margin-top: -1px;
+  background: var(--theme-text-muted, #7a6f58);
+  opacity: 0.4;
+}
+.axis-time-minute .axis-time-label {
+  font-size: 8px;
+  color: var(--theme-text-muted, #7a6f58);
+  opacity: 0.6;
+}
+
 /* ===== Now marker ===== */
 
 .now-marker {

--- a/app/src/timeline/interactions/quick-add-zones.test.ts
+++ b/app/src/timeline/interactions/quick-add-zones.test.ts
@@ -132,8 +132,8 @@ describe('createQuickAddZones', () => {
     click(container);
     expect(onQuickAdd).toHaveBeenCalledTimes(1);
     const secs = onQuickAdd.mock.calls[0][0];
-    // 15-minute snap (900s)
-    expect(Math.abs(secs % 900)).toBe(0);
+    // 10-minute snap (600s)
+    expect(Math.abs(secs % 600)).toBe(0);
   });
 
   it('ctrl held during hover snaps to whole days', () => {

--- a/app/src/timeline/interactions/quick-add-zones.ts
+++ b/app/src/timeline/interactions/quick-add-zones.ts
@@ -5,7 +5,7 @@ import {
 import { fromAbsoluteSeconds } from '../../calendar/golarian.ts';
 import { formatAxisDay, formatAxisHour, formatNowMarker } from '../../calendar/format.ts';
 
-const SNAP_SECS = 900;
+const SNAP_SECS = 600;
 const QUICK_ADD_ZONE_TOP = 4;     // px below axisY where the indicator activates
 const QUICK_ADD_ZONE_BOTTOM = 68; // px below axisY where it stops
 

--- a/app/src/timeline/render/axis.test.ts
+++ b/app/src/timeline/render/axis.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { naturalTier, ALL_TIERS, type TimeTier } from './axis.ts';
+
+// Convenience: look up a tier by id
+function tier(id: TimeTier['id']): TimeTier {
+  const t = ALL_TIERS.find(t => t.id === id);
+  if (!t) throw new Error(`No tier: ${id}`);
+  return t;
+}
+
+describe('naturalTier', () => {
+  it('identifies midday (12:00:00 = 43200s)', () => {
+    expect(naturalTier(43200, ALL_TIERS)).toBe(tier('midday'));
+  });
+
+  it('identifies an hour mark that is not midday (09:00 = 32400s)', () => {
+    expect(naturalTier(32400, ALL_TIERS)).toBe(tier('hour'));
+  });
+
+  it('identifies 2am (7200s) as an hour, not midday', () => {
+    expect(naturalTier(7200, ALL_TIERS)).toBe(tier('hour'));
+  });
+
+  it('identifies a half-hour that is not on an hour (00:30 = 1800s)', () => {
+    expect(naturalTier(1800, ALL_TIERS)).toBe(tier('half'));
+  });
+
+  it('identifies 23:30 (84600s) as half', () => {
+    expect(naturalTier(84600, ALL_TIERS)).toBe(tier('half'));
+  });
+
+  it('identifies a quarter-hour that is not on a half-hour (00:15 = 900s)', () => {
+    expect(naturalTier(900, ALL_TIERS)).toBe(tier('quarter'));
+  });
+
+  it('identifies 00:45 (2700s) as quarter', () => {
+    expect(naturalTier(2700, ALL_TIERS)).toBe(tier('quarter'));
+  });
+
+  it('identifies a minute mark that is not on any coarser boundary (00:01 = 60s)', () => {
+    expect(naturalTier(60, ALL_TIERS)).toBe(tier('minute'));
+  });
+
+  it('identifies 00:11 (660s) as minute', () => {
+    expect(naturalTier(660, ALL_TIERS)).toBe(tier('minute'));
+  });
+
+  it('returns null for a second-level value not on any minute boundary (37s)', () => {
+    expect(naturalTier(37, ALL_TIERS)).toBeNull();
+  });
+
+  it('midday wins over hour when both divide 43200', () => {
+    // 43200 is divisible by 3600 (hour step) too, but midday comes first in ALL_TIERS
+    expect(naturalTier(43200, ALL_TIERS)?.id).toBe('midday');
+  });
+
+  it('half wins over quarter when both divide 1800', () => {
+    // 1800 is divisible by 900 (quarter step), but half (1800) appears first
+    expect(naturalTier(1800, ALL_TIERS)?.id).toBe('half');
+  });
+
+  it('works with a subset of tiers (only midday + hour active)', () => {
+    const active = ALL_TIERS.filter(t => t.id === 'midday' || t.id === 'hour');
+    expect(naturalTier(43200, active)?.id).toBe('midday');
+    expect(naturalTier(3600, active)?.id).toBe('hour');
+    // 1800 is not a multiple of either 43200 or 3600 → null
+    expect(naturalTier(1800, active)).toBeNull();
+  });
+});

--- a/app/src/timeline/render/axis.ts
+++ b/app/src/timeline/render/axis.ts
@@ -1,6 +1,6 @@
 import { type ViewState, type ViewportSize, xToSeconds, secondsToX, SECONDS_PER_DAY } from '../interactions/zoom.ts';
 import { fromAbsoluteDays, toAbsoluteDays, daysInMonth, monthName, fromAbsoluteSeconds } from '../../calendar/golarian.ts';
-import { formatAxisDay, formatAxisHour } from '../../calendar/format.ts';
+import { formatAxisDayTick, formatAxisHour } from '../../calendar/format.ts';
 
 /**
  * Render axis major tick marks and labels for the visible range.
@@ -44,12 +44,31 @@ export function renderAxis(
     mark.className = 'axis-tick-mark';
     tick.appendChild(mark);
 
+    const pxPerTick = pixelsPerDay * dayStep;
+    const dayLabelLevel = pxPerTick >= 55 ? 'full' : 'short';
+
     const label = document.createElement('div');
     label.className = 'axis-tick-label';
-    label.textContent = formatAxisDay(date);
+    label.textContent = formatAxisDayTick(date, dayLabelLevel);
     tick.appendChild(label);
 
     container.appendChild(tick);
+  }
+
+  // Pinned day label: when zoomed to hours the midnight tick is off-screen left,
+  // so pin the current day's label at the left edge (mirrors the month-label pin).
+  if (dayStep === 1) {
+    const leftDay = Math.floor(startSec / SECONDS_PER_DAY);
+    const leftDayX = secondsToX(leftDay * SECONDS_PER_DAY, view, size);
+    if (leftDayX < 0) {
+      const date = fromAbsoluteDays(leftDay);
+      const pin = document.createElement('div');
+      pin.className = 'axis-day-pin';
+      pin.style.left = '8px';
+      pin.style.top = `${axisY + 17}px`;
+      pin.textContent = formatAxisDayTick(date, 'full');
+      container.appendChild(pin);
+    }
   }
 
   // Month bands + labels
@@ -195,7 +214,7 @@ function renderTimeTicks(
       const date = fromAbsoluteSeconds(t);
       const lbl = document.createElement('div');
       lbl.className = 'axis-time-label';
-      lbl.textContent = formatAxisHour(date);
+      lbl.textContent = formatAxisHour(date, true);
       el.appendChild(lbl);
     }
 

--- a/app/src/timeline/render/axis.ts
+++ b/app/src/timeline/render/axis.ts
@@ -1,6 +1,6 @@
 import { type ViewState, type ViewportSize, xToSeconds, secondsToX, SECONDS_PER_DAY } from '../interactions/zoom.ts';
-import { fromAbsoluteDays, toAbsoluteDays, daysInMonth, monthName } from '../../calendar/golarian.ts';
-import { formatAxisDay } from '../../calendar/format.ts';
+import { fromAbsoluteDays, toAbsoluteDays, daysInMonth, monthName, fromAbsoluteSeconds } from '../../calendar/golarian.ts';
+import { formatAxisDay, formatAxisHour } from '../../calendar/format.ts';
 
 /**
  * Render axis major tick marks and labels for the visible range.
@@ -94,6 +94,9 @@ export function renderAxis(
 
     monthStartDay = monthEndDay;
   }
+
+  // Intraday time dividers (appended last so they sit above month bands)
+  renderTimeTicks(container, view, size, axisY, startSec, endSec);
 }
 
 /** Choose day-tick spacing that keeps labels readable at the current zoom level. */
@@ -105,6 +108,101 @@ function chooseDayStep(pixelsPerDay: number): number {
     if (c >= idealDays) return c;
   }
   return candidates[candidates.length - 1];
+}
+
+// ---------------------------------------------------------------------------
+// Intraday time dividers
+// ---------------------------------------------------------------------------
+
+export interface TimeTier {
+  readonly id: 'midday' | 'hour' | 'half' | 'quarter' | 'minute';
+  /** Seconds between ticks of this tier. */
+  readonly stepSecs: number;
+  /** Minimum pixels-per-day to render the tick mark. */
+  readonly markMinPPD: number;
+  /** Tick mark height in px (centered on the axis line). */
+  readonly markHeight: number;
+  /** Minimum pixels-per-day to also render the hh:mm label. */
+  readonly labelMinPPD: number;
+}
+
+export const ALL_TIERS: readonly TimeTier[] = [
+  { id: 'midday',  stepSecs: 43200, markMinPPD:   80, markHeight: 12, labelMinPPD:   120 },
+  { id: 'hour',    stepSecs:  3600, markMinPPD:  800, markHeight:  8, labelMinPPD:  1500 },
+  { id: 'half',    stepSecs:  1800, markMinPPD: 1600, markHeight:  5, labelMinPPD:  3000 },
+  { id: 'quarter', stepSecs:   900, markMinPPD: 3200, markHeight:  3, labelMinPPD:  6000 },
+  { id: 'minute',  stepSecs:    60, markMinPPD:40000, markHeight:  2, labelMinPPD: 100000 },
+];
+
+/**
+ * Returns the coarsest tier (from `tiers`, ordered coarsest-first) whose step
+ * evenly divides `withinDay`, or null if none do.
+ *
+ * Pure function — exported for tests.
+ */
+export function naturalTier(withinDay: number, tiers: readonly TimeTier[]): TimeTier | null {
+  for (const tier of tiers) {
+    if (withinDay % tier.stepSecs === 0) return tier;
+  }
+  return null;
+}
+
+/**
+ * Render intraday time-divider ticks into `container`.
+ * Called from `renderAxis` after day ticks and month bands are placed.
+ */
+function renderTimeTicks(
+  container: HTMLElement,
+  view: ViewState,
+  size: ViewportSize,
+  axisY: number,
+  startSec: number,
+  endSec: number,
+): void {
+  const pixelsPerDay = SECONDS_PER_DAY / view.secondsPerPixel;
+
+  const activeTiers = ALL_TIERS.filter(t => pixelsPerDay >= t.markMinPPD);
+  if (activeTiers.length === 0) return;
+
+  // Step by the finest active tier so we visit every relevant position.
+  const stepSecs = activeTiers[activeTiers.length - 1].stepSecs;
+
+  const firstTick = Math.ceil(startSec / stepSecs) * stepSecs;
+  const frag = document.createDocumentFragment();
+
+  for (let t = firstTick; t <= endSec; t += stepSecs) {
+    // Defensive positive modulo (seconds since epoch are always positive for
+    // in-game dates, but guard anyway).
+    const withinDay = ((t % SECONDS_PER_DAY) + SECONDS_PER_DAY) % SECONDS_PER_DAY;
+    if (withinDay === 0) continue; // midnight → owned by day-boundary tick
+
+    const tier = naturalTier(withinDay, activeTiers);
+    if (!tier) continue;
+
+    const x = secondsToX(t, view, size);
+    if (x < -5 || x > size.width + 5) continue;
+
+    const el = document.createElement('div');
+    el.className = `axis-time-tick axis-time-${tier.id}`;
+    el.style.left = `${x}px`;
+    el.style.top = `${axisY}px`;
+
+    const mark = document.createElement('div');
+    mark.className = 'axis-time-mark';
+    el.appendChild(mark);
+
+    if (pixelsPerDay >= tier.labelMinPPD) {
+      const date = fromAbsoluteSeconds(t);
+      const lbl = document.createElement('div');
+      lbl.className = 'axis-time-label';
+      lbl.textContent = formatAxisHour(date);
+      el.appendChild(lbl);
+    }
+
+    frag.appendChild(el);
+  }
+
+  container.appendChild(frag);
 }
 
 export function todayAbsoluteSeconds(): number {


### PR DESCRIPTION
Closes #12

## Summary

- **Quick-add snap**: Changed from 15-minute (900s) to 10-minute (600s) chunks when clicking to add a new event on the timeline.
- **Intraday time dividers**: Added zoom-aware tick marks between day boundaries on the axis. Five tiers render progressively as you zoom in:

| Tier | Appears at | Labels at |
|---|---|---|
| Midday (12:00) | ≥ 80 px/day (default zoom) | ≥ 120 px/day |
| Hours | ≥ 800 px/day | ≥ 1500 px/day |
| Half-hours | ≥ 1600 px/day | ≥ 3000 px/day |
| Quarter-hours | ≥ 3200 px/day | ≥ 6000 px/day |
| Minutes | ≥ 40 000 px/day | ≥ 100 000 px/day |

All labels use `hh:mm` digital format. Marks are centered on the axis line and sized/coloured to create a clear visual hierarchy (tallest/most opaque = midday, shortest/most faint = minutes). At very low zoom no intraday ticks appear.

## Implementation notes

- New `naturalTier(withinDay, tiers)` pure function determines which tier "owns" a given second-within-day position: the coarsest active tier whose step divides `withinDay`. This prevents double-drawing at boundaries (e.g. 12:00 is always midday, never hour; 09:00 is always hour, never half-hour).
- Ticks are rendered into a `DocumentFragment` and appended once, sitting above month bands in DOM order.
- Midnight (`withinDay === 0`) is always skipped — the existing day-boundary tick owns that position.

## Test plan

- [x] All 159 existing tests pass
- [x] New `axis.test.ts` covers `naturalTier` edge cases: midday vs hour at 43200, half vs quarter at 1800, minute vs none at non-boundary, subset-of-active-tiers behaviour
- [ ] Visually verify: at default zoom, midday tick visible between each day pair
- [ ] Zoom in ~4–5x: hour ticks appear
- [ ] Zoom in further: half-hour, quarter-hour, minute ticks appear in sequence
- [ ] Zoom out past threshold: all intraday ticks disappear
- [ ] Quick-add: hovering the axis zone snaps to 10-minute boundaries (not 15)

https://claude.ai/code/session_01SoSry4V9hcRE3f2JUP83S4

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoSry4V9hcRE3f2JUP83S4)_