### PR TITLE
Fix vertical scrollbar on file tabs bar

### DIFF
--- a/app/src/styles/notes/tabs.css
+++ b/app/src/styles/notes/tabs.css
@@ -40,7 +40,7 @@
 .tab.is-active::after {
   content: '';
   position: absolute;
-  left: 0; right: 0; bottom: -1px;
+  left: 0; right: 0; bottom: 0;
   height: 1px;
   background: var(--theme-accent-gold, #c9a860);
 }

--- a/app/src/styles/notes/tabs.css
+++ b/app/src/styles/notes/tabs.css
@@ -14,6 +14,7 @@
   border-bottom: 1px solid var(--theme-border, #3a3a30);
   height: 34px;
   overflow-x: auto;
+  overflow-y: hidden;
   scrollbar-width: thin;
   flex-shrink: 0;
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fixes a spurious vertical scrollbar appearing on the right side of the file tabs bar (#42)
- Root cause: setting `overflow-x: auto` implicitly makes `overflow-y: auto` per the CSS spec, so any content fractionally taller than the fixed 34px height (e.g. due to subpixel rendering or the active tab's `::after` at `bottom: -1px`) triggers a scrollbar
- Fix: add `overflow-y: hidden` to `.tabs-bar` to explicitly suppress vertical overflow while keeping horizontal scrolling intact

## Test plan

- [x] Open the notes view with several tabs open — no vertical scrollbar should appear on the tabs bar
- [x] Verify horizontal scrolling still works when many tabs are open (more than fit the width)
- [x] Check the active tab gold underline still renders correctly at 100%, 125%, and 150% browser zoom

Fixes #42

https://claude.ai/code/session_018jGZ241phXtP6e8zdz1twU
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_018jGZ241phXtP6e8zdz1twU)_