### PR TITLE
[Timeline][Foundation] Coordinate math + view scaffold

### DIFF
--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -62,7 +62,7 @@ export default function App() {
       case 'notes':
         return <NotesView campaignPath={activeCampaign.path} campaignId={activeCampaign.id} />;
       case 'timeline':
-        return <TimelineView />;
+        return <TimelineView campaignPath={activeCampaign.path} />;
       case 'relationships':
         return <RelationshipsView />;
       default:

--- a/desktop/src/renderer/timeline/math/__tests__/zoom.test.ts
+++ b/desktop/src/renderer/timeline/math/__tests__/zoom.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import {
+  xToSeconds,
+  secondsToX,
+  zoomAbout,
+  panByPixels,
+  SECONDS_PER_DAY,
+  DEFAULT_SECONDS_PER_PIXEL,
+} from '../zoom';
+import type { ViewState, ViewportSize } from '../zoom';
+
+const VIEW: ViewState = { centerSeconds: 1_000_000, secondsPerPixel: 100 };
+const SIZE: ViewportSize = { width: 1000, height: 600 };
+
+describe('xToSeconds', () => {
+  it('center x maps to centerSeconds', () => {
+    expect(xToSeconds(500, VIEW, SIZE)).toBe(1_000_000);
+  });
+
+  it('x to the right of center adds seconds', () => {
+    expect(xToSeconds(600, VIEW, SIZE)).toBe(1_010_000);
+  });
+
+  it('x to the left of center subtracts seconds', () => {
+    expect(xToSeconds(400, VIEW, SIZE)).toBe(990_000);
+  });
+});
+
+describe('secondsToX', () => {
+  it('centerSeconds maps to center x', () => {
+    expect(secondsToX(1_000_000, VIEW, SIZE)).toBe(500);
+  });
+
+  it('seconds ahead of center maps right of center', () => {
+    expect(secondsToX(1_010_000, VIEW, SIZE)).toBe(600);
+  });
+
+  it('round-trips with xToSeconds', () => {
+    const x = 350;
+    const s = xToSeconds(x, VIEW, SIZE);
+    expect(secondsToX(s, VIEW, SIZE)).toBeCloseTo(x);
+  });
+});
+
+describe('panByPixels', () => {
+  it('positive delta shifts center back in time', () => {
+    const result = panByPixels(VIEW, 100);
+    expect(result.centerSeconds).toBe(1_000_000 - 100 * 100);
+  });
+
+  it('negative delta shifts center forward in time', () => {
+    const result = panByPixels(VIEW, -100);
+    expect(result.centerSeconds).toBe(1_000_000 + 100 * 100);
+  });
+
+  it('zero delta leaves center unchanged', () => {
+    expect(panByPixels(VIEW, 0).centerSeconds).toBe(VIEW.centerSeconds);
+  });
+
+  it('does not change secondsPerPixel', () => {
+    expect(panByPixels(VIEW, 50).secondsPerPixel).toBe(VIEW.secondsPerPixel);
+  });
+
+  it('returns a new object', () => {
+    expect(panByPixels(VIEW, 10)).not.toBe(VIEW);
+  });
+});
+
+describe('zoomAbout', () => {
+  it('anchor pixel stays at the same seconds after zoom', () => {
+    const anchorX = 300;
+    const anchorSecs = xToSeconds(anchorX, VIEW, SIZE);
+    const result = zoomAbout(VIEW, SIZE, anchorX, 2);
+    expect(xToSeconds(anchorX, result, SIZE)).toBeCloseTo(anchorSecs);
+  });
+
+  it('zooming in (factor < 1) decreases secondsPerPixel', () => {
+    const result = zoomAbout(VIEW, SIZE, 500, 0.5);
+    expect(result.secondsPerPixel).toBeLessThan(VIEW.secondsPerPixel);
+  });
+
+  it('zooming out (factor > 1) increases secondsPerPixel', () => {
+    const result = zoomAbout(VIEW, SIZE, 500, 2);
+    expect(result.secondsPerPixel).toBeGreaterThan(VIEW.secondsPerPixel);
+  });
+
+  it('zoom about center x does not move centerSeconds', () => {
+    const result = zoomAbout(VIEW, SIZE, 500, 3);
+    expect(result.centerSeconds).toBeCloseTo(VIEW.centerSeconds);
+  });
+
+  it('clamps secondsPerPixel at minimum (1 s/px) when zooming in too far', () => {
+    const nearMin: ViewState = { centerSeconds: 0, secondsPerPixel: 1.5 };
+    const result = zoomAbout(nearMin, SIZE, 500, 0.1);
+    expect(result.secondsPerPixel).toBe(1);
+  });
+
+  it('clamps secondsPerPixel at maximum (30 days/px) when zooming out too far', () => {
+    const nearMax: ViewState = { centerSeconds: 0, secondsPerPixel: 30 * 86400 - 1 };
+    const result = zoomAbout(nearMax, SIZE, 500, 100);
+    expect(result.secondsPerPixel).toBe(30 * 86400);
+  });
+});
+
+describe('constants', () => {
+  it('SECONDS_PER_DAY is 86400', () => {
+    expect(SECONDS_PER_DAY).toBe(86400);
+  });
+
+  it('DEFAULT_SECONDS_PER_PIXEL represents one day per 200 pixels', () => {
+    expect(DEFAULT_SECONDS_PER_PIXEL).toBe(86400 / 200);
+  });
+});

--- a/desktop/src/renderer/timeline/math/zoom.ts
+++ b/desktop/src/renderer/timeline/math/zoom.ts
@@ -1,0 +1,64 @@
+/**
+ * Zoom/pan state for the timeline.
+ *
+ * Coordinate system:
+ *  - Domain: absolute seconds since Golarian epoch (year 0, Abadius 1).
+ *  - Range: pixel x within the viewport.
+ *  - `centerSeconds` = the seconds-value rendered at viewport x = centerX.
+ *  - `secondsPerPixel` = scale factor. Smaller = more zoomed in.
+ */
+export interface ViewState {
+  centerSeconds: number;
+  secondsPerPixel: number;
+}
+
+export interface ViewportSize {
+  width: number;
+  height: number;
+}
+
+export function xToSeconds(x: number, view: ViewState, size: ViewportSize): number {
+  const centerX = size.width / 2;
+  return view.centerSeconds + (x - centerX) * view.secondsPerPixel;
+}
+
+export function secondsToX(seconds: number, view: ViewState, size: ViewportSize): number {
+  const centerX = size.width / 2;
+  return centerX + (seconds - view.centerSeconds) / view.secondsPerPixel;
+}
+
+/**
+ * Zoom about a fixed pixel x — the seconds value at that x stays put.
+ * Returns a new ViewState.
+ */
+export function zoomAbout(
+  view: ViewState,
+  size: ViewportSize,
+  anchorX: number,
+  factor: number,
+): ViewState {
+  const anchorSeconds = xToSeconds(anchorX, view, size);
+  const newSecondsPerPixel = clampScale(view.secondsPerPixel * factor);
+  const centerX = size.width / 2;
+  const newCenter = anchorSeconds - (anchorX - centerX) * newSecondsPerPixel;
+  return { centerSeconds: newCenter, secondsPerPixel: newSecondsPerPixel };
+}
+
+export function panByPixels(view: ViewState, deltaPixels: number): ViewState {
+  return {
+    centerSeconds: view.centerSeconds - deltaPixels * view.secondsPerPixel,
+    secondsPerPixel: view.secondsPerPixel,
+  };
+}
+
+/** Clamp scale so we can't zoom past sensible limits. */
+function clampScale(s: number): number {
+  const MIN = 1;
+  const MAX = 30 * 86400;
+  return Math.max(MIN, Math.min(MAX, s));
+}
+
+export const SECONDS_PER_DAY = 86400;
+
+/** Default: one day takes up ~200px */
+export const DEFAULT_SECONDS_PER_PIXEL = SECONDS_PER_DAY / 200;

--- a/desktop/src/renderer/views/timeline/TimelineView.tsx
+++ b/desktop/src/renderer/views/timeline/TimelineView.tsx
@@ -1,51 +1,94 @@
-import React, { useState } from 'react';
-import { FooterPortal } from '../../components/FooterPortal';
+import { useEffect, useRef, useState } from 'react';
+import { timelinePort } from '../../timeline/data/ports';
+import type { EventListItem, Palette, Session, State } from '../../timeline/data/types';
+import {
+  DEFAULT_SECONDS_PER_PIXEL,
+  type ViewState,
+  type ViewportSize,
+} from '../../timeline/math/zoom';
 
-export function TimelineView() {
-  const [highlighted, setHighlighted] = useState(false);
+interface TimelineViewProps {
+  campaignPath: string;
+}
+
+interface LoadedData {
+  palette: Palette | null;
+  gameState: State | null;
+  events: EventListItem[];
+  sessions: Session[];
+}
+
+export function TimelineView({ campaignPath }: TimelineViewProps) {
+  const [viewState] = useState<ViewState>({
+    centerSeconds: 0,
+    secondsPerPixel: DEFAULT_SECONDS_PER_PIXEL,
+  });
+  const [viewportSize, setViewportSize] = useState<ViewportSize>({ width: 0, height: 0 });
+  const [loadedData, setLoadedData] = useState<LoadedData>({
+    palette: null,
+    gameState: null,
+    events: [],
+    sessions: [],
+  });
+
+  const viewportRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = viewportRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const { contentRect } = entries[0];
+      setViewportSize({ width: contentRect.width, height: contentRect.height });
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    // gameState/events/sessions pre-wired here; consumed by render layers in follow-up issues.
+    Promise.all([
+      timelinePort.loadPalette(campaignPath),
+      timelinePort.getState(campaignPath),
+      timelinePort.listEvents(campaignPath),
+      timelinePort.getSessions(campaignPath),
+    ])
+      .then(([palette, gameState, events, sessions]) => {
+        if (!cancelled) setLoadedData({ palette, gameState, events, sessions });
+      })
+      .catch((err) => console.error('[TimelineView] failed to load campaign data', err));
+    return () => {
+      cancelled = true;
+    };
+  }, [campaignPath]);
+
+  const bgColor = loadedData.palette?.theme.background ?? '#09090b';
 
   return (
     <div
+      ref={viewportRef}
+      data-timeline-viewport
+      data-width={viewportSize.width}
+      data-height={viewportSize.height}
+      data-center={viewState.centerSeconds}
+      data-scale={viewState.secondsPerPixel}
       style={{
-        display: 'flex',
-        flexDirection: 'column',
-        height: '100%',
+        position: 'relative',
         width: '100%',
-        alignItems: 'center',
-        justifyContent: 'center',
-        backgroundColor: highlighted ? 'rgba(99, 102, 241, 0.1)' : 'transparent',
-        transition: 'background-color 0.3s',
+        height: '100%',
+        backgroundColor: bgColor,
+        overflow: 'hidden',
       }}
     >
-      <h1
-        style={{
-          color: highlighted ? '#818cf8' : '#fff',
-          transition: 'color 0.2s',
-          fontSize: '48px',
-          fontWeight: 800,
-        }}
-      >
-        Timeline
-      </h1>
-      <p style={{ color: '#888' }}>Future home of the Timeline interface.</p>
-
-      <FooterPortal>
-        <button
-          onClick={() => setHighlighted(!highlighted)}
-          style={{
-            background: 'rgba(99, 102, 241, 0.1)',
-            color: '#818cf8',
-            border: '1px solid #6366f1',
-            padding: '6px 16px',
-            borderRadius: '4px',
-            cursor: 'pointer',
-            fontWeight: 600,
-            fontSize: '13px',
-          }}
-        >
-          Highlight Timeline
-        </button>
-      </FooterPortal>
+      <div
+        data-layer="axis-layer"
+        style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}
+      />
+      <div
+        data-layer="session-layer"
+        style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}
+      />
+      <div data-layer="cards-layer" style={{ position: 'absolute', inset: 0 }} />
     </div>
   );
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Ports `app/src/timeline/interactions/zoom.ts` to `desktop/src/renderer/timeline/math/zoom.ts` as a pure, standalone module (no DOM, no React)
- Adds 100% branch coverage tests for `xToSeconds`, `secondsToX`, `zoomAbout`, `panByPixels`, and the `clampScale` min/max clamp branches
- Replaces the `TimelineView` placeholder with a React scaffold: owns `ViewState` state, tracks viewport size via `ResizeObserver`, loads palette/state/events/sessions on mount via the data port, and renders empty `axis-layer`, `session-layer`, and `cards-layer` containers
- Wires `campaignPath` from `App` into `TimelineView`

Closes #78. Part of #67.

## Test plan

- [x] All 161 tests pass (`vitest --run` in `desktop/`)
- [x] ESLint clean (`eslint "src/**/*.{ts,tsx}"` in `desktop/`)
- [x] Navigate to the Timeline tab in a campaign — empty dark viewport renders without errors
- [ ] Resize the window — `data-width`/`data-height` attributes update on the viewport div

https://claude.ai/code/session_01CEWZRNrandNLTmkU5vVDDn
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEWZRNrandNLTmkU5vVDDn)_