### PR TITLE
Fix link picker dropdown not scrolling on arrow key navigation

### DIFF
--- a/app/src/notes/editor/LinkPickerDropdown.tsx
+++ b/app/src/notes/editor/LinkPickerDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import type { LinkIndexEntry } from '../../data/types.ts';
 import { folderColor } from '../types.ts';
 import type { LinkPickerHandle } from '../hooks/useLinkPicker.ts';
@@ -18,7 +18,12 @@ interface LinkPickerDropdownProps {
 export const LinkPickerDropdown = forwardRef<LinkPickerHandle, LinkPickerDropdownProps>(
   function LinkPickerDropdown({ x, y, items, onPick, onClose: _onClose }, ref) {
     const [selected, setSelected] = useState(0);
+    const listRef = useRef<HTMLDivElement>(null);
     useEffect(() => { setSelected(0); }, [items]);
+    useEffect(() => {
+      const row = listRef.current?.children[selected] as HTMLElement | undefined;
+      row?.scrollIntoView({ block: 'nearest' });
+    }, [selected]);
     useImperativeHandle(ref, () => ({
       handleKey(key: string): boolean {
         if (key === 'ArrowDown') { setSelected(s => Math.min(s + 1, items.length - 1)); return true; }
@@ -36,7 +41,7 @@ export const LinkPickerDropdown = forwardRef<LinkPickerHandle, LinkPickerDropdow
       );
     }
     return (
-      <div className="link-picker" style={{ left: x, top: y }}>
+      <div ref={listRef} className="link-picker" style={{ left: x, top: y }}>
         {items.map((it, i) => {
           const folder = it.path.split('/')[0];
           return (


### PR DESCRIPTION
Fixes #9

## Problem

When the `@`-mention link picker is open and the user navigates with arrow keys, the selected item wasn't guaranteed to be visible. Items near the bottom (or top after wrapping) could be clipped or entirely off-screen inside the `max-height: 240px` scrollable container.

## Fix

Added a `useRef` on the dropdown container and a `useEffect` that calls `scrollIntoView({ block: 'nearest' })` on the newly-selected row whenever `selected` changes.

- `block: 'nearest'` scrolls the minimum distance to bring the row into view — no jarring jumps when the item is already visible
- The `.link-picker` is the nearest scroll container, so scroll stays contained within the dropdown
- On mount / query change, `selected` resets to 0 and the effect is a no-op (first row is always visible)

## Change

`app/src/notes/editor/LinkPickerDropdown.tsx` — 7 lines added, 2 changed.

https://claude.ai/code/session_01KML4VVX5JY1cgxpPLzNbbW

---
_Generated by [Claude Code](https://claude.ai/code/session_01KML4VVX5JY1cgxpPLzNbbW)_