### PR TITLE
fix: load file when closing a tab reveals an unloaded tab

### DIFF
--- a/app/src/notes/Notes.tsx
+++ b/app/src/notes/Notes.tsx
@@ -77,29 +77,40 @@ export function NotesApp() {
     openFiles, setOpenFiles, setFolderFiles, pushToast,
   });
 
+  const ensureLoaded = useCallback((folder: string, path: string) => {
+    const key = `${folder}/${path}`;
+    setOpenFiles(prev => {
+      if (prev[key] && (prev[key].content !== null || prev[key].loading)) return prev;
+      void getNote(folder, path).then(({ content, mtime }) => {
+        setOpenFiles(p => ({ ...p, [key]: { content, mtime, dirty: false, loading: false } }));
+      }).catch(err => {
+        pushToast(`Failed to load ${key}: ${String(err)}`);
+        setOpenFiles(p => ({ ...p, [key]: { content: '', mtime: '', dirty: false, loading: false } }));
+      });
+      return { ...prev, [key]: { content: null, mtime: '', dirty: false, loading: true } };
+    });
+  }, [pushToast]);
+
   const activeTabRef = useRef<OpenTab | null>(activeTab);
   useEffect(() => { activeTabRef.current = activeTab; }, [activeTab]);
 
   // ---- Bootstrap ----
   useEffect(() => {
-    // Load content for any tab that was active when we last left
     if (activeTab && activeTab.fileKind !== 'asset') {
-      const key = tabKey(activeTab);
-      setOpenFiles(prev => {
-        if (prev[key]?.content !== undefined) return prev;
-        void getNote(activeTab.folder, activeTab.path).then(({ content, mtime }) => {
-          setOpenFiles(p => ({ ...p, [key]: { content, mtime, dirty: false, loading: false } }));
-        }).catch(() => {
-          setOpenFiles(p => ({ ...p, [key]: { content: '', mtime: '', dirty: false, loading: false } }));
-        });
-        return { ...prev, [key]: { content: null, mtime: '', dirty: false, loading: true } };
-      });
+      ensureLoaded(activeTab.folder, activeTab.path);
     }
     Promise.all([
       listNoteFolders().then(fs => setFolders(fs.map(f => f.name))),
       getLinkIndex().then(setLinkIndex),
     ]).catch(err => pushToast(`Failed to load: ${String(err)}`));
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Load content whenever the active tab changes to a file not yet fetched.
+  // Covers the case where closing a tab reveals a tab whose file was never loaded.
+  useEffect(() => {
+    if (!activeTab || activeTab.fileKind === 'asset') return;
+    ensureLoaded(activeTab.folder, activeTab.path);
+  }, [activeTab?.folder, activeTab?.path, ensureLoaded]);
 
   // ---- Persist tabs to localStorage ----
   useEffect(() => {
@@ -175,20 +186,9 @@ export function NotesApp() {
 
   // ---- File operations ----
   async function openFile(folder: string, path: string, fileKind?: 'note' | 'asset') {
-    const key = `${folder}/${path}`;
     setTabs(prev => prev.some(t => t.folder === folder && t.path === path) ? prev : [...prev, { folder, path, fileKind }]);
     setActiveTab({ folder, path, fileKind });
-    if (fileKind === 'asset') return;
-    setOpenFiles(prev => {
-      if (prev[key] && (prev[key].content !== null || prev[key].loading)) return prev;
-      void getNote(folder, path).then(({ content, mtime }) => {
-        setOpenFiles(p => ({ ...p, [key]: { content, mtime, dirty: false, loading: false } }));
-      }).catch(err => {
-        pushToast(`Failed to load ${key}: ${String(err)}`);
-        setOpenFiles(p => ({ ...p, [key]: { content: '', mtime: '', dirty: false, loading: false } }));
-      });
-      return { ...prev, [key]: { content: null, mtime: '', dirty: false, loading: true } };
-    });
+    if (fileKind !== 'asset') ensureLoaded(folder, path);
   }
 
   function handleContentChange(folder: string, path: string, content: string) {


### PR DESCRIPTION
## Summary

Fixes #41

- File loading was only triggered in two places: a one-time bootstrap `useEffect` (on mount) and `openFile` (explicit user click). When `doCloseTab` set a new `activeTab` there was nothing watching `activeTab` to kick off a fetch.
- Extracted a stable `ensureLoaded(folder, path)` callback that atomically checks `openFiles` state and starts a fetch only if the file isn't already loaded or loading.
- Added a `useEffect` on `[activeTab?.folder, activeTab?.path, ensureLoaded]` so any code path that mutates `activeTab` — including `doCloseTab` — automatically fetches the revealed file.
- Simplified `openFile` and the bootstrap effect to both delegate to `ensureLoaded`, eliminating the previously duplicated loading logic.

## Test plan

- [x] Open two or more tabs where at least one was never clicked/viewed in the session
- [x] Close the active tab so the unloaded tab is revealed — confirm the file loads instead of staying "loading…" forever
- [x] Open a fresh session with multiple tabs in localStorage; close the initially-active tab and confirm the next tab loads
- [x] Verify that switching tabs normally (clicking) still loads files correctly
- [x] Verify that asset tabs (images etc.) are still excluded from loading

https://claude.ai/code/session_01N6EsgK5AXM59Xd6ZsKReRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6EsgK5AXM59Xd6ZsKReRt)_