### PR TITLE
[Timeline][Interaction] Zoom + pan (#83)

### DIFF
--- a/desktop/src/renderer/timeline/interactions/__tests__/pan.test.ts
+++ b/desktop/src/renderer/timeline/interactions/__tests__/pan.test.ts
@@ -1,0 +1,185 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createPan } from '../pan';
+import type { ViewState } from '../../math/zoom';
+
+function makeContainer(): HTMLElement {
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  return el;
+}
+
+function makeView(): ViewState {
+  return { centerSeconds: 1_000_000, secondsPerPixel: 100 };
+}
+
+interface Captured {
+  view: ViewState;
+}
+
+function setup(
+  opts: {
+    shouldIgnore?: (e: MouseEvent) => boolean;
+    isOtherDragActive?: () => boolean;
+  } = {},
+) {
+  const container = makeContainer();
+  const captured: Captured = { view: makeView() };
+  const pan = createPan(container, {
+    getView: () => captured.view,
+    setView: (v) => {
+      captured.view = v;
+    },
+    shouldIgnore: opts.shouldIgnore,
+    isOtherDragActive: opts.isOtherDragActive,
+  });
+  return { container, pan, captured };
+}
+
+function md(container: HTMLElement, x: number) {
+  container.dispatchEvent(new MouseEvent('mousedown', { clientX: x, clientY: 100, bubbles: true }));
+}
+function mm(x: number) {
+  window.dispatchEvent(new MouseEvent('mousemove', { clientX: x, clientY: 100 }));
+}
+function mu() {
+  window.dispatchEvent(new MouseEvent('mouseup', { clientX: 0, clientY: 0 }));
+}
+
+describe('createPan', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('starts not dragging and not moved', () => {
+    const { pan } = setup();
+    expect(pan.isDragging()).toBe(false);
+    expect(pan.wasMoved()).toBe(false);
+  });
+
+  it('mousedown puts us into dragging', () => {
+    const { container, pan } = setup();
+    md(container, 100);
+    expect(pan.isDragging()).toBe(true);
+    expect(pan.wasMoved()).toBe(false);
+  });
+
+  it('movement under the 5px threshold leaves wasMoved false and view unchanged', () => {
+    const { container, pan, captured } = setup();
+    const before = captured.view;
+    md(container, 100);
+    mm(102);
+    mm(104);
+    expect(pan.wasMoved()).toBe(false);
+    expect(captured.view).toBe(before);
+  });
+
+  it('exactly 5px of movement engages the pan', () => {
+    const { container, pan, captured } = setup();
+    const before = captured.view;
+    md(container, 100);
+    mm(105);
+    expect(pan.wasMoved()).toBe(true);
+    expect(captured.view).not.toBe(before);
+  });
+
+  it('movement past the threshold pans the view in the correct direction', () => {
+    const { container, captured } = setup();
+    const before = captured.view.centerSeconds;
+    md(container, 100);
+    mm(110); // dragging right → panning left → center moves earlier in time
+    expect(captured.view.centerSeconds).toBeLessThan(before);
+  });
+
+  it('does not change secondsPerPixel while panning', () => {
+    const { container, captured } = setup();
+    md(container, 100);
+    mm(200);
+    expect(captured.view.secondsPerPixel).toBe(makeView().secondsPerPixel);
+  });
+
+  it('mouseup ends the drag but keeps wasMoved until next mousedown', () => {
+    const { container, pan } = setup();
+    md(container, 100);
+    mm(120);
+    mu();
+    expect(pan.isDragging()).toBe(false);
+    expect(pan.wasMoved()).toBe(true);
+    md(container, 100);
+    expect(pan.wasMoved()).toBe(false);
+  });
+
+  it('cursor is "grabbing" during drag and restored on mouseup', () => {
+    const { container } = setup();
+    container.style.cursor = 'grab';
+    md(container, 100);
+    expect(container.style.cursor).toBe('grabbing');
+    mu();
+    expect(container.style.cursor).toBe('grab');
+  });
+
+  it('non-left-button mousedown does not start a drag', () => {
+    const { container, pan } = setup();
+    container.dispatchEvent(
+      new MouseEvent('mousedown', { button: 2, clientX: 100, clientY: 100, bubbles: true }),
+    );
+    expect(pan.isDragging()).toBe(false);
+    mm(200);
+    expect(pan.wasMoved()).toBe(false);
+  });
+
+  it('shouldIgnore returning true skips the mousedown', () => {
+    const { container, pan } = setup({ shouldIgnore: () => true });
+    md(container, 100);
+    expect(pan.isDragging()).toBe(false);
+    mm(120);
+    expect(pan.wasMoved()).toBe(false);
+  });
+
+  it('isOtherDragActive returning true skips the mousedown', () => {
+    let other = false;
+    const { container, pan, captured } = setup({ isOtherDragActive: () => other });
+    other = true;
+    md(container, 100);
+    expect(pan.isDragging()).toBe(false);
+    const before = captured.view;
+    mm(200);
+    expect(captured.view).toBe(before);
+  });
+
+  it('wasMoved resets even when shouldIgnore prevents the drag', () => {
+    const { container, pan } = setup({ shouldIgnore: () => true });
+    // First gesture: normal drag, sets wasMoved via direct manipulation
+    // Since shouldIgnore=true, wasMoved never sets. Simulate a prior wasMoved state
+    // by using a separate pan without shouldIgnore, then testing reset.
+    pan.destroy();
+    const container2 = makeContainer();
+    let ignore = false;
+    const captured2: Captured = { view: makeView() };
+    const pan2 = createPan(container2, {
+      getView: () => captured2.view,
+      setView: (v) => { captured2.view = v; },
+      shouldIgnore: () => ignore,
+    });
+    // First gesture moves, sets wasMoved
+    md(container2, 100);
+    mm(200);
+    mu();
+    expect(pan2.wasMoved()).toBe(true);
+    // Next mousedown resets wasMoved even if shouldIgnore prevents claiming the gesture
+    ignore = true;
+    md(container2, 200);
+    expect(pan2.wasMoved()).toBe(false);
+    pan2.destroy();
+  });
+
+  it('destroy removes all listeners so subsequent events are no-ops', () => {
+    const { container, pan, captured } = setup();
+    pan.destroy();
+    md(container, 100);
+    expect(pan.isDragging()).toBe(false);
+    const before = captured.view;
+    mm(200);
+    expect(captured.view).toBe(before);
+  });
+});

--- a/desktop/src/renderer/timeline/interactions/__tests__/pan.test.ts
+++ b/desktop/src/renderer/timeline/interactions/__tests__/pan.test.ts
@@ -148,17 +148,18 @@ describe('createPan', () => {
   });
 
   it('wasMoved resets even when shouldIgnore prevents the drag', () => {
-    const { container, pan } = setup({ shouldIgnore: () => true });
-    // First gesture: normal drag, sets wasMoved via direct manipulation
-    // Since shouldIgnore=true, wasMoved never sets. Simulate a prior wasMoved state
-    // by using a separate pan without shouldIgnore, then testing reset.
+    const { pan } = setup({ shouldIgnore: () => true });
+    // Since shouldIgnore=true, wasMoved never sets. Build a second pan to reach a
+    // prior wasMoved=true state, then verify the next mousedown resets it.
     pan.destroy();
     const container2 = makeContainer();
     let ignore = false;
     const captured2: Captured = { view: makeView() };
     const pan2 = createPan(container2, {
       getView: () => captured2.view,
-      setView: (v) => { captured2.view = v; },
+      setView: (v) => {
+        captured2.view = v;
+      },
       shouldIgnore: () => ignore,
     });
     // First gesture moves, sets wasMoved

--- a/desktop/src/renderer/timeline/interactions/__tests__/useZoom.test.ts
+++ b/desktop/src/renderer/timeline/interactions/__tests__/useZoom.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { applyWheelZoom } from '../useZoom';
+import { xToSeconds, SECONDS_PER_DAY } from '../../math/zoom';
+import type { ViewState, ViewportSize } from '../../math/zoom';
+
+const VIEW: ViewState = { centerSeconds: 1_000_000, secondsPerPixel: 100 };
+const SIZE: ViewportSize = { width: 1000, height: 600 };
+
+describe('applyWheelZoom', () => {
+  it('anchor pixel x stays at the same in-game seconds after zoom', () => {
+    const anchorX = 300;
+    const anchorSecsBefore = xToSeconds(anchorX, VIEW, SIZE);
+    const result = applyWheelZoom(anchorX, -100, VIEW, SIZE);
+    expect(xToSeconds(anchorX, result, SIZE)).toBeCloseTo(anchorSecsBefore, 6);
+  });
+
+  it('negative deltaY zooms in (decreases secondsPerPixel)', () => {
+    const result = applyWheelZoom(500, -500, VIEW, SIZE);
+    expect(result.secondsPerPixel).toBeLessThan(VIEW.secondsPerPixel);
+  });
+
+  it('positive deltaY zooms out (increases secondsPerPixel)', () => {
+    const result = applyWheelZoom(500, 500, VIEW, SIZE);
+    expect(result.secondsPerPixel).toBeGreaterThan(VIEW.secondsPerPixel);
+  });
+
+  it('zero deltaY leaves view unchanged', () => {
+    const result = applyWheelZoom(500, 0, VIEW, SIZE);
+    expect(result.centerSeconds).toBeCloseTo(VIEW.centerSeconds);
+    expect(result.secondsPerPixel).toBeCloseTo(VIEW.secondsPerPixel);
+  });
+
+  it('zooming about the viewport center does not shift centerSeconds', () => {
+    const centerX = SIZE.width / 2;
+    const result = applyWheelZoom(centerX, -500, VIEW, SIZE);
+    expect(result.centerSeconds).toBeCloseTo(VIEW.centerSeconds, 6);
+  });
+
+  it('anchor invariant holds for off-center cursor positions', () => {
+    const anchorX = 800;
+    const anchorSecsBefore = xToSeconds(anchorX, VIEW, SIZE);
+    const result = applyWheelZoom(anchorX, 300, VIEW, SIZE);
+    expect(xToSeconds(anchorX, result, SIZE)).toBeCloseTo(anchorSecsBefore, 6);
+  });
+
+  it('clamps at minimum zoom (1 s/px) when zooming in past the limit', () => {
+    const nearMin: ViewState = { centerSeconds: 0, secondsPerPixel: 1.1 };
+    const result = applyWheelZoom(500, -100_000, nearMin, SIZE);
+    expect(result.secondsPerPixel).toBe(1);
+  });
+
+  it('clamps at maximum zoom (30 days/px) when zooming out past the limit', () => {
+    const nearMax: ViewState = { centerSeconds: 0, secondsPerPixel: 30 * SECONDS_PER_DAY - 1 };
+    const result = applyWheelZoom(500, 100_000, nearMax, SIZE);
+    expect(result.secondsPerPixel).toBe(30 * SECONDS_PER_DAY);
+  });
+
+  it('returns a new object (immutable)', () => {
+    const result = applyWheelZoom(500, -100, VIEW, SIZE);
+    expect(result).not.toBe(VIEW);
+  });
+});

--- a/desktop/src/renderer/timeline/interactions/pan.ts
+++ b/desktop/src/renderer/timeline/interactions/pan.ts
@@ -1,0 +1,68 @@
+import { panByPixels, type ViewState } from '../math/zoom';
+
+const DRAG_THRESHOLD_PX = 5;
+
+export interface PanDeps {
+  getView(): ViewState;
+  setView(next: ViewState): void;
+  shouldIgnore?: (e: MouseEvent) => boolean;
+  isOtherDragActive?: () => boolean;
+}
+
+export interface PanController {
+  destroy(): void;
+  isDragging(): boolean;
+  wasMoved(): boolean;
+}
+
+export function createPan(container: HTMLElement, deps: PanDeps): PanController {
+  let dragging = false;
+  let dragStartX = 0;
+  let dragMoved = false;
+  let lastX = 0;
+  let preDragCursor = '';
+
+  function onMouseDown(e: MouseEvent) {
+    // Always reset the moved flag on a new gesture, even if pan doesn't claim it.
+    dragMoved = false;
+    if (e.button !== 0) return;
+    if (deps.shouldIgnore?.(e)) return;
+    if (deps.isOtherDragActive?.()) return;
+    dragging = true;
+    dragStartX = e.clientX;
+    lastX = e.clientX;
+    preDragCursor = container.style.cursor;
+    container.style.cursor = 'grabbing';
+  }
+
+  function onMouseMove(e: MouseEvent) {
+    if (!dragging) return;
+    if (!dragMoved && Math.abs(e.clientX - dragStartX) >= DRAG_THRESHOLD_PX) {
+      dragMoved = true;
+    }
+    if (!dragMoved) return;
+    const delta = e.clientX - lastX;
+    lastX = e.clientX;
+    deps.setView(panByPixels(deps.getView(), delta));
+  }
+
+  function onMouseUp() {
+    if (!dragging) return;
+    dragging = false;
+    container.style.cursor = preDragCursor;
+  }
+
+  container.addEventListener('mousedown', onMouseDown);
+  window.addEventListener('mousemove', onMouseMove);
+  window.addEventListener('mouseup', onMouseUp);
+
+  return {
+    destroy() {
+      container.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+    },
+    isDragging: () => dragging,
+    wasMoved: () => dragMoved,
+  };
+}

--- a/desktop/src/renderer/timeline/interactions/usePan.ts
+++ b/desktop/src/renderer/timeline/interactions/usePan.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef, type Dispatch, type RefObject, type SetStateAction } from 'react';
+import { createPan, type PanController, type PanDeps } from './pan';
+import type { ViewState } from '../math/zoom';
+
+export type { PanController };
+
+export function usePan(
+  containerRef: RefObject<HTMLDivElement | null>,
+  viewRef: RefObject<ViewState>,
+  setView: Dispatch<SetStateAction<ViewState>>,
+  extra?: Pick<PanDeps, 'shouldIgnore' | 'isOtherDragActive'>,
+): PanController {
+  const innerRef = useRef<PanController>({
+    destroy: () => {},
+    isDragging: () => false,
+    wasMoved: () => false,
+  });
+
+  // Stable delegate object — callers can hold this reference safely across renders.
+  const stable = useRef<PanController>({
+    destroy: () => innerRef.current.destroy(),
+    isDragging: () => innerRef.current.isDragging(),
+    wasMoved: () => innerRef.current.wasMoved(),
+  }).current;
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const pan = createPan(container, {
+      getView: () => viewRef.current,
+      setView,
+      shouldIgnore: extra?.shouldIgnore,
+      isOtherDragActive: extra?.isOtherDragActive,
+    });
+    innerRef.current = pan;
+
+    return () => {
+      pan.destroy();
+      innerRef.current = { destroy: () => {}, isDragging: () => false, wasMoved: () => false };
+    };
+    // containerRef.current, viewRef, and setView are all stable for the component lifetime.
+    // extra callbacks intentionally omitted — callers must provide stable references.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return stable;
+}

--- a/desktop/src/renderer/timeline/interactions/useZoom.ts
+++ b/desktop/src/renderer/timeline/interactions/useZoom.ts
@@ -1,0 +1,43 @@
+import { useEffect, type Dispatch, type RefObject, type SetStateAction } from 'react';
+import { zoomAbout, type ViewState, type ViewportSize } from '../math/zoom';
+
+/**
+ * Pure zoom math for a single wheel event — exported for testing.
+ * `anchorX` is pixel x relative to the left edge of the timeline container.
+ */
+export function applyWheelZoom(
+  anchorX: number,
+  deltaY: number,
+  view: ViewState,
+  size: ViewportSize,
+): ViewState {
+  const factor = Math.pow(1.001, deltaY);
+  return zoomAbout(view, size, anchorX, factor);
+}
+
+export function useZoom(
+  containerRef: RefObject<HTMLDivElement | null>,
+  viewRef: RefObject<ViewState>,
+  sizeRef: RefObject<ViewportSize>,
+  setView: Dispatch<SetStateAction<ViewState>>,
+): void {
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    function onWheel(e: WheelEvent) {
+      e.preventDefault();
+      // clientX - rect.left gives position relative to container left edge,
+      // which is what zoomAbout expects. offsetX is target-relative and breaks
+      // when the wheel fires over a child element (Cards, SessionBands, etc.).
+      const rect = container!.getBoundingClientRect();
+      const anchorX = e.clientX - rect.left;
+      setView(applyWheelZoom(anchorX, e.deltaY, viewRef.current, sizeRef.current));
+    }
+
+    container.addEventListener('wheel', onWheel, { passive: false });
+    return () => container.removeEventListener('wheel', onWheel);
+    // containerRef.current, viewRef, sizeRef, and setView are all stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/desktop/src/renderer/views/timeline/timeline-view.tsx
+++ b/desktop/src/renderer/views/timeline/timeline-view.tsx
@@ -12,6 +12,8 @@ import { Axis } from '../../timeline/render/axis';
 import { Cards } from '../../timeline/render/cards.tsx';
 import { NowMarker } from '../../timeline/render/now-marker';
 import { SessionBands } from '../../timeline/render/session-bands.tsx';
+import { usePan } from '../../timeline/interactions/usePan';
+import { useZoom } from '../../timeline/interactions/useZoom';
 
 interface TimelineViewProps {
   campaignPath: string;
@@ -25,7 +27,7 @@ interface LoadedData {
 }
 
 export function TimelineView({ campaignPath }: TimelineViewProps) {
-  const [viewState] = useState<ViewState>({
+  const [viewState, setViewState] = useState<ViewState>({
     centerSeconds: 0,
     secondsPerPixel: DEFAULT_SECONDS_PER_PIXEL,
   });
@@ -38,6 +40,15 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
   });
 
   const viewportRef = useRef<HTMLDivElement>(null);
+
+  // Keep refs in sync so event-handler closures always see the latest state.
+  const viewRef = useRef<ViewState>(viewState);
+  const sizeRef = useRef<ViewportSize>(viewportSize);
+  viewRef.current = viewState;
+  sizeRef.current = viewportSize;
+
+  usePan(viewportRef, viewRef, setViewState);
+  useZoom(viewportRef, viewRef, sizeRef, setViewState);
 
   useEffect(() => {
     const el = viewportRef.current;
@@ -86,6 +97,7 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
         height: '100%',
         backgroundColor: bgColor,
         overflow: 'hidden',
+        cursor: 'grab',
         ...(loadedData.palette ? paletteToCssVars(loadedData.palette) : {}),
       }}
     >


### PR DESCRIPTION
Closes #83.

## Summary

- **`pan.ts`** — framework-agnostic `createPan` factory (left-button guard, 5 px drag threshold, `shouldIgnore` / `isOtherDragActive` hooks for future coordination, cursor save/restore)
- **`usePan.ts`** — thin React hook wrapping `createPan`; returns a stable `PanController` (`isDragging()` / `wasMoved()`) so card-click-vs-drag suppression works for downstream interactions
- **`useZoom.ts`** — React hook + exported `applyWheelZoom` for wheel-anchored zoom; uses `clientX - rect.left` (not `offsetX`) to get correct anchor when wheel fires over a child element (Cards, SessionBands, etc.)
- **`timeline-view.tsx`** — wires both hooks; adds `cursor: grab` baseline style

## Scope

Zero changes outside `./desktop/` — confirmed with `git diff --stat main...HEAD -- ':!desktop'` (empty).

## Test plan

- [x] `npm --prefix desktop run test` → 315/315 green
- [x] `npm --prefix desktop run build` → clean
- [x] Wheel zoom keeps cursor pixel fixed (anchor invariant)
- [x] Click-drag pan engages after 5 px threshold; short clicks don't pan
- [x] Right-click / middle-click does not start a pan
- [x] Cursor shows `grab` at rest, `grabbing` during drag, restores to `grab` after

https://claude.ai/code/session_01CR4p666F7CdJ9NSrwj4r78

---
_Generated by [Claude Code](https://claude.ai/code/session_01CR4p666F7CdJ9NSrwj4r78)_