### PR TITLE
Fix session deletion not clearing sesh tags from events

### DIFF
--- a/app/src/timeline/app.ts
+++ b/app/src/timeline/app.ts
@@ -327,6 +327,7 @@ export async function createTimelineApp(): Promise<TimelineApp> {
       await putSessions(newSessions);
       appState.sessions = newSessions;
       renderTimeline();
+      await applySessionTagsToAllEvents();
     }
   });
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fixes #56: deleting a session now removes the orphaned `sesh:` tags from all events that fell within that session's in-game timespan.

## Root cause

In `app/src/timeline/app.ts`, the `deleted` branch of the session pill click handler persisted the updated sessions list and re-rendered the timeline, but never called `applySessionTagsToAllEvents()`. The `saved` and `onCreateSession` paths both called it correctly — this was simply a missing call in the one remaining branch.

## Fix

One line added: `await applySessionTagsToAllEvents()` after `renderTimeline()` in the `deleted` branch, making all three session-mutation paths symmetric.

`applySessionTagsToAllEvents()` recomputes the correct `sesh:` tags for every event against the current session list (which already excludes the deleted session at that point) and writes back any events whose tags have changed. As a bonus, it also handles any `computeSessionLabel()` renumbering knock-on effects from the deletion.

## Test plan

- [x] Create a session with an in-game date range
- [x] Verify events within that range acquire the `sesh:` tag
- [x] Delete the session
- [x] Verify the `sesh:` tag is removed from those events

https://claude.ai/code/session_01Xv4V328JDbNZJSP1FSv3fW
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xv4V328JDbNZJSP1FSv3fW)_