### PR TITLE
feat(timeline): now-marker render module (#82)

### DIFF
--- a/app/src/timeline/app.ts
+++ b/app/src/timeline/app.ts
@@ -3,7 +3,6 @@ import { listEvents, getEvent, deleteEvent, updateEvent } from '../data/http/eve
 import { getState, putState, getTags, getSessions, putSessions } from '../data/http/state.http.ts';
 import { ApiError } from '../data/http/client.ts';
 import { parseISOString, toAbsoluteSeconds, fromAbsoluteSeconds, toISOString } from '../calendar/golarian.ts';
-import { formatNowMarker } from '../calendar/format.ts';
 import { openAdvanceTimePopover } from '../panels/toolbar.ts';
 import {
   type ViewState, type ViewportSize,
@@ -16,6 +15,7 @@ import { createSessionMode } from './interactions/session-mode.ts';
 import { createSessionTooltip } from './interactions/session-tooltip.ts';
 import { renderAxis } from './render/axis.ts';
 import { layoutCards, renderCards, type CardExpansion } from './render/cards.ts';
+import { renderNowMarker } from './render/now-marker.ts';
 import {
   computeSessionBandsFromSessions,
   renderSessionRail,
@@ -125,38 +125,7 @@ export async function createTimelineApp(): Promise<TimelineApp> {
     cardsLayer.classList.toggle('is-session-mode', appState.sessionMode);
     container.classList.toggle('is-session-mode', appState.sessionMode);
 
-    const existing = container.querySelector('.now-marker');
-    if (existing) existing.remove();
-    const nowX = (appState.inGameNowSeconds - appState.view.centerSeconds) / appState.view.secondsPerPixel + size.width / 2;
-    if (nowX >= 0 && nowX <= size.width) {
-      const axisY = Math.floor(size.height * 0.8);
-      const nowDate = parseISOString(appState.inGameNow);
-      const [dayMonth, year, time] = formatNowMarker(nowDate);
-      const marker = document.createElement('div');
-      marker.className = 'now-marker';
-      marker.style.left = `${nowX}px`;
-      const labels = document.createElement('div');
-      labels.className = 'now-marker-labels';
-      labels.style.top = `${axisY + 66}px`;
-      labels.innerHTML = `
-        <div class="now-marker-date">${dayMonth}</div>
-        <div class="now-marker-year">${year}</div>
-        ${time ? `<div class="now-marker-time">${time}</div>` : ''}
-      `;
-      labels.addEventListener('contextmenu', (e) => {
-        e.preventDefault();
-        openAdvanceTimePopover(labels as unknown as HTMLButtonElement, appState.inGameNow, async (newNow) => {
-          const newState: State = { ...appState.state, in_game_now: newNow };
-          await putState(newState);
-          appState.state = newState;
-          appState.inGameNow = newNow;
-          appState.inGameNowSeconds = toAbsoluteSeconds(parseISOString(newNow));
-          renderTimeline();
-        });
-      });
-      marker.appendChild(labels);
-      container.appendChild(marker);
-    }
+    renderNowMarker(container, appState.inGameNowSeconds, appState.view, size);
   }
 
   function renderSidebar() {

--- a/app/src/timeline/interactions/zoom.ts
+++ b/app/src/timeline/interactions/zoom.ts
@@ -60,3 +60,11 @@ export const SECONDS_PER_DAY = 86400;
 
 /** Default: one day takes up ~200px */
 export const DEFAULT_SECONDS_PER_PIXEL = SECONDS_PER_DAY / 200;
+
+/** Fraction of viewport height at which the horizontal axis line sits. */
+export const AXIS_Y_RATIO = 0.8;
+
+/** Returns the y-pixel of the horizontal axis line for the given viewport. */
+export function axisY(size: ViewportSize): number {
+  return Math.floor(size.height * AXIS_Y_RATIO);
+}

--- a/app/src/timeline/render/now-marker.test.ts
+++ b/app/src/timeline/render/now-marker.test.ts
@@ -1,0 +1,184 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderNowMarker, NOW_MARKER_LABEL_OFFSET_PX } from './now-marker.ts';
+import { parseISOString, toAbsoluteSeconds } from '../../calendar/golarian.ts';
+import { DEFAULT_SECONDS_PER_PIXEL, axisY, secondsToX } from '../interactions/zoom.ts';
+import type { ViewState, ViewportSize } from '../interactions/zoom.ts';
+
+// 4726-05-04 at midnight is a stable test date
+const NOW_DATE = '4726-05-04';
+const NOW_WITH_TIME = '4726-05-04T15:30:00';
+
+function nowSecs(iso: string): number {
+  return toAbsoluteSeconds(parseISOString(iso));
+}
+
+function makeView(centerSeconds: number, secondsPerPixel = DEFAULT_SECONDS_PER_PIXEL): ViewState {
+  return { centerSeconds, secondsPerPixel };
+}
+
+function makeSize(width = 1000, height = 600): ViewportSize {
+  return { width, height };
+}
+
+describe('renderNowMarker', () => {
+  let host: HTMLDivElement;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+  });
+
+  // ── Visibility ──────────────────────────────────────────────────────────────
+
+  it('renders a .now-marker element when the position is in the viewport', () => {
+    const secs = nowSecs(NOW_DATE);
+    renderNowMarker(host, secs, makeView(secs), makeSize());
+    expect(host.querySelector('.now-marker')).not.toBeNull();
+  });
+
+  it('returns null and adds nothing when off-screen to the left', () => {
+    const secs = nowSecs(NOW_DATE);
+    // Push center far to the right so nowX < 0
+    const view = makeView(secs + 2000 * DEFAULT_SECONDS_PER_PIXEL);
+    const result = renderNowMarker(host, secs, view, makeSize());
+    expect(result).toBeNull();
+    expect(host.querySelector('.now-marker')).toBeNull();
+  });
+
+  it('returns null and adds nothing when off-screen to the right', () => {
+    const secs = nowSecs(NOW_DATE);
+    // Push center far to the left so nowX > width
+    const view = makeView(secs - 2000 * DEFAULT_SECONDS_PER_PIXEL);
+    const result = renderNowMarker(host, secs, view, makeSize());
+    expect(result).toBeNull();
+    expect(host.querySelector('.now-marker')).toBeNull();
+  });
+
+  it('returns the created element when visible', () => {
+    const secs = nowSecs(NOW_DATE);
+    const result = renderNowMarker(host, secs, makeView(secs), makeSize());
+    expect(result).not.toBeNull();
+    expect(result?.classList.contains('now-marker')).toBe(true);
+  });
+
+  // ── Idempotency ─────────────────────────────────────────────────────────────
+
+  it('replaces a previous marker instead of adding a second one', () => {
+    const secs = nowSecs(NOW_DATE);
+    const view = makeView(secs);
+    renderNowMarker(host, secs, view, makeSize());
+    renderNowMarker(host, secs, view, makeSize());
+    expect(host.querySelectorAll('.now-marker')).toHaveLength(1);
+  });
+
+  it('removes an existing off-screen marker when the new position is also off-screen', () => {
+    const secs = nowSecs(NOW_DATE);
+    // First call puts a marker on-screen
+    renderNowMarker(host, secs, makeView(secs), makeSize());
+    expect(host.querySelectorAll('.now-marker')).toHaveLength(1);
+    // Second call: now is off-screen — should clean up the old one
+    const offView = makeView(secs + 2000 * DEFAULT_SECONDS_PER_PIXEL);
+    renderNowMarker(host, secs, offView, makeSize());
+    expect(host.querySelectorAll('.now-marker')).toHaveLength(0);
+  });
+
+  // ── Position ────────────────────────────────────────────────────────────────
+
+  it('places the marker at the horizontal centre when now equals centerSeconds', () => {
+    const secs = nowSecs(NOW_DATE);
+    const size = makeSize(1000, 600);
+    renderNowMarker(host, secs, makeView(secs), size);
+    const marker = host.querySelector('.now-marker') as HTMLElement;
+    expect(marker.style.left).toBe('500px');
+  });
+
+  it('positions labels below the axis at the expected offset', () => {
+    const secs = nowSecs(NOW_DATE);
+    const size = makeSize(1000, 600);
+    renderNowMarker(host, secs, makeView(secs), size);
+    const labels = host.querySelector('.now-marker-labels') as HTMLElement;
+    expect(labels.style.top).toBe(`${axisY(size) + NOW_MARKER_LABEL_OFFSET_PX}px`);
+  });
+
+  it('renders the marker when nowX is exactly 0 (left edge)', () => {
+    const secs = nowSecs(NOW_DATE);
+    const size = makeSize(1000, 600);
+    // Place now exactly at left edge: centerSeconds such that secondsToX returns 0
+    // secondsToX(s, view, size) = width/2 + (s - center) / spp = 0
+    // => center = s + (width/2) * spp
+    const view = makeView(secs + (size.width / 2) * DEFAULT_SECONDS_PER_PIXEL);
+    const computedX = secondsToX(secs, view, size);
+    expect(Math.round(computedX)).toBe(0);
+    const result = renderNowMarker(host, secs, view, size);
+    expect(result).not.toBeNull();
+  });
+
+  it('renders the marker when nowX is exactly at the right edge (size.width)', () => {
+    const secs = nowSecs(NOW_DATE);
+    const size = makeSize(1000, 600);
+    // secondsToX = width/2 + (s - center) / spp = width
+    // => center = s - (width/2) * spp
+    const view = makeView(secs - (size.width / 2) * DEFAULT_SECONDS_PER_PIXEL);
+    const computedX = secondsToX(secs, view, size);
+    expect(Math.round(computedX)).toBe(size.width);
+    const result = renderNowMarker(host, secs, view, size);
+    expect(result).not.toBeNull();
+  });
+
+  // ── Label content ───────────────────────────────────────────────────────────
+
+  it('renders the day-of-month and month name in .now-marker-date', () => {
+    const secs = nowSecs(NOW_DATE);
+    renderNowMarker(host, secs, makeView(secs), makeSize());
+    const dateEl = host.querySelector('.now-marker-date');
+    expect(dateEl?.textContent).toContain('4th');
+    expect(dateEl?.textContent).toContain('Desnus');
+  });
+
+  it('renders the year in .now-marker-year', () => {
+    const secs = nowSecs(NOW_DATE);
+    renderNowMarker(host, secs, makeView(secs), makeSize());
+    const yearEl = host.querySelector('.now-marker-year');
+    expect(yearEl?.textContent).toContain('4726');
+    expect(yearEl?.textContent).toContain('AR');
+  });
+
+  it('renders a .now-marker-time element when the time is not midnight', () => {
+    const secs = nowSecs(NOW_WITH_TIME);
+    renderNowMarker(host, secs, makeView(secs), makeSize());
+    const timeEl = host.querySelector('.now-marker-time');
+    expect(timeEl).not.toBeNull();
+    expect(timeEl?.textContent).toBe('15:30');
+  });
+
+  it('omits .now-marker-time when the time is midnight', () => {
+    const secs = nowSecs(NOW_DATE);
+    renderNowMarker(host, secs, makeView(secs), makeSize());
+    expect(host.querySelector('.now-marker-time')).toBeNull();
+  });
+
+  it('pads single-digit hours with a leading zero', () => {
+    const secs = nowSecs('4726-05-04T09:05:00');
+    renderNowMarker(host, secs, makeView(secs), makeSize());
+    expect(host.querySelector('.now-marker-time')?.textContent).toBe('09:05');
+  });
+
+  // ── Label ordering ──────────────────────────────────────────────────────────
+
+  it('renders date before year before time in DOM order', () => {
+    const secs = nowSecs(NOW_WITH_TIME);
+    renderNowMarker(host, secs, makeView(secs), makeSize());
+    const labels = host.querySelector('.now-marker-labels')!;
+    const children = Array.from(labels.children).map(el => el.className);
+    expect(children).toEqual(['now-marker-date', 'now-marker-year', 'now-marker-time']);
+  });
+
+  it('renders date before year with no time element in DOM order when midnight', () => {
+    const secs = nowSecs(NOW_DATE);
+    renderNowMarker(host, secs, makeView(secs), makeSize());
+    const labels = host.querySelector('.now-marker-labels')!;
+    const children = Array.from(labels.children).map(el => el.className);
+    expect(children).toEqual(['now-marker-date', 'now-marker-year']);
+  });
+});

--- a/app/src/timeline/render/now-marker.ts
+++ b/app/src/timeline/render/now-marker.ts
@@ -1,0 +1,60 @@
+import { type ViewState, type ViewportSize, secondsToX, axisY } from '../interactions/zoom.ts';
+import { fromAbsoluteSeconds } from '../../calendar/golarian.ts';
+import { formatNowMarker } from '../../calendar/format.ts';
+
+/** Vertical offset below the axis line where the label group starts. */
+export const NOW_MARKER_LABEL_OFFSET_PX = 66;
+
+/**
+ * Render the "now" marker — a full-height vertical accent line at `nowSeconds`
+ * with date/year label above and optional time label below the axis.
+ *
+ * Removes any existing `.now-marker` child of `host` before painting.
+ * Returns the created element so the caller can attach interaction listeners,
+ * or `null` when the position is off-screen.
+ */
+export function renderNowMarker(
+  host: HTMLElement,
+  nowSeconds: number,
+  view: ViewState,
+  size: ViewportSize,
+): HTMLElement | null {
+  const existing = host.querySelector('.now-marker');
+  if (existing) existing.remove();
+
+  const nowX = secondsToX(nowSeconds, view, size);
+  if (nowX < 0 || nowX > size.width) return null;
+
+  const y = axisY(size);
+  const date = fromAbsoluteSeconds(nowSeconds);
+  const [dayMonth, year, time] = formatNowMarker(date);
+
+  const marker = document.createElement('div');
+  marker.className = 'now-marker';
+  marker.style.left = `${nowX}px`;
+
+  const labels = document.createElement('div');
+  labels.className = 'now-marker-labels';
+  labels.style.top = `${y + NOW_MARKER_LABEL_OFFSET_PX}px`;
+
+  const dateEl = document.createElement('div');
+  dateEl.className = 'now-marker-date';
+  dateEl.textContent = dayMonth;
+  labels.appendChild(dateEl);
+
+  const yearEl = document.createElement('div');
+  yearEl.className = 'now-marker-year';
+  yearEl.textContent = year;
+  labels.appendChild(yearEl);
+
+  if (time) {
+    const timeEl = document.createElement('div');
+    timeEl.className = 'now-marker-time';
+    timeEl.textContent = time;
+    labels.appendChild(timeEl);
+  }
+
+  marker.appendChild(labels);
+  host.appendChild(marker);
+  return marker;
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Extracts the inline now-marker DOM code from `app.ts` into `render/now-marker.ts`, a proper render module per the AGENTS.md render/interaction split
- Adds `axisY(size)` helper and `AXIS_Y_RATIO` constant to `interactions/zoom.ts` to avoid duplicating `Math.floor(height * 0.8)` across call sites
- Removes the contextmenu (advance-time popover) from the render path — issue #82 specifies the marker as read-only; the right-click interaction is a later task
- 17 new DOM tests (happy-dom) covering visibility, idempotency, x-position, label content, label ordering, boundary edges, and midnight time-omission

## Architecture decisions

**`renderNowMarker(host, nowSeconds, view, size) → HTMLElement | null`** is the single exported function. It:
- Removes any existing `.now-marker` before painting (idempotent)
- Returns `null` when the position is off-screen (no DOM side-effects)
- Returns the marker element when visible so callers can attach interaction listeners without querying into internals
- Has no event listeners (pure render)

The contextmenu/advance-time popover belonged to an interaction concern; per the issue it is left for a later task.

**`axisY(size)`** is added to `zoom.ts` (which already owns `ViewportSize`) to give all render and interaction modules a single source of truth for the axis position. This PR uses it in the new module; a follow-up can sweep the remaining call sites.

## Test plan

- [ ] `npm test` passes (176 tests across 11 files)
- [ ] Marker renders at correct x position on the timeline
- [ ] Marker position updates when `state.in_game_now` changes (toolbar "Advance Time" button)
- [ ] No marker when scrolled so the now position is off-screen
- [ ] Date/year labels visible; time label appears only when time ≠ midnight

Closes #82

https://claude.ai/code/session_01W3nw72TVFJjxAUaEdB5xmn
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3nw72TVFJjxAUaEdB5xmn)_