### PR TITLE
Add desktop timeline data access layer (IPC + renderer port)

### DIFF
--- a/desktop/src/main/ipcHandlers.ts
+++ b/desktop/src/main/ipcHandlers.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import matter from 'gray-matter';
 import { generateShortId } from '../shared/ids.js';
 import { buildLinkIndex } from './linkIndex.js';
+import { registerTimelineIpcHandlers } from './timelineIpcHandlers.js';
 
 const CONFIG_PATH = path.join(app.getPath('userData'), 'config.json');
 
@@ -264,4 +265,6 @@ ${description}
       return false;
     }
   });
+
+  registerTimelineIpcHandlers();
 }

--- a/desktop/src/main/timelineIpcHandlers.ts
+++ b/desktop/src/main/timelineIpcHandlers.ts
@@ -198,7 +198,15 @@ export function registerTimelineIpcHandlers() {
     if (!fs.existsSync(filePath)) {
       return {
         theme: {},
-        weekdays: { monday: '', tuesday: '', wednesday: '', thursday: '', friday: '', saturday: '', sunday: '' },
+        weekdays: {
+          monday: '',
+          tuesday: '',
+          wednesday: '',
+          thursday: '',
+          friday: '',
+          saturday: '',
+          sunday: '',
+        },
       };
     }
     return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Palette;

--- a/desktop/src/main/timelineIpcHandlers.ts
+++ b/desktop/src/main/timelineIpcHandlers.ts
@@ -1,0 +1,206 @@
+import { ipcMain, shell } from 'electron';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import matter from 'gray-matter';
+
+import type {
+  Event,
+  EventFrontmatter,
+  EventListItem,
+  EventWithMtime,
+  Session,
+  State,
+  TagsRegistry,
+  Palette,
+  ConflictResult,
+} from '../renderer/timeline/data/types.js';
+
+const SAFE_FILENAME_RE = /^[A-Za-z0-9._-]+\.md$/;
+
+function assertSafeFilename(dir: string, filename: string): void {
+  if (!SAFE_FILENAME_RE.test(filename)) {
+    throw new Error(`Unsafe event filename: ${filename}`);
+  }
+  // Belt-and-suspenders: ensure the resolved path stays inside dir
+  const resolved = path.resolve(path.join(dir, filename));
+  if (!resolved.startsWith(path.resolve(dir) + path.sep)) {
+    throw new Error(`Path traversal detected for filename: ${filename}`);
+  }
+}
+
+function eventsDir(campaignPath: string) {
+  return path.join(campaignPath, 'events');
+}
+
+function fileMtime(filePath: string): string {
+  // NOTE: mtime precision varies by filesystem (ext4: ms, FAT: 2s, APFS: ns).
+  // Two saves within the same tick may produce the same mtime string, allowing a
+  // silent clobber. For a single-user desktop app this is acceptable; a future
+  // strengthening is to use a content hash (sha1) as the ETag instead.
+  return fs.statSync(filePath).mtime.toISOString();
+}
+
+function parseEventFile(
+  filePath: string,
+  filename: string,
+): { event: Event; lastModified: string } {
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  const { data, content: body } = matter(raw);
+  const lastModified = fileMtime(filePath);
+  const event: Event = {
+    filename,
+    title: String(data.title ?? ''),
+    date: String(data.date ?? ''),
+    tags: Array.isArray(data.tags) ? data.tags : [],
+    ...(data.color !== undefined ? { color: String(data.color) } : {}),
+    ...(data.status !== undefined ? { status: data.status as Event['status'] } : {}),
+    body: body.trimStart(),
+    mtime: lastModified,
+  };
+  return { event, lastModified };
+}
+
+export function registerTimelineIpcHandlers() {
+  ipcMain.handle('timeline:listEvents', (_event, campaignPath: string): EventListItem[] => {
+    const dir = eventsDir(campaignPath);
+    if (!fs.existsSync(dir)) return [];
+    return fs
+      .readdirSync(dir)
+      .filter((f) => SAFE_FILENAME_RE.test(f))
+      .map((filename) => {
+        const filePath = path.join(dir, filename);
+        const raw = fs.readFileSync(filePath, 'utf-8');
+        const { data } = matter(raw);
+        return {
+          filename,
+          title: String(data.title ?? ''),
+          date: String(data.date ?? ''),
+          tags: Array.isArray(data.tags) ? data.tags : [],
+          ...(data.color !== undefined ? { color: String(data.color) } : {}),
+          ...(data.status !== undefined ? { status: data.status as EventListItem['status'] } : {}),
+          mtime: fileMtime(filePath),
+        } satisfies EventListItem;
+      });
+  });
+
+  ipcMain.handle(
+    'timeline:getEvent',
+    (_event, campaignPath: string, filename: string): EventWithMtime => {
+      const dir = eventsDir(campaignPath);
+      assertSafeFilename(dir, filename);
+      return parseEventFile(path.join(dir, filename), filename);
+    },
+  );
+
+  ipcMain.handle(
+    'timeline:updateEvent',
+    (
+      _event,
+      campaignPath: string,
+      filename: string,
+      frontmatter: EventFrontmatter,
+      body: string,
+      ifUnmodifiedSince: string,
+    ): EventWithMtime | ConflictResult => {
+      const dir = eventsDir(campaignPath);
+      assertSafeFilename(dir, filename);
+      const filePath = path.join(dir, filename);
+      const currentMtime = fileMtime(filePath);
+      if (currentMtime !== ifUnmodifiedSince) return { conflict: true };
+      const content = matter.stringify(body, frontmatter as unknown as Record<string, unknown>);
+      fs.writeFileSync(filePath, content, 'utf-8');
+      return parseEventFile(filePath, filename);
+    },
+  );
+
+  ipcMain.handle(
+    'timeline:createEvent',
+    (
+      _event,
+      campaignPath: string,
+      filename: string,
+      frontmatter: EventFrontmatter,
+      body: string,
+    ): EventWithMtime => {
+      const dir = eventsDir(campaignPath);
+      assertSafeFilename(dir, filename);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      const filePath = path.join(dir, filename);
+      const content = matter.stringify(body, frontmatter as unknown as Record<string, unknown>);
+      // 'wx' flag: fail if the file already exists, preventing silent clobbers.
+      fs.writeFileSync(filePath, content, { encoding: 'utf-8', flag: 'wx' });
+      return parseEventFile(filePath, filename);
+    },
+  );
+
+  ipcMain.handle(
+    'timeline:deleteEvent',
+    async (
+      _event,
+      campaignPath: string,
+      filename: string,
+      ifUnmodifiedSince: string,
+    ): Promise<{ ok: true } | ConflictResult> => {
+      const dir = eventsDir(campaignPath);
+      assertSafeFilename(dir, filename);
+      const filePath = path.join(dir, filename);
+      const currentMtime = fileMtime(filePath);
+      if (currentMtime !== ifUnmodifiedSince) return { conflict: true };
+      await shell.trashItem(path.resolve(filePath));
+      return { ok: true };
+    },
+  );
+
+  // getSessions/getTags/loadPalette return empty-ish defaults when the file
+  // doesn't exist yet (the file is optional / auto-created on first write).
+  // getState likewise. getEvent, by contrast, throws on missing file — it is
+  // an addressable resource and a miss is a caller error.
+  ipcMain.handle('timeline:getSessions', (_event, campaignPath: string): Session[] => {
+    const filePath = path.join(campaignPath, 'sessions.json');
+    if (!fs.existsSync(filePath)) return [];
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Session[];
+  });
+
+  ipcMain.handle(
+    'timeline:putSessions',
+    (_event, campaignPath: string, sessions: Session[]): { ok: true } => {
+      const filePath = path.join(campaignPath, 'sessions.json');
+      fs.writeFileSync(filePath, JSON.stringify(sessions, null, 2), 'utf-8');
+      return { ok: true };
+    },
+  );
+
+  ipcMain.handle('timeline:getState', (_event, campaignPath: string): State => {
+    const filePath = path.join(campaignPath, 'state.json');
+    if (!fs.existsSync(filePath)) {
+      return { in_game_now: '', current_session: null, campaign_start: '' };
+    }
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as State;
+  });
+
+  ipcMain.handle(
+    'timeline:putState',
+    (_event, campaignPath: string, state: State): { ok: true } => {
+      const filePath = path.join(campaignPath, 'state.json');
+      fs.writeFileSync(filePath, JSON.stringify(state, null, 2), 'utf-8');
+      return { ok: true };
+    },
+  );
+
+  ipcMain.handle('timeline:getTags', (_event, campaignPath: string): TagsRegistry => {
+    const filePath = path.join(campaignPath, 'tags.json');
+    if (!fs.existsSync(filePath)) return {};
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as TagsRegistry;
+  });
+
+  ipcMain.handle('timeline:loadPalette', (_event, campaignPath: string): Palette => {
+    const filePath = path.join(campaignPath, 'palette.json');
+    if (!fs.existsSync(filePath)) {
+      return {
+        theme: {},
+        weekdays: { monday: '', tuesday: '', wednesday: '', thursday: '', friday: '', saturday: '', sunday: '' },
+      };
+    }
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Palette;
+  });
+}

--- a/desktop/src/preload/index.cts
+++ b/desktop/src/preload/index.cts
@@ -39,4 +39,45 @@ contextBridge.exposeInMainWorld('fsApi', {
     ipcRenderer.on('notes:indexDelta', listener);
     return () => ipcRenderer.removeListener('notes:indexDelta', listener);
   },
+
+  // Timeline
+  timelineListEvents: (campaignPath: string) =>
+    ipcRenderer.invoke('timeline:listEvents', campaignPath),
+  timelineGetEvent: (campaignPath: string, filename: string) =>
+    ipcRenderer.invoke('timeline:getEvent', campaignPath, filename),
+  timelineCreateEvent: (
+    campaignPath: string,
+    filename: string,
+    frontmatter: unknown,
+    body: string,
+  ) => ipcRenderer.invoke('timeline:createEvent', campaignPath, filename, frontmatter, body),
+  timelineUpdateEvent: (
+    campaignPath: string,
+    filename: string,
+    frontmatter: unknown,
+    body: string,
+    ifUnmodifiedSince: string,
+  ) =>
+    ipcRenderer.invoke(
+      'timeline:updateEvent',
+      campaignPath,
+      filename,
+      frontmatter,
+      body,
+      ifUnmodifiedSince,
+    ),
+  timelineDeleteEvent: (campaignPath: string, filename: string, ifUnmodifiedSince: string) =>
+    ipcRenderer.invoke('timeline:deleteEvent', campaignPath, filename, ifUnmodifiedSince),
+  timelineGetSessions: (campaignPath: string) =>
+    ipcRenderer.invoke('timeline:getSessions', campaignPath),
+  timelinePutSessions: (campaignPath: string, sessions: unknown) =>
+    ipcRenderer.invoke('timeline:putSessions', campaignPath, sessions),
+  timelineGetState: (campaignPath: string) =>
+    ipcRenderer.invoke('timeline:getState', campaignPath),
+  timelinePutState: (campaignPath: string, state: unknown) =>
+    ipcRenderer.invoke('timeline:putState', campaignPath, state),
+  timelineGetTags: (campaignPath: string) =>
+    ipcRenderer.invoke('timeline:getTags', campaignPath),
+  timelineLoadPalette: (campaignPath: string) =>
+    ipcRenderer.invoke('timeline:loadPalette', campaignPath),
 });

--- a/desktop/src/renderer/timeline/data/__tests__/ports.test.ts
+++ b/desktop/src/renderer/timeline/data/__tests__/ports.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { timelinePort, ConflictError } from '../ports';
-import type { EventListItem, EventWithMtime, Session, State, TagsRegistry, Palette } from '../types';
+import type {
+  EventListItem,
+  EventWithMtime,
+  Session,
+  State,
+  TagsRegistry,
+  Palette,
+} from '../types';
 
 const mockFsApi = {
   timelineListEvents: vi.fn(),
@@ -81,7 +88,13 @@ describe('updateEvent', () => {
   it('throws ConflictError when the file was concurrently modified', async () => {
     mockFsApi.timelineUpdateEvent.mockResolvedValue({ conflict: true });
     await expect(
-      timelinePort.updateEvent(CAMPAIGN, ITEM.filename, { title: 'T', date: '4726-03-01' }, '', MTIME),
+      timelinePort.updateEvent(
+        CAMPAIGN,
+        ITEM.filename,
+        { title: 'T', date: '4726-03-01' },
+        '',
+        MTIME,
+      ),
     ).rejects.toBeInstanceOf(ConflictError);
   });
 });
@@ -89,16 +102,14 @@ describe('updateEvent', () => {
 describe('deleteEvent', () => {
   it('resolves on success', async () => {
     mockFsApi.timelineDeleteEvent.mockResolvedValue({ ok: true });
-    await expect(
-      timelinePort.deleteEvent(CAMPAIGN, ITEM.filename, MTIME),
-    ).resolves.toBeUndefined();
+    await expect(timelinePort.deleteEvent(CAMPAIGN, ITEM.filename, MTIME)).resolves.toBeUndefined();
   });
 
   it('throws ConflictError when the file was concurrently modified', async () => {
     mockFsApi.timelineDeleteEvent.mockResolvedValue({ conflict: true });
-    await expect(
-      timelinePort.deleteEvent(CAMPAIGN, ITEM.filename, MTIME),
-    ).rejects.toBeInstanceOf(ConflictError);
+    await expect(timelinePort.deleteEvent(CAMPAIGN, ITEM.filename, MTIME)).rejects.toBeInstanceOf(
+      ConflictError,
+    );
   });
 });
 
@@ -130,7 +141,11 @@ describe('putSessions', () => {
 
 describe('getState', () => {
   it('delegates to fsApi', async () => {
-    const state: State = { in_game_now: '4726-03-01T00:00:00', current_session: null, campaign_start: '4726-01-01' };
+    const state: State = {
+      in_game_now: '4726-03-01T00:00:00',
+      current_session: null,
+      campaign_start: '4726-01-01',
+    };
     mockFsApi.timelineGetState.mockResolvedValue(state);
     expect(await timelinePort.getState(CAMPAIGN)).toEqual(state);
   });
@@ -139,7 +154,11 @@ describe('getState', () => {
 describe('putState', () => {
   it('delegates to fsApi', async () => {
     mockFsApi.timelinePutState.mockResolvedValue({ ok: true });
-    const state: State = { in_game_now: '4726-03-01', current_session: null, campaign_start: '4726-01-01' };
+    const state: State = {
+      in_game_now: '4726-03-01',
+      current_session: null,
+      campaign_start: '4726-01-01',
+    };
     await timelinePort.putState(CAMPAIGN, state);
     expect(mockFsApi.timelinePutState).toHaveBeenCalledWith(CAMPAIGN, state);
   });
@@ -157,7 +176,15 @@ describe('loadPalette', () => {
   it('delegates to fsApi', async () => {
     const palette: Palette = {
       theme: { background: '#1a1a1a' },
-      weekdays: { monday: '#8da8c4', tuesday: '#a07850', wednesday: '#d4a850', thursday: '#5a8090', friday: '#c06040', saturday: '#7560a0', sunday: '#e5b860' },
+      weekdays: {
+        monday: '#8da8c4',
+        tuesday: '#a07850',
+        wednesday: '#d4a850',
+        thursday: '#5a8090',
+        friday: '#c06040',
+        saturday: '#7560a0',
+        sunday: '#e5b860',
+      },
     };
     mockFsApi.timelineLoadPalette.mockResolvedValue(palette);
     expect(await timelinePort.loadPalette(CAMPAIGN)).toEqual(palette);

--- a/desktop/src/renderer/timeline/data/__tests__/ports.test.ts
+++ b/desktop/src/renderer/timeline/data/__tests__/ports.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { timelinePort, ConflictError } from '../ports';
+import type { EventListItem, EventWithMtime, Session, State, TagsRegistry, Palette } from '../types';
+
+const mockFsApi = {
+  timelineListEvents: vi.fn(),
+  timelineGetEvent: vi.fn(),
+  timelineCreateEvent: vi.fn(),
+  timelineUpdateEvent: vi.fn(),
+  timelineDeleteEvent: vi.fn(),
+  timelineGetSessions: vi.fn(),
+  timelinePutSessions: vi.fn(),
+  timelineGetState: vi.fn(),
+  timelinePutState: vi.fn(),
+  timelineGetTags: vi.fn(),
+  timelineLoadPalette: vi.fn(),
+};
+
+vi.stubGlobal('window', { fsApi: mockFsApi });
+
+const CAMPAIGN = '/fake/campaign';
+const MTIME = '2026-01-01T00:00:00.000Z';
+
+const ITEM: EventListItem = {
+  filename: '4726-03-01-test.md',
+  title: 'Test',
+  date: '4726-03-01',
+  mtime: MTIME,
+};
+
+const EVENT_WITH_MTIME: EventWithMtime = {
+  event: { ...ITEM, body: 'hello' },
+  lastModified: MTIME,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('listEvents', () => {
+  it('delegates to fsApi', async () => {
+    mockFsApi.timelineListEvents.mockResolvedValue([ITEM]);
+    const result = await timelinePort.listEvents(CAMPAIGN);
+    expect(mockFsApi.timelineListEvents).toHaveBeenCalledWith(CAMPAIGN);
+    expect(result).toEqual([ITEM]);
+  });
+});
+
+describe('getEvent', () => {
+  it('delegates to fsApi', async () => {
+    mockFsApi.timelineGetEvent.mockResolvedValue(EVENT_WITH_MTIME);
+    const result = await timelinePort.getEvent(CAMPAIGN, ITEM.filename);
+    expect(mockFsApi.timelineGetEvent).toHaveBeenCalledWith(CAMPAIGN, ITEM.filename);
+    expect(result).toEqual(EVENT_WITH_MTIME);
+  });
+});
+
+describe('createEvent', () => {
+  it('delegates to fsApi', async () => {
+    mockFsApi.timelineCreateEvent.mockResolvedValue(EVENT_WITH_MTIME);
+    const fm = { title: 'Test', date: '4726-03-01' };
+    const result = await timelinePort.createEvent(CAMPAIGN, ITEM.filename, fm, 'hello');
+    expect(mockFsApi.timelineCreateEvent).toHaveBeenCalledWith(
+      CAMPAIGN,
+      ITEM.filename,
+      fm,
+      'hello',
+    );
+    expect(result).toEqual(EVENT_WITH_MTIME);
+  });
+});
+
+describe('updateEvent', () => {
+  it('returns updated event on success', async () => {
+    mockFsApi.timelineUpdateEvent.mockResolvedValue(EVENT_WITH_MTIME);
+    const fm = { title: 'Test', date: '4726-03-01' };
+    const result = await timelinePort.updateEvent(CAMPAIGN, ITEM.filename, fm, 'body', MTIME);
+    expect(result).toEqual(EVENT_WITH_MTIME);
+  });
+
+  it('throws ConflictError when the file was concurrently modified', async () => {
+    mockFsApi.timelineUpdateEvent.mockResolvedValue({ conflict: true });
+    await expect(
+      timelinePort.updateEvent(CAMPAIGN, ITEM.filename, { title: 'T', date: '4726-03-01' }, '', MTIME),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});
+
+describe('deleteEvent', () => {
+  it('resolves on success', async () => {
+    mockFsApi.timelineDeleteEvent.mockResolvedValue({ ok: true });
+    await expect(
+      timelinePort.deleteEvent(CAMPAIGN, ITEM.filename, MTIME),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws ConflictError when the file was concurrently modified', async () => {
+    mockFsApi.timelineDeleteEvent.mockResolvedValue({ conflict: true });
+    await expect(
+      timelinePort.deleteEvent(CAMPAIGN, ITEM.filename, MTIME),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});
+
+describe('getSessions', () => {
+  it('delegates to fsApi', async () => {
+    const sessions: Session[] = [
+      {
+        id: 'abc',
+        inGameStart: '4726-01-01T00:00:00',
+        inGameEnd: '4726-01-02T00:00:00',
+        realStart: '2026-01-01T12:00:00',
+        realEnd: '2026-01-01T16:00:00',
+        color: '#ff0000',
+      },
+    ];
+    mockFsApi.timelineGetSessions.mockResolvedValue(sessions);
+    const result = await timelinePort.getSessions(CAMPAIGN);
+    expect(result).toEqual(sessions);
+  });
+});
+
+describe('putSessions', () => {
+  it('delegates to fsApi', async () => {
+    mockFsApi.timelinePutSessions.mockResolvedValue({ ok: true });
+    await timelinePort.putSessions(CAMPAIGN, []);
+    expect(mockFsApi.timelinePutSessions).toHaveBeenCalledWith(CAMPAIGN, []);
+  });
+});
+
+describe('getState', () => {
+  it('delegates to fsApi', async () => {
+    const state: State = { in_game_now: '4726-03-01T00:00:00', current_session: null, campaign_start: '4726-01-01' };
+    mockFsApi.timelineGetState.mockResolvedValue(state);
+    expect(await timelinePort.getState(CAMPAIGN)).toEqual(state);
+  });
+});
+
+describe('putState', () => {
+  it('delegates to fsApi', async () => {
+    mockFsApi.timelinePutState.mockResolvedValue({ ok: true });
+    const state: State = { in_game_now: '4726-03-01', current_session: null, campaign_start: '4726-01-01' };
+    await timelinePort.putState(CAMPAIGN, state);
+    expect(mockFsApi.timelinePutState).toHaveBeenCalledWith(CAMPAIGN, state);
+  });
+});
+
+describe('getTags', () => {
+  it('delegates to fsApi', async () => {
+    const tags: TagsRegistry = { 'plot:beast': { color: '#8b0000', description: 'Beast arc' } };
+    mockFsApi.timelineGetTags.mockResolvedValue(tags);
+    expect(await timelinePort.getTags(CAMPAIGN)).toEqual(tags);
+  });
+});
+
+describe('loadPalette', () => {
+  it('delegates to fsApi', async () => {
+    const palette: Palette = {
+      theme: { background: '#1a1a1a' },
+      weekdays: { monday: '#8da8c4', tuesday: '#a07850', wednesday: '#d4a850', thursday: '#5a8090', friday: '#c06040', saturday: '#7560a0', sunday: '#e5b860' },
+    };
+    mockFsApi.timelineLoadPalette.mockResolvedValue(palette);
+    expect(await timelinePort.loadPalette(CAMPAIGN)).toEqual(palette);
+  });
+});
+
+// ConflictError identity
+describe('ConflictError', () => {
+  it('is an instance of Error', () => {
+    const e = new ConflictError();
+    expect(e).toBeInstanceOf(Error);
+    expect(e.name).toBe('ConflictError');
+  });
+});

--- a/desktop/src/renderer/timeline/data/ports.ts
+++ b/desktop/src/renderer/timeline/data/ports.ts
@@ -16,9 +16,7 @@ export class ConflictError extends Error {
   }
 }
 
-function assertNotConflict<T>(
-  result: T | ConflictResult,
-): asserts result is T {
+function assertNotConflict<T>(result: T | ConflictResult): asserts result is T {
   if (result !== null && typeof result === 'object' && 'conflict' in result) {
     throw new ConflictError();
   }

--- a/desktop/src/renderer/timeline/data/ports.ts
+++ b/desktop/src/renderer/timeline/data/ports.ts
@@ -1,0 +1,99 @@
+import type {
+  EventFrontmatter,
+  EventListItem,
+  EventWithMtime,
+  Session,
+  State,
+  TagsRegistry,
+  Palette,
+  ConflictResult,
+} from './types';
+
+export class ConflictError extends Error {
+  constructor() {
+    super('Conflict: file was modified since last read');
+    this.name = 'ConflictError';
+  }
+}
+
+function assertNotConflict<T>(
+  result: T | ConflictResult,
+): asserts result is T {
+  if (result !== null && typeof result === 'object' && 'conflict' in result) {
+    throw new ConflictError();
+  }
+}
+
+export const timelinePort = {
+  async listEvents(campaignPath: string): Promise<EventListItem[]> {
+    return window.fsApi.timelineListEvents(campaignPath);
+  },
+
+  async getEvent(campaignPath: string, filename: string): Promise<EventWithMtime> {
+    return window.fsApi.timelineGetEvent(campaignPath, filename);
+  },
+
+  async createEvent(
+    campaignPath: string,
+    filename: string,
+    frontmatter: EventFrontmatter,
+    body: string,
+  ): Promise<EventWithMtime> {
+    return window.fsApi.timelineCreateEvent(campaignPath, filename, frontmatter, body);
+  },
+
+  async updateEvent(
+    campaignPath: string,
+    filename: string,
+    frontmatter: EventFrontmatter,
+    body: string,
+    ifUnmodifiedSince: string,
+  ): Promise<EventWithMtime> {
+    const result = await window.fsApi.timelineUpdateEvent(
+      campaignPath,
+      filename,
+      frontmatter,
+      body,
+      ifUnmodifiedSince,
+    );
+    assertNotConflict(result);
+    return result;
+  },
+
+  async deleteEvent(
+    campaignPath: string,
+    filename: string,
+    ifUnmodifiedSince: string,
+  ): Promise<void> {
+    const result = await window.fsApi.timelineDeleteEvent(
+      campaignPath,
+      filename,
+      ifUnmodifiedSince,
+    );
+    assertNotConflict(result);
+  },
+
+  async getSessions(campaignPath: string): Promise<Session[]> {
+    return window.fsApi.timelineGetSessions(campaignPath);
+  },
+
+  async putSessions(campaignPath: string, sessions: Session[]): Promise<void> {
+    await window.fsApi.timelinePutSessions(campaignPath, sessions);
+  },
+
+  async getState(campaignPath: string): Promise<State> {
+    return window.fsApi.timelineGetState(campaignPath);
+  },
+
+  async putState(campaignPath: string, state: State): Promise<void> {
+    await window.fsApi.timelinePutState(campaignPath, state);
+  },
+
+  async getTags(campaignPath: string): Promise<TagsRegistry> {
+    return window.fsApi.timelineGetTags(campaignPath);
+  },
+
+  async loadPalette(campaignPath: string): Promise<Palette> {
+    return window.fsApi.timelineLoadPalette(campaignPath);
+  },
+};

--- a/desktop/src/renderer/timeline/data/types.ts
+++ b/desktop/src/renderer/timeline/data/types.ts
@@ -1,0 +1,63 @@
+export interface EventFrontmatter {
+  title: string;
+  date: string;
+  tags?: string[];
+  color?: string;
+  status?: 'happened' | 'planned';
+}
+
+export interface Event extends EventFrontmatter {
+  filename: string;
+  body: string;
+  mtime: string;
+}
+
+export interface EventListItem extends EventFrontmatter {
+  filename: string;
+  mtime: string;
+}
+
+export interface State {
+  in_game_now: string;
+  current_session: string | null;
+  campaign_start: string;
+}
+
+export interface TagInfo {
+  color: string;
+  description: string;
+}
+
+export type TagsRegistry = Record<string, TagInfo>;
+
+export interface Session {
+  id: string;
+  inGameStart: string;
+  inGameEnd: string;
+  realStart: string;
+  realEnd: string;
+  color: string;
+  real_date?: string;
+  in_game_start?: string;
+  notes?: string;
+}
+
+export interface Palette {
+  theme: Record<string, string>;
+  weekdays: {
+    monday: string;
+    tuesday: string;
+    wednesday: string;
+    thursday: string;
+    friday: string;
+    saturday: string;
+    sunday: string;
+  };
+}
+
+export type ConflictResult = { conflict: true };
+
+export interface EventWithMtime {
+  event: Event;
+  lastModified: string;
+}

--- a/desktop/src/types/global.d.ts
+++ b/desktop/src/types/global.d.ts
@@ -1,5 +1,16 @@
 export {};
 
+import type {
+  EventFrontmatter,
+  EventListItem,
+  EventWithMtime,
+  Session,
+  State,
+  TagsRegistry,
+  Palette,
+  ConflictResult,
+} from '../renderer/timeline/data/types';
+
 export interface Campaign {
   id: string;
   name: string;
@@ -53,6 +64,34 @@ declare global {
 
       // Dialog
       selectDirectory: () => Promise<string | null>;
+
+      // Timeline
+      timelineListEvents: (campaignPath: string) => Promise<EventListItem[]>;
+      timelineGetEvent: (campaignPath: string, filename: string) => Promise<EventWithMtime>;
+      timelineCreateEvent: (
+        campaignPath: string,
+        filename: string,
+        frontmatter: EventFrontmatter,
+        body: string,
+      ) => Promise<EventWithMtime>;
+      timelineUpdateEvent: (
+        campaignPath: string,
+        filename: string,
+        frontmatter: EventFrontmatter,
+        body: string,
+        ifUnmodifiedSince: string,
+      ) => Promise<EventWithMtime | ConflictResult>;
+      timelineDeleteEvent: (
+        campaignPath: string,
+        filename: string,
+        ifUnmodifiedSince: string,
+      ) => Promise<{ ok: true } | ConflictResult>;
+      timelineGetSessions: (campaignPath: string) => Promise<Session[]>;
+      timelinePutSessions: (campaignPath: string, sessions: Session[]) => Promise<{ ok: true }>;
+      timelineGetState: (campaignPath: string) => Promise<State>;
+      timelinePutState: (campaignPath: string, state: State) => Promise<{ ok: true }>;
+      timelineGetTags: (campaignPath: string) => Promise<TagsRegistry>;
+      timelineLoadPalette: (campaignPath: string) => Promise<Palette>;
     };
   }
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds 10 timeline-specific IPC handlers in the Electron main process (`timelineIpcHandlers.ts`) for events, sessions, state, tags, and palette CRUD
- Adds a typed renderer port (`desktop/src/renderer/timeline/data/ports.ts`) that wraps `window.fsApi` and exposes a clean async API for the React timeline view
- Extends preload bridge and `global.d.ts` with all new timeline methods
- Shared types (`types.ts`) mirror `app/src/data/types.ts` for parity

### Key design choices
- **Timeline-specific handlers** (not generic `fs:read` in renderer): bundles FS ops in main, saves N round-trips for `listEvents`, keeps `gray-matter` and `node:path` out of the renderer bundle
- **Mtime-based conflict detection** on `updateEvent`/`deleteEvent` — same semantics as the web app's `If-Unmodified-Since`; documented precision/TOCTOU limits in a comment
- **`wx` flag** on `createEvent` prevents silent file clobbers
- **Filename safety validation** (regex + resolved-path check) on all per-file handlers to block path traversal

### Test plan
- [x] 142 vitest tests pass (`./node_modules/.bin/vitest run`)
- [x] No new TypeScript errors introduced (`tsc --noEmit` error count unchanged)
- [x] Opus advisor review conducted; all blockers (path traversal, `wx` flag) addressed before this PR

Closes #77. Part of #67.

https://claude.ai/code/session_01XyYi6mgQZfSUKXnJq9GA5S
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyYi6mgQZfSUKXnJq9GA5S)_