### PR TITLE
[Timeline][Interaction] Card expansion + resizable preview

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -23,11 +23,14 @@
         "chokidar": "4.0.1",
         "electron-updater": "6.3.9",
         "gray-matter": "4.0.3",
+        "markdown-it": "^14.1.1",
         "react": "19.2.6",
         "react-dom": "19.2.6"
       },
       "devDependencies": {
+        "@testing-library/react": "^16.3.2",
         "@types/js-yaml": "^4.0.9",
+        "@types/markdown-it": "^14.1.2",
         "@types/node": "20.19.0",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
@@ -53,6 +56,43 @@
         "vite": "8.0.11",
         "vitest": "4.1.5",
         "wait-on": "8.0.1"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -2135,6 +2175,55 @@
         "node": ">=10"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -2145,6 +2234,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
@@ -2234,6 +2331,31 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -2998,6 +3120,17 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -3982,6 +4115,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4091,6 +4235,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -6875,6 +7027,15 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -6954,6 +7115,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6962,6 +7134,35 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/matcher": {
@@ -6987,6 +7188,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -7894,6 +8101,44 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/proc-log": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
@@ -7985,6 +8230,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9385,6 +9639,12 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.8.0"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -23,14 +23,12 @@
         "chokidar": "4.0.1",
         "electron-updater": "6.3.9",
         "gray-matter": "4.0.3",
-        "markdown-it": "^14.1.1",
         "react": "19.2.6",
         "react-dom": "19.2.6"
       },
       "devDependencies": {
         "@testing-library/react": "^16.3.2",
         "@types/js-yaml": "^4.0.9",
-        "@types/markdown-it": "^14.1.2",
         "@types/node": "20.19.0",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
@@ -2331,31 +2329,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/markdown-it": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/linkify-it": "^5",
-        "@types/mdurl": "^2"
-      }
-    },
-    "node_modules/@types/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -7027,15 +7000,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -7136,35 +7100,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
-    "node_modules/markdown-it/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -7188,12 +7123,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -8230,15 +8159,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9639,12 +9559,6 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.8.0"
       }
-    },
-    "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -67,11 +67,14 @@
     "chokidar": "4.0.1",
     "electron-updater": "6.3.9",
     "gray-matter": "4.0.3",
+    "markdown-it": "^14.1.1",
     "react": "19.2.6",
     "react-dom": "19.2.6"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
     "@types/js-yaml": "^4.0.9",
+    "@types/markdown-it": "^14.1.2",
     "@types/node": "20.19.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -67,14 +67,12 @@
     "chokidar": "4.0.1",
     "electron-updater": "6.3.9",
     "gray-matter": "4.0.3",
-    "markdown-it": "^14.1.1",
     "react": "19.2.6",
     "react-dom": "19.2.6"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.2",
     "@types/js-yaml": "^4.0.9",
-    "@types/markdown-it": "^14.1.2",
     "@types/node": "20.19.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",

--- a/desktop/src/renderer/app.tsx
+++ b/desktop/src/renderer/app.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Footer, ViewType } from './components/footer';
 import { NotesView } from './views/notes/notes-view';
 import { TimelineView } from './views/timeline/timeline-view';

--- a/desktop/src/renderer/components/editor.tsx
+++ b/desktop/src/renderer/components/editor.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FileEntry } from '../hooks/useFiles';
 
 interface EditorProps {

--- a/desktop/src/renderer/components/footer.tsx
+++ b/desktop/src/renderer/components/footer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 export type ViewType = 'notes' | 'timeline' | 'relationships';
 

--- a/desktop/src/renderer/main.tsx
+++ b/desktop/src/renderer/main.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './app.tsx';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/desktop/src/renderer/notes/components/breadcrumb-nav.tsx
+++ b/desktop/src/renderer/notes/components/breadcrumb-nav.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment } from 'react';
 import { tabKey, type OpenTab } from '../types.ts';
 import type { SaveStatus } from '../hooks/useSaveSync.ts';
 
@@ -28,10 +28,10 @@ export function BreadcrumbNav({ activeTab, savingState, savedAt }: BreadcrumbNav
       <span className="breadcrumb-sep">/</span>
       <span className="breadcrumb-segment">{activeTab.folder}</span>
       {pathParts.slice(0, -1).map((part, i) => (
-        <React.Fragment key={i}>
+        <Fragment key={i}>
           <span className="breadcrumb-sep">/</span>
           <span className="breadcrumb-segment">{part}</span>
-        </React.Fragment>
+        </Fragment>
       ))}
       <span className="breadcrumb-sep">/</span>
       <span className="breadcrumb-segment is-leaf">{pathParts[pathParts.length - 1]}</span>

--- a/desktop/src/renderer/notes/components/editor-tabs.tsx
+++ b/desktop/src/renderer/notes/components/editor-tabs.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { folderColor, tabKey, type FileState, type OpenTab } from '../types.ts';
 
 interface EditorTabsProps {

--- a/desktop/src/renderer/notes/components/folder-sidebar.tsx
+++ b/desktop/src/renderer/notes/components/folder-sidebar.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   folderColor,
   isFileKind,

--- a/desktop/src/renderer/notes/components/meta-panel.tsx
+++ b/desktop/src/renderer/notes/components/meta-panel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 
 interface MetaPanelProps {
   frontmatter: string;

--- a/desktop/src/renderer/notes/components/quick-add.tsx
+++ b/desktop/src/renderer/notes/components/quick-add.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { folderColor, slugify } from '../types.ts';
 
 const KNOWN_KINDS = [

--- a/desktop/src/renderer/notes/styles/editor-surface.css
+++ b/desktop/src/renderer/notes/styles/editor-surface.css
@@ -25,7 +25,6 @@
   flex: 1 1 auto;
   position: relative;
   overflow: auto;
-  padding: 28px 60px 100px;
   font-family: ui-monospace, 'Consolas', monospace;
   font-size: 16px;
   line-height: 1.65;
@@ -45,7 +44,6 @@
   color: var(--theme-text-primary, #d8d0b8);
   border: none;
   outline: none;
-  padding: 28px 60px 100px;
   font-family: ui-monospace, 'Consolas', monospace;
   font-size: 15px;
   line-height: 1.65;
@@ -93,7 +91,7 @@
 }
 
 .cm-scroller {
-  padding: 28px 60px 100px;
+  padding: 0 10px 0 10px;
 }
 
 .cm-content {

--- a/desktop/src/renderer/shared/markdown-editor/AGENTS.md
+++ b/desktop/src/renderer/shared/markdown-editor/AGENTS.md
@@ -1,6 +1,6 @@
 # Shared Markdown Editor
 
-A CodeMirror 6 wrapper for editing markdown. Used by notes; intended for events and any future markdown-editing surface.
+A CodeMirror 6 wrapper for editing and previewing markdown. Used by notes and the timeline card expansion; intended for any surface that needs to display or edit markdown.
 
 ## Boundary rules
 
@@ -11,23 +11,30 @@ A CodeMirror 6 wrapper for editing markdown. Used by notes; intended for events 
 ## Module shape
 
 - `markdown-editor.tsx` — `<MarkdownEditor>` React wrapper around CodeMirror 6.
+- `markdown-preview.tsx` — `<MarkdownPreview>` thin read-only wrapper around `<MarkdownEditor>`. Use for non-editing surfaces (timeline card expansion, future peek windows). No `onChange` required.
 - `format-toolbar.tsx` — `<FormatToolbar>` markdown-formatting buttons. Renders a host-supplied `footerSlot` in the right side of the toolbar.
 - `commands.ts` — pure CodeMirror commands (bold/italic/heading/list/etc). Safe to import standalone for custom toolbars.
 - `theme.ts` — `lastGaspThemeExtensions` styling + syntax highlighting.
 - `extensions/wiki-links.ts` — `[[name|id]]` parsing, completion, click handler. Activated via `props.wikiLinks`.
 - `extensions/decorations.ts` — markdown visual decorations (headings, bold, etc).
-- `extensions/image-decorations.ts` — renders `![alt](url)` as an inline image widget.
+- `extensions/image-decorations.ts` — renders `![alt](url)` as an inline image widget. Accepts `resolveSrc` to transform raw image paths (e.g. relative paths → `notes-asset://`).
 - `extensions/image-paste.ts` — clipboard paste. Calls `props.imagePaste.onImagePaste(blob, mime)` and inserts the returned URL.
 - `extensions/drop-link.ts` — drag-and-drop. Calls `props.dropLink.decodeDrop(event)` and inserts the returned markdown.
 - `domain/markdown/` — pure markdown manipulation functions (toggle inline/block, insert templates). No IO.
 
 ## Props contract
 
-- `content` / `onChange` — controlled document.
+- `content` / `onChange` — controlled document. `onChange` is optional when `readOnly` is true.
+- `readOnly` — when true, sets `EditorState.readOnly` and `EditorView.editable.of(false)`. Suppresses `highlightActiveLine`. `onChange` becomes optional.
 - `isSourceMode` — toggles between live-decoration mode and plain source. Reconfigures a `Compartment`; never remounts.
+- `images` — optional `{ resolveSrc?: (rawSrc: string) => string | null }`. Passed to `imageDecorations()`. Supply `resolveSrc` to render images with relative or non-`notes-asset://` URLs (e.g. timeline event bodies). Return `null` to skip rendering a given image.
 - `savedInstance` / `onSaveInstance` — preserve doc + selection + undo history across host-level remounts (e.g., tab switching). The compartment is part of the saved instance and must round-trip.
 - `viewRef` — imperative access for toolbars and focus management.
 - `wikiLinks`, `imagePaste`, `dropLink` — optional host-supplied behaviors. Each is its own config object; omit to disable that feature entirely.
+
+## How to add a new read-only preview surface
+
+Use `<MarkdownPreview>` — it accepts `content`, `images`, `wikiLinks`, and `className`. Do not reach for a separate markdown library.
 
 ## How to add a new host
 

--- a/desktop/src/renderer/shared/markdown-editor/__tests__/markdown-editor.test.tsx
+++ b/desktop/src/renderer/shared/markdown-editor/__tests__/markdown-editor.test.tsx
@@ -3,7 +3,7 @@
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import React, { createRef } from 'react';
+import  { createRef, ReactElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { act } from 'react';
 import { EditorView } from '@codemirror/view';
@@ -24,7 +24,7 @@ function teardown() {
   container.remove();
 }
 
-function renderEl(el: React.ReactElement) {
+function renderEl(el: ReactElement) {
   act(() => root.render(el));
 }
 

--- a/desktop/src/renderer/shared/markdown-editor/__tests__/markdown-editor.test.tsx
+++ b/desktop/src/renderer/shared/markdown-editor/__tests__/markdown-editor.test.tsx
@@ -185,4 +185,23 @@ describe('MarkdownEditor', () => {
     renderEl(<MarkdownEditor content="no extras" onChange={vi.fn()} />);
     expect(container.querySelector('.markdown-editor-container')).not.toBeNull();
   });
+
+  it('mounts in readOnly mode without onChange and is non-editable', () => {
+    setup();
+    const viewRef = createRef<EditorView | null>() as React.MutableRefObject<EditorView | null>;
+    renderEl(<MarkdownEditor content="read me" readOnly viewRef={viewRef} />);
+    expect(container.querySelector('.markdown-editor-container')).not.toBeNull();
+    expect(viewRef.current?.state.readOnly).toBe(true);
+    expect(viewRef.current?.contentDOM.contentEditable).toBe('false');
+  });
+
+  it('does not invoke onChange in readOnly mode when no onChange is supplied', () => {
+    setup();
+    // Should mount without throwing even with no onChange
+    const viewRef = createRef<EditorView | null>() as React.MutableRefObject<EditorView | null>;
+    renderEl(<MarkdownEditor content="static" readOnly viewRef={viewRef} />);
+    // EditorState.readOnly blocks user-initiated mutations (keyboard/paste), not
+    // programmatic dispatch — so just confirm the readOnly facet is set.
+    expect(viewRef.current?.state.readOnly).toBe(true);
+  });
 });

--- a/desktop/src/renderer/shared/markdown-editor/__tests__/markdown-editor.test.tsx
+++ b/desktop/src/renderer/shared/markdown-editor/__tests__/markdown-editor.test.tsx
@@ -3,7 +3,7 @@
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import  { createRef, ReactElement } from 'react';
+import { createRef, ReactElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { act } from 'react';
 import { EditorView } from '@codemirror/view';

--- a/desktop/src/renderer/shared/markdown-editor/__tests__/markdown-preview.test.tsx
+++ b/desktop/src/renderer/shared/markdown-editor/__tests__/markdown-preview.test.tsx
@@ -2,7 +2,6 @@
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 import { describe, it, expect } from 'vitest';
-import React from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { act } from 'react';
 import { MarkdownPreview } from '../markdown-preview';

--- a/desktop/src/renderer/shared/markdown-editor/__tests__/markdown-preview.test.tsx
+++ b/desktop/src/renderer/shared/markdown-editor/__tests__/markdown-preview.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+import { MarkdownPreview } from '../markdown-preview';
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setup() {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+}
+
+function teardown() {
+  act(() => root.unmount());
+  container.remove();
+}
+
+describe('MarkdownPreview', () => {
+  it('renders without crashing and without onChange', () => {
+    setup();
+    act(() => root.render(<MarkdownPreview content="Hello **world**" />));
+    expect(container.querySelector('.markdown-editor-container')).not.toBeNull();
+    teardown();
+  });
+
+  it('applies className to the wrapper div', () => {
+    setup();
+    act(() => root.render(<MarkdownPreview content="text" className="exp-body" />));
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.classList.contains('exp-body')).toBe(true);
+    teardown();
+  });
+
+  it('mounts a read-only CodeMirror editor', () => {
+    setup();
+    act(() =>
+      root.render(
+        <MarkdownPreview
+          content="read only"
+          images={{
+            resolveSrc: (src) => `notes-asset://current/events/${encodeURIComponent(src)}`,
+          }}
+        />,
+      ),
+    );
+    // contentEditable=false indicates the editor is non-editable
+    const cmContent = container.querySelector('[contenteditable]');
+    expect(cmContent?.getAttribute('contenteditable')).toBe('false');
+    teardown();
+  });
+});

--- a/desktop/src/renderer/shared/markdown-editor/extensions/__tests__/image-decorations.test.ts
+++ b/desktop/src/renderer/shared/markdown-editor/extensions/__tests__/image-decorations.test.ts
@@ -16,9 +16,20 @@ describe('findImagesInText', () => {
     });
   });
 
-  it('ignores non-notes-asset images', () => {
+  it('finds non-notes-asset images too (resolveSrc decides rendering)', () => {
     const text = '![alt](https://example.com/img.png)';
-    expect(findImagesInText(text)).toHaveLength(0);
+    const imgs = findImagesInText(text);
+    expect(imgs).toHaveLength(1);
+    expect(imgs[0].src).toBe('https://example.com/img.png');
+    expect(imgs[0].alt).toBe('alt');
+  });
+
+  it('finds bare relative-path images', () => {
+    const text = '![hero](hero.jpg)';
+    const imgs = findImagesInText(text);
+    expect(imgs).toHaveLength(1);
+    expect(imgs[0].src).toBe('hero.jpg');
+    expect(imgs[0].alt).toBe('hero');
   });
 
   it('handles multiple images in order', () => {

--- a/desktop/src/renderer/shared/markdown-editor/extensions/image-decorations.ts
+++ b/desktop/src/renderer/shared/markdown-editor/extensions/image-decorations.ts
@@ -8,12 +8,22 @@ export interface ParsedImage {
   altFrom: number; // position of first alt char (after `![`)
   altTo: number; // position after last alt char (before `]`)
   alt: string;
-  src: string;
+  src: string; // raw src from the markdown (before any transformation)
 }
 
-const IMAGE_RE = /!\[([^\]]*)\]\((notes-asset:\/\/[^)]+)\)/g;
+export interface ImageDecorationsOptions {
+  /** Map a raw image src to a displayable URL, or return null to skip the widget. */
+  resolveSrc?: (rawSrc: string) => string | null;
+}
 
-/** Finds all `![alt](notes-asset://...)` images in `text`, positions offset by `offset`. */
+// Matches any ![alt](url) — url may be any non-whitespace, non-paren sequence.
+const IMAGE_RE = /!\[([^\]]*)\]\(([^)\s]+)\)/g;
+
+/** Default: only render notes-asset:// images (backward-compatible behaviour). */
+const defaultResolveSrc = (src: string): string | null =>
+  src.startsWith('notes-asset://') ? src : null;
+
+/** Finds all `![alt](url)` images in `text`, positions offset by `offset`. */
 export function findImagesInText(text: string, offset = 0): ParsedImage[] {
   const results: ParsedImage[] = [];
   const re = new RegExp(IMAGE_RE.source, 'g');
@@ -62,19 +72,25 @@ class ImageWidget extends WidgetType {
   }
 }
 
-function buildImageDecorations(state: EditorState): DecorationSet {
+function buildImageDecorations(
+  state: EditorState,
+  resolveSrc: (rawSrc: string) => string | null,
+): DecorationSet {
   const cursorHead = state.selection.main.head;
   const builder = new RangeSetBuilder<Decoration>();
   const images = findImagesInText(state.doc.toString());
 
   for (const img of images) {
+    const resolvedSrc = resolveSrc(img.src);
+    if (resolvedSrc === null) continue;
+
     // Always render the image — block widget appears above the label line.
     // side: -1 places it before the character at img.from.
     builder.add(
       img.from,
       img.from,
       Decoration.widget({
-        widget: new ImageWidget(img.src, img.alt),
+        widget: new ImageWidget(resolvedSrc, img.alt),
         side: -1,
       }),
     );
@@ -93,14 +109,15 @@ function buildImageDecorations(state: EditorState): DecorationSet {
   return builder.finish();
 }
 
-export function imageDecorations(): Extension {
+export function imageDecorations(opts?: ImageDecorationsOptions): Extension {
+  const resolveSrc = opts?.resolveSrc ?? defaultResolveSrc;
   return StateField.define<DecorationSet>({
     create(state) {
-      return buildImageDecorations(state);
+      return buildImageDecorations(state, resolveSrc);
     },
     update(value, transaction) {
       if (transaction.docChanged || transaction.selection) {
-        return buildImageDecorations(transaction.state);
+        return buildImageDecorations(transaction.state, resolveSrc);
       }
       return value.map(transaction.changes);
     },

--- a/desktop/src/renderer/shared/markdown-editor/format-toolbar.tsx
+++ b/desktop/src/renderer/shared/markdown-editor/format-toolbar.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { type EditorView } from '@codemirror/view';
 import {
   boldCommand,

--- a/desktop/src/renderer/shared/markdown-editor/index.ts
+++ b/desktop/src/renderer/shared/markdown-editor/index.ts
@@ -4,9 +4,12 @@ export type {
   SavedEditorInstance,
   WikiLinksHostConfig,
 } from './markdown-editor';
+export { MarkdownPreview } from './markdown-preview';
+export type { MarkdownPreviewProps } from './markdown-preview';
 export { FormatToolbar } from './format-toolbar';
 export type { FormatToolbarProps } from './format-toolbar';
 export type { WikiLinkSuggestion } from './extensions/wiki-links';
 export type { ImagePasteConfig } from './extensions/image-paste';
 export type { DropLinkConfig, DropInsert } from './extensions/drop-link';
+export type { ImageDecorationsOptions } from './extensions/image-decorations';
 export * from './commands';

--- a/desktop/src/renderer/shared/markdown-editor/markdown-editor.tsx
+++ b/desktop/src/renderer/shared/markdown-editor/markdown-editor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import {
   EditorView,
   highlightSpecialChars,

--- a/desktop/src/renderer/shared/markdown-editor/markdown-editor.tsx
+++ b/desktop/src/renderer/shared/markdown-editor/markdown-editor.tsx
@@ -26,7 +26,7 @@ import { lastGaspThemeExtensions } from './theme';
 import { wikiLinks, setKnownIds, type WikiLinkSuggestion } from './extensions/wiki-links';
 import { markdownDecorations } from './extensions/decorations';
 import { imagePaste, type ImagePasteConfig } from './extensions/image-paste';
-import { imageDecorations } from './extensions/image-decorations';
+import { imageDecorations, type ImageDecorationsOptions } from './extensions/image-decorations';
 import { dropLink, type DropLinkConfig } from './extensions/drop-link';
 import { formattingKeymap } from './commands';
 
@@ -48,7 +48,10 @@ export interface WikiLinksHostConfig {
 
 export interface MarkdownEditorProps {
   content: string;
-  onChange: (content: string) => void;
+  onChange?: (content: string) => void;
+
+  /** When true, disables all editing and makes onChange optional. */
+  readOnly?: boolean;
 
   isSourceMode?: boolean;
 
@@ -61,6 +64,9 @@ export interface MarkdownEditorProps {
   /** Enables wiki-link parsing, completion, and click-to-open. Omit to disable. */
   wikiLinks?: WikiLinksHostConfig;
 
+  /** Image decoration options — supply resolveSrc to handle non-notes-asset URLs. */
+  images?: ImageDecorationsOptions;
+
   /** Enables image paste-to-disk. Omit to drop pasted images silently. */
   imagePaste?: ImagePasteConfig;
 
@@ -71,11 +77,13 @@ export interface MarkdownEditorProps {
 export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   content,
   onChange,
+  readOnly = false,
   isSourceMode = false,
   savedInstance,
   onSaveInstance,
   viewRef,
   wikiLinks: wikiLinksConfig,
+  images: imagesConfig,
   imagePaste: imagePasteConfig,
   dropLink: dropLinkConfig,
 }) => {
@@ -86,11 +94,15 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   const onChangeRef = useRef(onChange);
   const onSaveInstanceRef = useRef(onSaveInstance);
   const isSourceModeRef = useRef(isSourceMode);
+  const readOnlyRef = useRef(readOnly);
   const wikiLinksRef = useRef(wikiLinksConfig);
+  const imagesRef = useRef(imagesConfig);
   onChangeRef.current = onChange;
   onSaveInstanceRef.current = onSaveInstance;
   isSourceModeRef.current = isSourceMode;
+  readOnlyRef.current = readOnly;
   wikiLinksRef.current = wikiLinksConfig;
+  imagesRef.current = imagesConfig;
 
   const modeCompartmentRef = useRef<Compartment>(
     savedInstance?.modeCompartment ?? new Compartment(),
@@ -99,7 +111,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   /** Extensions that differ between live and source mode. */
   function buildModeExtensions(sourceMode: boolean): Extension[] {
     if (sourceMode) return [];
-    const exts: Extension[] = [markdownDecorations(), imageDecorations()];
+    const exts: Extension[] = [markdownDecorations(), imageDecorations(imagesRef.current)];
     if (wikiLinksRef.current) {
       exts.push(
         wikiLinks({
@@ -119,8 +131,10 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
 
     const compartment = modeCompartmentRef.current;
 
+    const ro = readOnlyRef.current;
+
     const baseExtensions: Extension[] = [
-      highlightActiveLine(),
+      ...(ro ? [] : [highlightActiveLine()]),
       highlightSpecialChars(),
       history(),
       drawSelection(),
@@ -147,12 +161,17 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
       EditorView.lineWrapping,
       EditorView.updateListener.of((update) => {
         if (update.docChanged) {
-          onChangeRef.current(update.state.doc.toString());
+          onChangeRef.current?.(update.state.doc.toString());
         }
       }),
       Prec.high(formattingKeymap),
       compartment.of(buildModeExtensions(isSourceModeRef.current)),
     ];
+
+    if (ro) {
+      baseExtensions.push(EditorState.readOnly.of(true));
+      baseExtensions.push(EditorView.editable.of(false));
+    }
 
     if (imagePasteConfig) {
       baseExtensions.push(imagePaste(imagePasteConfig));

--- a/desktop/src/renderer/shared/markdown-editor/markdown-preview.tsx
+++ b/desktop/src/renderer/shared/markdown-editor/markdown-preview.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MarkdownEditor } from './markdown-editor';
 import type { WikiLinksHostConfig } from './markdown-editor';
 import type { ImageDecorationsOptions } from './extensions/image-decorations';

--- a/desktop/src/renderer/shared/markdown-editor/markdown-preview.tsx
+++ b/desktop/src/renderer/shared/markdown-editor/markdown-preview.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { MarkdownEditor } from './markdown-editor';
+import type { WikiLinksHostConfig } from './markdown-editor';
+import type { ImageDecorationsOptions } from './extensions/image-decorations';
+
+export interface MarkdownPreviewProps {
+  content: string;
+  /** Image decoration options — supply resolveSrc to handle relative or non-notes-asset URLs. */
+  images?: ImageDecorationsOptions;
+  /** Optional wiki-link config — allows link-click navigation from preview surfaces. */
+  wikiLinks?: WikiLinksHostConfig;
+  className?: string;
+}
+
+export const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({
+  content,
+  images,
+  wikiLinks,
+  className,
+}) => (
+  <div className={className}>
+    <MarkdownEditor content={content} readOnly images={images} wikiLinks={wikiLinks} />
+  </div>
+);

--- a/desktop/src/renderer/timeline/interactions/__tests__/useCardExpansion.test.ts
+++ b/desktop/src/renderer/timeline/interactions/__tests__/useCardExpansion.test.ts
@@ -1,0 +1,221 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useCardExpansion } from '../useCardExpansion';
+import type { PanController } from '../usePan';
+import type { EventWithMtime } from '../../data/types';
+
+// ---- Mocks ----
+
+vi.mock('../../data/ports', () => ({
+  timelinePort: {
+    getEvent: vi.fn(),
+  },
+}));
+
+import { timelinePort } from '../../data/ports';
+const mockGetEvent = vi.mocked(timelinePort.getEvent);
+
+function makePan(wasMoved = false): PanController {
+  return {
+    destroy: vi.fn(),
+    isDragging: vi.fn(() => false),
+    wasMoved: vi.fn(() => wasMoved),
+  };
+}
+
+function makeEventResponse(filename: string, body: string): EventWithMtime {
+  return {
+    event: {
+      filename,
+      title: 'T',
+      date: '4726-05-04',
+      tags: [],
+      mtime: '2026-01-01T00:00:00Z',
+      body,
+    },
+    lastModified: '2026-01-01T00:00:00Z',
+  };
+}
+
+beforeEach(() => {
+  mockGetEvent.mockReset();
+});
+
+// ---- Tests ----
+
+describe('useCardExpansion', () => {
+  it('starts with no expansion', () => {
+    const pan = makePan();
+    const { result } = renderHook(() => useCardExpansion('camp', pan));
+    expect(result.current.expansion).toBeNull();
+  });
+
+  it('click suppressed when pan.wasMoved() is true — expansion stays null', async () => {
+    const pan = makePan(true); // wasMoved = true
+    const { result } = renderHook(() => useCardExpansion('camp', pan));
+
+    act(() => {
+      result.current.handleCardClick('a.md');
+    });
+
+    expect(result.current.expansion).toBeNull();
+    expect(mockGetEvent).not.toHaveBeenCalled();
+  });
+
+  it('sets body to null (loading) immediately on click, then loads the body', async () => {
+    const pan = makePan();
+    let resolveEvent!: (v: EventWithMtime) => void;
+    mockGetEvent.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveEvent = resolve;
+      }),
+    );
+
+    const { result } = renderHook(() => useCardExpansion('camp', pan));
+
+    act(() => {
+      result.current.handleCardClick('a.md');
+    });
+
+    // Immediately after click: loading state
+    expect(result.current.expansion).toEqual({ filename: 'a.md', body: null });
+
+    // Resolve the fetch
+    await act(async () => {
+      resolveEvent(makeEventResponse('a.md', '# Hello'));
+    });
+
+    expect(result.current.expansion).toEqual({ filename: 'a.md', body: '# Hello' });
+  });
+
+  it('clicking the expanded card again collapses it', async () => {
+    const pan = makePan();
+    mockGetEvent.mockResolvedValueOnce(makeEventResponse('a.md', '# A'));
+    const { result } = renderHook(() => useCardExpansion('camp', pan));
+
+    await act(async () => {
+      result.current.handleCardClick('a.md');
+    });
+    await waitFor(() => expect(result.current.expansion?.body).toBe('# A'));
+
+    // Click same card again
+    act(() => {
+      result.current.handleCardClick('a.md');
+    });
+
+    expect(result.current.expansion).toBeNull();
+  });
+
+  it('clicking a different card before the first fetch resolves discards the first body', async () => {
+    const pan = makePan();
+
+    let resolveA!: (v: EventWithMtime) => void;
+    mockGetEvent
+      .mockReturnValueOnce(
+        new Promise((r) => {
+          resolveA = r;
+        }),
+      ) // A hangs
+      .mockResolvedValueOnce(makeEventResponse('b.md', '# B')); // B resolves
+
+    const { result } = renderHook(() => useCardExpansion('camp', pan));
+
+    // Click A (hangs)
+    act(() => result.current.handleCardClick('a.md'));
+    expect(result.current.expansion?.filename).toBe('a.md');
+
+    // Click B before A resolves
+    await act(async () => result.current.handleCardClick('b.md'));
+    await waitFor(() => expect(result.current.expansion?.body).toBe('# B'));
+
+    // Now resolve A late — should be discarded
+    await act(async () => {
+      resolveA(makeEventResponse('a.md', '# A'));
+    });
+
+    // B's expansion is still shown; A's body was discarded
+    expect(result.current.expansion).toEqual({ filename: 'b.md', body: '# B' });
+  });
+
+  it('clicking the loading card (body: null) collapses it, and the fetch result is discarded', async () => {
+    const pan = makePan();
+    let resolveA!: (v: EventWithMtime) => void;
+    mockGetEvent.mockReturnValueOnce(
+      new Promise((r) => {
+        resolveA = r;
+      }),
+    );
+
+    const { result } = renderHook(() => useCardExpansion('camp', pan));
+
+    // Click A — starts loading
+    act(() => result.current.handleCardClick('a.md'));
+    expect(result.current.expansion).toEqual({ filename: 'a.md', body: null });
+
+    // Click A again while loading — should collapse
+    act(() => result.current.handleCardClick('a.md'));
+    expect(result.current.expansion).toBeNull();
+
+    // Resolve the fetch — should be a no-op
+    await act(async () => {
+      resolveA(makeEventResponse('a.md', '# A'));
+    });
+
+    expect(result.current.expansion).toBeNull();
+  });
+
+  it('collapse() sets expansion to null', async () => {
+    const pan = makePan();
+    mockGetEvent.mockResolvedValueOnce(makeEventResponse('a.md', '# A'));
+    const { result } = renderHook(() => useCardExpansion('camp', pan));
+
+    await act(async () => result.current.handleCardClick('a.md'));
+    await waitFor(() => expect(result.current.expansion?.body).toBe('# A'));
+
+    act(() => result.current.collapse());
+    expect(result.current.expansion).toBeNull();
+  });
+
+  it('Escape key collapses the expansion', async () => {
+    const pan = makePan();
+    mockGetEvent.mockResolvedValueOnce(makeEventResponse('a.md', '# A'));
+    const { result } = renderHook(() => useCardExpansion('camp', pan));
+
+    await act(async () => result.current.handleCardClick('a.md'));
+    await waitFor(() => expect(result.current.expansion?.body).toBe('# A'));
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+
+    expect(result.current.expansion).toBeNull();
+  });
+
+  it('Escape key does nothing when no card is expanded', () => {
+    const pan = makePan();
+    const { result } = renderHook(() => useCardExpansion('camp', pan));
+    expect(result.current.expansion).toBeNull();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+
+    expect(result.current.expansion).toBeNull();
+  });
+
+  it('other key presses do not collapse the expansion', async () => {
+    const pan = makePan();
+    mockGetEvent.mockResolvedValueOnce(makeEventResponse('a.md', '# A'));
+    const { result } = renderHook(() => useCardExpansion('camp', pan));
+
+    await act(async () => result.current.handleCardClick('a.md'));
+    await waitFor(() => expect(result.current.expansion?.body).toBe('# A'));
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+
+    expect(result.current.expansion).not.toBeNull();
+  });
+});

--- a/desktop/src/renderer/timeline/interactions/__tests__/usePreviewSize.test.ts
+++ b/desktop/src/renderer/timeline/interactions/__tests__/usePreviewSize.test.ts
@@ -1,11 +1,13 @@
 // @vitest-environment happy-dom
-import { describe, it, expect, beforeEach } from 'vitest';
-import { loadPreviewSize } from '../usePreviewSize';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { loadPreviewSize, usePreviewSize } from '../usePreviewSize';
 
 const KEY = 'preview-card-size';
 
 beforeEach(() => {
   localStorage.clear();
+  vi.restoreAllMocks();
 });
 
 describe('loadPreviewSize', () => {
@@ -47,5 +49,43 @@ describe('loadPreviewSize', () => {
     const stored = { width: 512, expandedHeight: 256 };
     localStorage.setItem(KEY, JSON.stringify(stored));
     expect(loadPreviewSize()).toEqual(stored);
+  });
+});
+
+describe('usePreviewSize — save path', () => {
+  it('save updates the returned state', () => {
+    const { result } = renderHook(() => usePreviewSize());
+    expect(result.current[0]).toEqual({ width: 640, expandedHeight: 480 });
+
+    act(() => {
+      result.current[1]({ width: 900, expandedHeight: 350 });
+    });
+
+    expect(result.current[0]).toEqual({ width: 900, expandedHeight: 350 });
+  });
+
+  it('save writes to localStorage so loadPreviewSize returns the new value', () => {
+    const { result } = renderHook(() => usePreviewSize());
+
+    act(() => {
+      result.current[1]({ width: 720, expandedHeight: 400 });
+    });
+
+    expect(loadPreviewSize()).toEqual({ width: 720, expandedHeight: 400 });
+  });
+
+  it('save still updates in-memory state when setItem throws (e.g. quota exceeded)', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+
+    const { result } = renderHook(() => usePreviewSize());
+
+    act(() => {
+      result.current[1]({ width: 500, expandedHeight: 200 });
+    });
+
+    // State updated despite the write failure
+    expect(result.current[0]).toEqual({ width: 500, expandedHeight: 200 });
   });
 });

--- a/desktop/src/renderer/timeline/interactions/__tests__/usePreviewSize.test.ts
+++ b/desktop/src/renderer/timeline/interactions/__tests__/usePreviewSize.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadPreviewSize } from '../usePreviewSize';
+
+const KEY = 'preview-card-size';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('loadPreviewSize', () => {
+  it('returns defaults when localStorage is empty', () => {
+    const { width, expandedHeight } = loadPreviewSize();
+    expect(width).toBe(640);
+    expect(expandedHeight).toBe(480);
+  });
+
+  it('returns stored values when they are valid numbers', () => {
+    localStorage.setItem(KEY, JSON.stringify({ width: 800, expandedHeight: 300 }));
+    const { width, expandedHeight } = loadPreviewSize();
+    expect(width).toBe(800);
+    expect(expandedHeight).toBe(300);
+  });
+
+  it('returns defaults when the stored value is corrupt JSON', () => {
+    localStorage.setItem(KEY, 'not-json');
+    const { width, expandedHeight } = loadPreviewSize();
+    expect(width).toBe(640);
+    expect(expandedHeight).toBe(480);
+  });
+
+  it('returns defaults when the stored object is missing fields', () => {
+    localStorage.setItem(KEY, JSON.stringify({ width: 800 }));
+    const { width, expandedHeight } = loadPreviewSize();
+    expect(width).toBe(640);
+    expect(expandedHeight).toBe(480);
+  });
+
+  it('returns defaults when stored fields are non-numeric', () => {
+    localStorage.setItem(KEY, JSON.stringify({ width: '800', expandedHeight: 300 }));
+    const { width, expandedHeight } = loadPreviewSize();
+    expect(width).toBe(640);
+    expect(expandedHeight).toBe(480);
+  });
+
+  it('round-trips values through JSON.stringify correctly', () => {
+    const stored = { width: 512, expandedHeight: 256 };
+    localStorage.setItem(KEY, JSON.stringify(stored));
+    expect(loadPreviewSize()).toEqual(stored);
+  });
+});

--- a/desktop/src/renderer/timeline/interactions/useCardExpansion.ts
+++ b/desktop/src/renderer/timeline/interactions/useCardExpansion.ts
@@ -1,0 +1,69 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { timelinePort } from '../data/ports';
+import type { PanController } from './usePan';
+
+export interface CardExpansionState {
+  filename: string;
+  body: string | null; // null = still loading
+}
+
+export interface UseCardExpansionResult {
+  expansion: CardExpansionState | null;
+  handleCardClick: (filename: string) => void;
+  collapse: () => void;
+}
+
+export function useCardExpansion(campaignPath: string, pan: PanController): UseCardExpansionResult {
+  const [expansion, setExpansion] = useState<CardExpansionState | null>(null);
+
+  // Ref stays in sync with state, giving async callbacks a non-stale view
+  // without making handleCardClick depend on expansion in its closure.
+  const expansionRef = useRef<CardExpansionState | null>(null);
+  expansionRef.current = expansion;
+
+  const collapse = useCallback(() => {
+    expansionRef.current = null;
+    setExpansion(null);
+  }, []);
+
+  const handleCardClick = useCallback(
+    (filename: string) => {
+      if (pan.wasMoved()) return;
+
+      // Toggle off when clicking the already-expanded card (including while loading)
+      if (expansionRef.current?.filename === filename) {
+        collapse();
+        return;
+      }
+
+      // Start loading; record intent so the fetch callback can detect staleness
+      const next: CardExpansionState = { filename, body: null };
+      expansionRef.current = next;
+      setExpansion(next);
+
+      timelinePort
+        .getEvent(campaignPath, filename)
+        .then(({ event }) => {
+          // If the user navigated away from this card before the fetch resolved, discard
+          if (expansionRef.current?.filename !== filename) return;
+          const loaded: CardExpansionState = { filename, body: event.body };
+          expansionRef.current = loaded;
+          setExpansion(loaded);
+        })
+        .catch((err) => console.error('[useCardExpansion] failed to load event body', err));
+    },
+    [campaignPath, pan, collapse],
+  );
+
+  // Escape collapses while any card is expanded
+  useEffect(() => {
+    if (!expansion) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') collapse();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [expansion, collapse]);
+
+  return { expansion, handleCardClick, collapse };
+}

--- a/desktop/src/renderer/timeline/interactions/usePreviewSize.ts
+++ b/desktop/src/renderer/timeline/interactions/usePreviewSize.ts
@@ -1,0 +1,47 @@
+import { useState, useCallback } from 'react';
+
+const PREVIEW_SIZE_KEY = 'preview-card-size';
+const DEFAULT_WIDTH = 640;
+const DEFAULT_HEIGHT = 480;
+
+export interface PreviewSize {
+  width: number;
+  expandedHeight: number;
+}
+
+export function loadPreviewSize(): PreviewSize {
+  try {
+    const raw = localStorage.getItem(PREVIEW_SIZE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as unknown;
+      if (
+        parsed !== null &&
+        typeof parsed === 'object' &&
+        'width' in parsed &&
+        'expandedHeight' in parsed &&
+        typeof (parsed as Record<string, unknown>).width === 'number' &&
+        typeof (parsed as Record<string, unknown>).expandedHeight === 'number'
+      ) {
+        return parsed as PreviewSize;
+      }
+    }
+  } catch {
+    // ignore corrupt or missing storage
+  }
+  return { width: DEFAULT_WIDTH, expandedHeight: DEFAULT_HEIGHT };
+}
+
+export function usePreviewSize(): [PreviewSize, (s: PreviewSize) => void] {
+  const [size, setSize] = useState<PreviewSize>(loadPreviewSize);
+
+  const save = useCallback((s: PreviewSize) => {
+    try {
+      localStorage.setItem(PREVIEW_SIZE_KEY, JSON.stringify(s));
+    } catch {
+      // ignore quota errors
+    }
+    setSize(s);
+  }, []);
+
+  return [size, save];
+}

--- a/desktop/src/renderer/timeline/render/__tests__/card-expansion-layout.test.ts
+++ b/desktop/src/renderer/timeline/render/__tests__/card-expansion-layout.test.ts
@@ -24,7 +24,7 @@ describe('computeExpansionLayout', () => {
       expect(expandsDown).toBe(true);
     });
 
-    it('exactly on the boundary (normalTop - expandedHeight === 0) opens upward', () => {
+    it('an expansion that exactly fits the available space above opens upward', () => {
       const top = normalTop(0); // 392
       // expandedHeight exactly equals normalTop → 392-392 = 0, which is NOT < 0
       const { expandsDown } = computeExpansionLayout(top, top, 120, 640);

--- a/desktop/src/renderer/timeline/render/__tests__/card-expansion-layout.test.ts
+++ b/desktop/src/renderer/timeline/render/__tests__/card-expansion-layout.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { computeExpansionLayout, CARD_HEIGHT, CARD_GAP } from '../cards';
+
+const SIZE = { width: 1200, height: 600 };
+const AXIS_Y = Math.floor(SIZE.height * 0.8); // 480
+
+function normalTop(row: number): number {
+  return AXIS_Y - CARD_HEIGHT - CARD_GAP - row * (CARD_HEIGHT + CARD_GAP);
+}
+
+describe('computeExpansionLayout', () => {
+  describe('expandsDown flag', () => {
+    it('opens upward when there is room above the card', () => {
+      // row-0 card top is ~392; a 200px expansion fits above (392-200=192 > 0)
+      const top = normalTop(0); // 392
+      const { expandsDown } = computeExpansionLayout(top, 200, 120, 640);
+      expect(expandsDown).toBe(false);
+    });
+
+    it('opens downward when the expansion would go above the viewport top', () => {
+      // row-0 top is ~392; a 400px expansion would land at -8, so flip down
+      const top = normalTop(0); // 392
+      const { expandsDown } = computeExpansionLayout(top, 400, 120, 640);
+      expect(expandsDown).toBe(true);
+    });
+
+    it('exactly on the boundary (normalTop - expandedHeight === 0) opens upward', () => {
+      const top = normalTop(0); // 392
+      // expandedHeight exactly equals normalTop → 392-392 = 0, which is NOT < 0
+      const { expandsDown } = computeExpansionLayout(top, top, 120, 640);
+      expect(expandsDown).toBe(false);
+    });
+
+    it('one pixel over the boundary triggers downward expansion', () => {
+      const top = normalTop(0); // 392
+      const { expandsDown } = computeExpansionLayout(top, top + 1, 120, 640);
+      expect(expandsDown).toBe(true);
+    });
+  });
+
+  describe('cardTop', () => {
+    it('is normalTop - expandedHeight when opening upward', () => {
+      const top = normalTop(0); // 392
+      const { cardTop, expandsDown } = computeExpansionLayout(top, 100, 120, 640);
+      expect(expandsDown).toBe(false);
+      expect(cardTop).toBe(top - 100);
+    });
+
+    it('is normalTop when opening downward', () => {
+      const top = normalTop(0); // 392
+      const { cardTop, expandsDown } = computeExpansionLayout(top, 400, 120, 640);
+      expect(expandsDown).toBe(true);
+      expect(cardTop).toBe(top);
+    });
+  });
+
+  describe('cardWidth', () => {
+    it('uses previewWidth when wider than normalWidth', () => {
+      const { cardWidth } = computeExpansionLayout(300, 200, 120, 640);
+      expect(cardWidth).toBe(640);
+    });
+
+    it('uses normalWidth when wider than previewWidth', () => {
+      const { cardWidth } = computeExpansionLayout(300, 200, 700, 640);
+      expect(cardWidth).toBe(700);
+    });
+
+    it('uses normalWidth when equal to previewWidth', () => {
+      const { cardWidth } = computeExpansionLayout(300, 200, 640, 640);
+      expect(cardWidth).toBe(640);
+    });
+  });
+
+  describe('higher-row cards', () => {
+    it('row-2 card still expands down when height exceeds available space', () => {
+      const top = normalTop(2); // ~216
+      // A 250px expansion on row-2 (top=216) would need 216-250=-34 → down
+      const { expandsDown } = computeExpansionLayout(top, 250, 120, 640);
+      expect(expandsDown).toBe(true);
+    });
+
+    it('row-2 card expands up when there is enough room', () => {
+      const top = normalTop(2); // ~216
+      const { expandsDown } = computeExpansionLayout(top, 100, 120, 640);
+      expect(expandsDown).toBe(false);
+    });
+  });
+});

--- a/desktop/src/renderer/timeline/render/card-expansion.tsx
+++ b/desktop/src/renderer/timeline/render/card-expansion.tsx
@@ -5,10 +5,10 @@ import type { PreviewSize } from '../interactions/usePreviewSize';
 const md = new MarkdownIt({ html: false, linkify: true, breaks: false });
 
 /**
- * Rewrite relative image src attributes to notes-asset:// URLs so Electron
- * can serve them from the campaign directory.
+ * Rewrite relative image src attributes to notes-asset:// URLs.
+ * The main process resolves notes-asset://current/<relPath> against currentCampaignPath.
  */
-function fixImageUrls(el: HTMLElement, campaignPath: string): void {
+function fixImageUrls(el: HTMLElement): void {
   for (const img of el.querySelectorAll<HTMLImageElement>('img[src]')) {
     const src = img.getAttribute('src') ?? '';
     if (
@@ -20,16 +20,13 @@ function fixImageUrls(el: HTMLElement, campaignPath: string): void {
     ) {
       continue;
     }
-    // notes-asset://current/<relPath> → resolved relative to campaignPath in main process
     img.setAttribute('src', `notes-asset://current/events/${encodeURIComponent(src)}`);
-    void campaignPath; // used conceptually; main process uses currentCampaignPath
   }
 }
 
 interface CardExpansionProps {
   body: string | null;
   expandsDown: boolean;
-  campaignPath: string;
   size: PreviewSize;
   centerX: number;
   onSizeChange: (s: PreviewSize) => void;
@@ -40,7 +37,6 @@ interface CardExpansionProps {
 export function CardExpansion({
   body,
   expandsDown,
-  campaignPath,
   size,
   centerX,
   onSizeChange,
@@ -54,9 +50,9 @@ export function CardExpansion({
   // Callback ref: after the body div mounts, rewrite any relative image URLs
   const bodyRef = useCallback(
     (el: HTMLDivElement | null) => {
-      if (el && body !== null) fixImageUrls(el, campaignPath);
+      if (el && body !== null) fixImageUrls(el);
     },
-    [body, campaignPath],
+    [body],
   );
 
   const handleResizeMouseDown = useCallback(

--- a/desktop/src/renderer/timeline/render/card-expansion.tsx
+++ b/desktop/src/renderer/timeline/render/card-expansion.tsx
@@ -1,0 +1,160 @@
+import { useRef, useCallback, type CSSProperties, type ReactElement } from 'react';
+import MarkdownIt from 'markdown-it';
+import type { PreviewSize } from '../interactions/usePreviewSize';
+
+const md = new MarkdownIt({ html: false, linkify: true, breaks: false });
+
+/**
+ * Rewrite relative image src attributes to notes-asset:// URLs so Electron
+ * can serve them from the campaign directory.
+ */
+function fixImageUrls(el: HTMLElement, campaignPath: string): void {
+  for (const img of el.querySelectorAll<HTMLImageElement>('img[src]')) {
+    const src = img.getAttribute('src') ?? '';
+    if (
+      src.startsWith('http') ||
+      src.startsWith('data:') ||
+      src.startsWith('notes-asset:') ||
+      src.startsWith('file:') ||
+      src.startsWith('/')
+    ) {
+      continue;
+    }
+    // notes-asset://current/<relPath> → resolved relative to campaignPath in main process
+    img.setAttribute('src', `notes-asset://current/events/${encodeURIComponent(src)}`);
+    void campaignPath; // used conceptually; main process uses currentCampaignPath
+  }
+}
+
+interface CardExpansionProps {
+  body: string | null;
+  expandsDown: boolean;
+  campaignPath: string;
+  size: PreviewSize;
+  centerX: number;
+  onSizeChange: (s: PreviewSize) => void;
+  /** Called with a boolean indicating whether a resize drag is in progress */
+  onResizeDragChange: (active: boolean) => void;
+}
+
+export function CardExpansion({
+  body,
+  expandsDown,
+  campaignPath,
+  size,
+  centerX,
+  onSizeChange,
+  onResizeDragChange,
+}: CardExpansionProps): ReactElement {
+  // Ref to the expansion container element (owns the height we resize)
+  const expRef = useRef<HTMLDivElement>(null);
+
+  const renderedHtml = body !== null ? md.render(body) : null;
+
+  // Callback ref: after the body div mounts, rewrite any relative image URLs
+  const bodyRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      if (el && body !== null) fixImageUrls(el, campaignPath);
+    },
+    [body, campaignPath],
+  );
+
+  const handleResizeMouseDown = useCallback(
+    (dir: 'nw' | 'ne' | 'sw' | 'se') => (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const expEl = expRef.current;
+      if (!expEl) return;
+      // Walk up to the card element (direct parent)
+      const cardEl = expEl.parentElement as HTMLElement | null;
+      if (!cardEl) return;
+
+      onResizeDragChange(true);
+
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const startW = cardEl.offsetWidth;
+      const startH = expEl.offsetHeight;
+      const startTop = parseFloat(cardEl.style.top);
+
+      const onMove = (me: MouseEvent) => {
+        const dx = me.clientX - startX;
+        const dy = me.clientY - startY;
+
+        // Symmetric width resize around the timeline anchor point (centerX)
+        const isWest = dir === 'nw' || dir === 'sw';
+        const newW = Math.max(200, startW + (isWest ? -dx : dx) * 2);
+        cardEl.style.width = `${newW}px`;
+        cardEl.style.left = `${centerX - newW / 2}px`;
+
+        if (expandsDown) {
+          const newH = Math.max(100, startH + dy);
+          expEl.style.height = `${newH}px`;
+        } else {
+          const newH = Math.max(100, startH - dy);
+          const newTop = startTop + (startH - newH);
+          if (newTop < 0) {
+            expEl.style.height = `${Math.max(100, startH + startTop)}px`;
+            cardEl.style.top = '0px';
+          } else {
+            expEl.style.height = `${newH}px`;
+            cardEl.style.top = `${newTop}px`;
+          }
+        }
+      };
+
+      const onUp = () => {
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+
+        onResizeDragChange(false);
+        onSizeChange({
+          width: cardEl.offsetWidth,
+          expandedHeight: expRef.current?.offsetHeight ?? size.expandedHeight,
+        });
+
+        // The mouseup fires just before a click event; block that click so it
+        // doesn't collapse the expansion immediately after a resize.
+        document.addEventListener('click', (ev) => ev.stopPropagation(), {
+          capture: true,
+          once: true,
+        });
+      };
+
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    },
+    [centerX, expandsDown, onResizeDragChange, onSizeChange, size.expandedHeight],
+  );
+
+  const dirs = expandsDown ? (['sw', 'se'] as const) : (['nw', 'ne'] as const);
+
+  return (
+    <div
+      ref={expRef}
+      className={`event-card-expanded${expandsDown ? ' expands-down' : ''}`}
+      style={{ height: size.expandedHeight } as CSSProperties}
+    >
+      {renderedHtml !== null ? (
+        <div
+          ref={bodyRef}
+          className="exp-body markdown-body"
+          // markdown-it renders with html:false so no XSS risk
+          dangerouslySetInnerHTML={{ __html: renderedHtml }}
+        />
+      ) : (
+        <div className="exp-body">
+          <span className="exp-loading">Loading…</span>
+        </div>
+      )}
+      {dirs.map((dir) => (
+        <div
+          key={dir}
+          className={`resize-handle resize-handle-${dir}`}
+          onMouseDown={handleResizeMouseDown(dir)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/desktop/src/renderer/timeline/render/card-expansion.tsx
+++ b/desktop/src/renderer/timeline/render/card-expansion.tsx
@@ -1,27 +1,12 @@
 import { useRef, useCallback, type CSSProperties, type ReactElement } from 'react';
-import MarkdownIt from 'markdown-it';
+import { MarkdownPreview } from '../../shared/markdown-editor';
 import type { PreviewSize } from '../interactions/usePreviewSize';
 
-const md = new MarkdownIt({ html: false, linkify: true, breaks: false });
+const ABSOLUTE_SRC_RE = /^(?:https?:|data:|notes-asset:|file:|\/)/;
 
-/**
- * Rewrite relative image src attributes to notes-asset:// URLs.
- * The main process resolves notes-asset://current/<relPath> against currentCampaignPath.
- */
-function fixImageUrls(el: HTMLElement): void {
-  for (const img of el.querySelectorAll<HTMLImageElement>('img[src]')) {
-    const src = img.getAttribute('src') ?? '';
-    if (
-      src.startsWith('http') ||
-      src.startsWith('data:') ||
-      src.startsWith('notes-asset:') ||
-      src.startsWith('file:') ||
-      src.startsWith('/')
-    ) {
-      continue;
-    }
-    img.setAttribute('src', `notes-asset://current/events/${encodeURIComponent(src)}`);
-  }
+function resolveEventImageSrc(src: string): string {
+  if (ABSOLUTE_SRC_RE.test(src)) return src;
+  return `notes-asset://current/events/${encodeURIComponent(src)}`;
 }
 
 interface CardExpansionProps {
@@ -44,16 +29,6 @@ export function CardExpansion({
 }: CardExpansionProps): ReactElement {
   // Ref to the expansion container element (owns the height we resize)
   const expRef = useRef<HTMLDivElement>(null);
-
-  const renderedHtml = body !== null ? md.render(body) : null;
-
-  // Callback ref: after the body div mounts, rewrite any relative image URLs
-  const bodyRef = useCallback(
-    (el: HTMLDivElement | null) => {
-      if (el && body !== null) fixImageUrls(el);
-    },
-    [body],
-  );
 
   const handleResizeMouseDown = useCallback(
     (dir: 'nw' | 'ne' | 'sw' | 'se') => (e: React.MouseEvent) => {
@@ -132,12 +107,11 @@ export function CardExpansion({
       className={`event-card-expanded${expandsDown ? ' expands-down' : ''}`}
       style={{ height: size.expandedHeight } as CSSProperties}
     >
-      {renderedHtml !== null ? (
-        <div
-          ref={bodyRef}
-          className="exp-body markdown-body"
-          // markdown-it renders with html:false so no XSS risk
-          dangerouslySetInnerHTML={{ __html: renderedHtml }}
+      {body !== null ? (
+        <MarkdownPreview
+          className="exp-body"
+          content={body}
+          images={{ resolveSrc: resolveEventImageSrc }}
         />
       ) : (
         <div className="exp-body">

--- a/desktop/src/renderer/timeline/render/cards.css
+++ b/desktop/src/renderer/timeline/render/cards.css
@@ -26,7 +26,24 @@
   gap: 2px;
 }
 
+.event-card-date {
+  font-size: 12px;
+  color: var(--theme-text-muted, #7a6f58);
+  font-family: ui-monospace, 'Consolas', monospace;
+  letter-spacing: 0.03em;
+}
+
+/* ===== Title row: title + action buttons ===== */
+
+.event-card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
 .event-card-title {
+  flex: 1;
   font-size: 15px;
   font-weight: 500;
   color: var(--theme-text-primary, #d8d0b8);
@@ -35,12 +52,140 @@
   text-overflow: ellipsis;
 }
 
-.event-card-date {
-  font-size: 12px;
-  color: var(--theme-text-muted, #7a6f58);
-  font-family: ui-monospace, 'Consolas', monospace;
-  letter-spacing: 0.03em;
+.event-card-actions {
+  display: none;
+  gap: 2px;
+  flex-shrink: 0;
 }
+
+.event-card.is-expanded .event-card-actions {
+  display: flex;
+}
+
+.event-card-action-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  background: transparent;
+  color: var(--theme-text-muted, #7a6f58);
+  padding: 0;
+}
+.event-card-action-btn:hover {
+  background: var(--theme-panel-accent, #3a4d35);
+}
+.event-card-action-btn--primary:hover {
+  color: var(--theme-accent, #6a9a4a);
+}
+.event-card-action-btn--danger:hover {
+  color: var(--theme-danger, #c06040);
+}
+
+/* ===== Tags — hidden when collapsed ===== */
+
+.event-card-tags {
+  display: none;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.event-card.is-expanded .event-card-tags {
+  display: flex;
+}
+
+.event-card-tag {
+  font-size: 11px;
+  font-family: ui-monospace, 'Consolas', monospace;
+  background: var(--theme-panel-accent, #3a4d35);
+  color: var(--theme-text-secondary, #a89a80);
+  border: 1px solid var(--theme-border, #3a3a30);
+  border-radius: 999px;
+  padding: 2px 8px;
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.4;
+}
+
+/* ===== Expanded card ===== */
+
+.event-card.is-expanded {
+  z-index: 30;
+  overflow: visible;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.8);
+  border-color: var(--theme-border-strong, #5a4530);
+}
+
+.event-card-expanded {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: 10px 12px 8px;
+  border-bottom: 1px solid var(--theme-border, #3a3a30);
+  overflow: hidden;
+}
+
+.event-card-expanded.expands-down {
+  border-bottom: none;
+  border-top: 1px solid var(--theme-border, #3a3a30);
+}
+
+.exp-body {
+  flex: 1;
+  overflow-y: auto;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--theme-text-primary, #d8d0b8);
+  min-height: 0;
+}
+
+.exp-loading {
+  color: var(--theme-text-muted, #7a6f58);
+  font-style: italic;
+}
+
+/* ===== Resize handles ===== */
+
+.resize-handle {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  z-index: 2;
+  opacity: 0.65;
+  transition: opacity 0.15s;
+}
+.resize-handle:hover {
+  opacity: 1;
+}
+
+.resize-handle::before,
+.resize-handle::after {
+  content: '';
+  position: absolute;
+  background: var(--theme-accent-gold, #c9a860);
+  border-radius: 1px;
+}
+
+.resize-handle-nw { top: 3px; left: 3px; cursor: nw-resize; }
+.resize-handle-nw::before { top: 0; left: 0; width: 8px; height: 2px; }
+.resize-handle-nw::after  { top: 0; left: 0; width: 2px; height: 8px; }
+
+.resize-handle-ne { top: 3px; right: 3px; cursor: ne-resize; }
+.resize-handle-ne::before { top: 0; right: 0; width: 8px; height: 2px; }
+.resize-handle-ne::after  { top: 0; right: 0; width: 2px; height: 8px; }
+
+.resize-handle-sw { bottom: 3px; left: 3px; cursor: sw-resize; }
+.resize-handle-sw::before { bottom: 0; left: 0; width: 8px; height: 2px; }
+.resize-handle-sw::after  { bottom: 0; left: 0; width: 2px; height: 8px; }
+
+.resize-handle-se { bottom: 3px; right: 3px; cursor: se-resize; }
+.resize-handle-se::before { bottom: 0; right: 0; width: 8px; height: 2px; }
+.resize-handle-se::after  { bottom: 0; right: 0; width: 2px; height: 8px; }
 
 /* ===== Connector line and axis dot ===== */
 

--- a/desktop/src/renderer/timeline/render/cards.css
+++ b/desktop/src/renderer/timeline/render/cards.css
@@ -137,11 +137,30 @@
 
 .exp-body {
   flex: 1;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+/* Override notes-editor padding/font within the compact card preview */
+.exp-body .cm-scroller {
+  padding: 6px 8px;
+}
+
+.exp-body .cm-content {
   font-size: 13px;
   line-height: 1.5;
+  font-family: inherit;
   color: var(--theme-text-primary, #d8d0b8);
-  min-height: 0;
+}
+
+/* No edit cursor or active-line highlight in the read-only preview */
+.exp-body .cm-cursor {
+  display: none;
+}
+
+.exp-body .cm-activeLine {
+  background: transparent;
 }
 
 .exp-loading {

--- a/desktop/src/renderer/timeline/render/cards.css
+++ b/desktop/src/renderer/timeline/render/cards.css
@@ -125,7 +125,6 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  padding: 10px 12px 8px;
   border-bottom: 1px solid var(--theme-border, #3a3a30);
   overflow: hidden;
 }

--- a/desktop/src/renderer/timeline/render/cards.ts
+++ b/desktop/src/renderer/timeline/render/cards.ts
@@ -62,6 +62,30 @@ export function layoutCards(
   });
 }
 
+export interface ExpansionLayout {
+  expandsDown: boolean;
+  cardTop: number;
+  cardWidth: number;
+}
+
+/**
+ * Compute geometry for an expanded card.
+ *
+ * Returns whether the expanded section opens downward (to stay on-screen),
+ * the adjusted top of the card element, and the card width (at least previewWidth).
+ */
+export function computeExpansionLayout(
+  normalTop: number,
+  expandedHeight: number,
+  normalWidth: number,
+  previewWidth: number,
+): ExpansionLayout {
+  const expandsDown = normalTop - expandedHeight < 0;
+  const cardTop = expandsDown ? normalTop : normalTop - expandedHeight;
+  const cardWidth = Math.max(normalWidth, previewWidth);
+  return { expandsDown, cardTop, cardWidth };
+}
+
 export function assignRows(laidOut: LaidOutCard[]): Map<string, CardPlacement> {
   const rows: { left: number; right: number }[][] = [];
   const sorted = [...laidOut].sort((a, b) => a.x - b.x);

--- a/desktop/src/renderer/timeline/render/cards.tsx
+++ b/desktop/src/renderer/timeline/render/cards.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, type CSSProperties, type ReactElement } from 'react';
+import { useCallback, useMemo, type CSSProperties, type ReactElement } from 'react';
 import './cards.css';
 import type { EventListItem, Palette } from '../data/types';
 import type { ViewState, ViewportSize } from '../math/zoom';
@@ -39,7 +39,6 @@ interface CardsProps {
   size: ViewportSize;
   palette: Palette;
   inGameNowSeconds: number;
-  campaignPath: string;
   expansion: CardExpansionState | null;
   previewSize: PreviewSize;
   onCardClick: (filename: string) => void;
@@ -53,7 +52,6 @@ export function Cards({
   size,
   palette,
   inGameNowSeconds,
-  campaignPath,
   expansion,
   previewSize,
   onCardClick,
@@ -120,7 +118,6 @@ export function Cards({
             expandsDown={expandsDown}
             expansion={expansion}
             previewSize={previewSize}
-            campaignPath={campaignPath}
             onCardClick={onCardClick}
             onPreviewSizeChange={onPreviewSizeChange}
             onResizeDragChange={onResizeDragChange}
@@ -140,7 +137,6 @@ interface CardItemProps {
   expandsDown: boolean;
   expansion: CardExpansionState | null;
   previewSize: PreviewSize;
-  campaignPath: string;
   onCardClick: (filename: string) => void;
   onPreviewSizeChange: (s: PreviewSize) => void;
   onResizeDragChange: (active: boolean) => void;
@@ -155,13 +151,10 @@ function CardItem({
   expandsDown,
   expansion,
   previewSize,
-  campaignPath,
   onCardClick,
   onPreviewSizeChange,
   onResizeDragChange,
 }: CardItemProps): ReactElement {
-  const cardRef = useRef<HTMLDivElement>(null);
-
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
@@ -174,7 +167,6 @@ function CardItem({
     <CardExpansion
       body={expansion?.body ?? null}
       expandsDown={expandsDown}
-      campaignPath={campaignPath}
       size={previewSize}
       centerX={card.x}
       onSizeChange={onPreviewSizeChange}
@@ -186,7 +178,6 @@ function CardItem({
 
   return (
     <div
-      ref={cardRef}
       className={`event-card${card.isFuture ? ' is-future' : ''}${isExpanded ? ' is-expanded' : ''}`}
       style={
         {

--- a/desktop/src/renderer/timeline/render/cards.tsx
+++ b/desktop/src/renderer/timeline/render/cards.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type CSSProperties, type ReactElement } from 'react';
+import { useCallback, useMemo, useRef, type CSSProperties, type ReactElement } from 'react';
 import './cards.css';
 import type { EventListItem, Palette } from '../data/types';
 import type { ViewState, ViewportSize } from '../math/zoom';
@@ -7,11 +7,31 @@ import {
   layoutCards,
   assignRows,
   weekdayColorFromPalette,
+  computeExpansionLayout,
   CARD_HEIGHT,
   CARD_GAP,
   type LaidOutCard,
   type CardPlacement,
 } from './cards';
+import type { CardExpansionState } from '../interactions/useCardExpansion';
+import type { PreviewSize } from '../interactions/usePreviewSize';
+import { CardExpansion } from './card-expansion';
+
+// MIT-licensed Heroicons v1 paths
+const ICON_EDIT = (
+  <svg viewBox="0 0 20 20" fill="currentColor" width="14" height="14" aria-hidden="true">
+    <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+  </svg>
+);
+const ICON_DELETE = (
+  <svg viewBox="0 0 20 20" fill="currentColor" width="14" height="14" aria-hidden="true">
+    <path
+      fillRule="evenodd"
+      d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
+      clipRule="evenodd"
+    />
+  </svg>
+);
 
 interface CardsProps {
   events: EventListItem[];
@@ -19,6 +39,12 @@ interface CardsProps {
   size: ViewportSize;
   palette: Palette;
   inGameNowSeconds: number;
+  campaignPath: string;
+  expansion: CardExpansionState | null;
+  previewSize: PreviewSize;
+  onCardClick: (filename: string) => void;
+  onPreviewSizeChange: (s: PreviewSize) => void;
+  onResizeDragChange: (active: boolean) => void;
 }
 
 export function Cards({
@@ -27,6 +53,12 @@ export function Cards({
   size,
   palette,
   inGameNowSeconds,
+  campaignPath,
+  expansion,
+  previewSize,
+  onCardClick,
+  onPreviewSizeChange,
+  onResizeDragChange,
 }: CardsProps): ReactElement | null {
   const laidOut = useMemo(
     () => layoutCards(events, view, size, inGameNowSeconds),
@@ -43,13 +75,7 @@ export function Cards({
   const axisY = Math.floor(size.height * 0.8);
 
   return (
-    <div
-      style={{
-        position: 'absolute',
-        inset: 0,
-        pointerEvents: 'none',
-      }}
-    >
+    <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
       {/* Connectors first so cards render on top */}
       {placed.map((card) => (
         <div
@@ -70,29 +96,149 @@ export function Cards({
         />
       ))}
       {placed.map((card) => {
-        const cardTop = axisY - CARD_HEIGHT - CARD_GAP - card.row * (CARD_HEIGHT + CARD_GAP);
+        const isExpanded = expansion?.filename === card.event.filename;
+        const normalTop = axisY - CARD_HEIGHT - CARD_GAP - card.row * (CARD_HEIGHT + CARD_GAP);
+        const { expandsDown, cardTop, cardWidth } = isExpanded
+          ? computeExpansionLayout(
+              normalTop,
+              previewSize.expandedHeight,
+              card.width,
+              previewSize.width,
+            )
+          : { expandsDown: false, cardTop: normalTop, cardWidth: card.width };
+
         const color = card.event.color ?? weekdayColorFromPalette(card.parsedDate, palette);
+
         return (
-          <div
+          <CardItem
             key={card.event.filename}
-            className={`event-card${card.isFuture ? ' is-future' : ''}`}
-            style={
-              {
-                left: card.x - card.width / 2,
-                width: card.width,
-                top: cardTop,
-                '--weekday-color': color,
-              } as CSSProperties
-            }
-          >
-            <div className="event-card-header" />
-            <div className="event-card-body">
-              <div className="event-card-title">{card.event.title}</div>
-              <div className="event-card-date">{formatCardFace(card.parsedDate)}</div>
-            </div>
-          </div>
+            card={card}
+            isExpanded={isExpanded}
+            cardTop={cardTop}
+            cardWidth={cardWidth}
+            color={color}
+            expandsDown={expandsDown}
+            expansion={expansion}
+            previewSize={previewSize}
+            campaignPath={campaignPath}
+            onCardClick={onCardClick}
+            onPreviewSizeChange={onPreviewSizeChange}
+            onResizeDragChange={onResizeDragChange}
+          />
         );
       })}
+    </div>
+  );
+}
+
+interface CardItemProps {
+  card: LaidOutCard & CardPlacement;
+  isExpanded: boolean;
+  cardTop: number;
+  cardWidth: number;
+  color: string;
+  expandsDown: boolean;
+  expansion: CardExpansionState | null;
+  previewSize: PreviewSize;
+  campaignPath: string;
+  onCardClick: (filename: string) => void;
+  onPreviewSizeChange: (s: PreviewSize) => void;
+  onResizeDragChange: (active: boolean) => void;
+}
+
+function CardItem({
+  card,
+  isExpanded,
+  cardTop,
+  cardWidth,
+  color,
+  expandsDown,
+  expansion,
+  previewSize,
+  campaignPath,
+  onCardClick,
+  onPreviewSizeChange,
+  onResizeDragChange,
+}: CardItemProps): ReactElement {
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onCardClick(card.event.filename);
+    },
+    [card.event.filename, onCardClick],
+  );
+
+  const expansionEl = isExpanded ? (
+    <CardExpansion
+      body={expansion?.body ?? null}
+      expandsDown={expandsDown}
+      campaignPath={campaignPath}
+      size={previewSize}
+      centerX={card.x}
+      onSizeChange={onPreviewSizeChange}
+      onResizeDragChange={onResizeDragChange}
+    />
+  ) : null;
+
+  const tags = card.event.tags;
+
+  return (
+    <div
+      ref={cardRef}
+      className={`event-card${card.isFuture ? ' is-future' : ''}${isExpanded ? ' is-expanded' : ''}`}
+      style={
+        {
+          left: card.x - cardWidth / 2,
+          width: cardWidth,
+          top: cardTop,
+          '--weekday-color': color,
+          pointerEvents: 'auto',
+        } as CSSProperties
+      }
+      onClick={handleClick}
+    >
+      {/* Expansion section above the card face when opening upward */}
+      {isExpanded && !expandsDown && expansionEl}
+
+      <div className="event-card-header" />
+      <div className="event-card-body">
+        <div className="event-card-title-row">
+          <div className="event-card-title">{card.event.title}</div>
+          <div className="event-card-actions">
+            <button
+              className="event-card-action-btn event-card-action-btn--danger"
+              data-action="delete"
+              title="Delete"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {ICON_DELETE}
+            </button>
+            <button
+              className="event-card-action-btn event-card-action-btn--primary"
+              data-action="edit"
+              title="Edit"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {ICON_EDIT}
+            </button>
+          </div>
+        </div>
+        <div className="event-card-date">{formatCardFace(card.parsedDate)}</div>
+        {tags && tags.length > 0 && (
+          <div className="event-card-tags">
+            {tags.map((t) => (
+              <span key={t} className="event-card-tag">
+                {t}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Expansion section below the card face when opening downward */}
+      {isExpanded && expandsDown && expansionEl}
     </div>
   );
 }

--- a/desktop/src/renderer/views/campaigns/campaign-manager.tsx
+++ b/desktop/src/renderer/views/campaigns/campaign-manager.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Campaign } from '../../types/global';
+import { useState } from 'react';
+import { Campaign } from '../../../types/global';
 
 interface CampaignManagerProps {
   campaigns: Campaign[];

--- a/desktop/src/renderer/views/notes/notes-view.tsx
+++ b/desktop/src/renderer/views/notes/notes-view.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { NotesApp } from '../../notes/notes';
 
 export function NotesView({

--- a/desktop/src/renderer/views/notes/sidebar.tsx
+++ b/desktop/src/renderer/views/notes/sidebar.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { FileEntry } from '../useFiles';
+import { FileEntry } from '../../hooks/useFiles';
 
 interface SidebarProps {
   files: FileEntry[];

--- a/desktop/src/renderer/views/relationships/relationships-view.tsx
+++ b/desktop/src/renderer/views/relationships/relationships-view.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { FooterPortal } from '../../components/footer-portal';
 
 export function RelationshipsView() {

--- a/desktop/src/renderer/views/setup/directory-picker.tsx
+++ b/desktop/src/renderer/views/setup/directory-picker.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 interface DirectoryPickerProps {
   onSelect: (path: string) => void;
 }

--- a/desktop/src/renderer/views/timeline/timeline-view.tsx
+++ b/desktop/src/renderer/views/timeline/timeline-view.tsx
@@ -130,7 +130,6 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
           size={viewportSize}
           palette={loadedData.palette}
           inGameNowSeconds={inGameNowSeconds}
-          campaignPath={campaignPath}
           expansion={expansion}
           previewSize={previewSize}
           onCardClick={handleCardClick}

--- a/desktop/src/renderer/views/timeline/timeline-view.tsx
+++ b/desktop/src/renderer/views/timeline/timeline-view.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { timelinePort } from '../../timeline/data/ports';
 import type { EventListItem, Palette, Session, State } from '../../timeline/data/types';
 import {
@@ -14,6 +14,8 @@ import { NowMarker } from '../../timeline/render/now-marker';
 import { SessionBands } from '../../timeline/render/session-bands.tsx';
 import { usePan } from '../../timeline/interactions/usePan';
 import { useZoom } from '../../timeline/interactions/useZoom';
+import { useCardExpansion } from '../../timeline/interactions/useCardExpansion';
+import { usePreviewSize } from '../../timeline/interactions/usePreviewSize';
 
 interface TimelineViewProps {
   campaignPath: string;
@@ -39,6 +41,12 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
     sessions: [],
   });
 
+  // Whether a resize drag is in progress — used to suppress pan during resize
+  const resizingRef = useRef(false);
+  const handleResizeDragChange = useCallback((active: boolean) => {
+    resizingRef.current = active;
+  }, []);
+
   const viewportRef = useRef<HTMLDivElement>(null);
 
   // Keep refs in sync so event-handler closures always see the latest state.
@@ -47,8 +55,13 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
   viewRef.current = viewState;
   sizeRef.current = viewportSize;
 
-  usePan(viewportRef, viewRef, setViewState);
+  const pan = usePan(viewportRef, viewRef, setViewState, {
+    isOtherDragActive: () => resizingRef.current,
+  });
   useZoom(viewportRef, viewRef, sizeRef, setViewState);
+
+  const [previewSize, savePreviewSize] = usePreviewSize();
+  const { expansion, handleCardClick } = useCardExpansion(campaignPath, pan);
 
   useEffect(() => {
     const el = viewportRef.current;
@@ -117,6 +130,12 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
           size={viewportSize}
           palette={loadedData.palette}
           inGameNowSeconds={inGameNowSeconds}
+          campaignPath={campaignPath}
+          expansion={expansion}
+          previewSize={previewSize}
+          onCardClick={handleCardClick}
+          onPreviewSizeChange={savePreviewSize}
+          onResizeDragChange={handleResizeDragChange}
         />
       )}
       {loadedData.palette && inGameNow && (


### PR DESCRIPTION
Closes #84. Part of #67.

## Summary

- **Click to expand**: clicking a card opens an inline markdown preview panel; clicking again collapses it. Only one card expanded at a time. Click is suppressed when `pan.wasMoved()` is true (drag vs click).
- **Escape to collapse**: Esc key collapses while any expansion is open.
- **Resize handles**: corner drag handles (nw/ne up-expand, sw/se down-expand) resize the panel symmetrically around the timeline anchor. Pan is suppressed during resize via `isOtherDragActive`. A post-resize capture-phase click listener prevents the trailing mouseup→click from immediately collapsing the card.
- **localStorage persistence**: preview size (`width` + `expandedHeight`) is saved on mouseup and restored on next expansion.
- **Markdown rendering**: body rendered via the shared `MarkdownEditor` (CodeMirror 6) in read-only live-decoration mode via the new `<MarkdownPreview>` component. Relative image `src` attributes are rewritten to `notes-asset://current/events/{src}` via `imageDecorations`'s new `resolveSrc` hook. No second markdown library needed.
- **Action buttons**: edit/delete buttons render in the title row when expanded; handlers are stubbed for wiring by the event editor task.
- **Tags**: tags row shown only when expanded.

## Architecture

| Concern | File |
|---|---|
| Layout math | `computeExpansionLayout` added to `render/cards.ts` |
| Expansion state + IO | `interactions/useCardExpansion.ts` |
| Size persistence | `interactions/usePreviewSize.ts` |
| Render | `render/card-expansion.tsx`, updated `render/cards.tsx` |
| Wiring | `views/timeline/timeline-view.tsx` |
| Styles | `render/cards.css` |
| Read-only preview | `shared/markdown-editor/markdown-preview.tsx` (new) |

## Shared editor changes

- `MarkdownEditor` gains a `readOnly` prop (suppresses `highlightActiveLine`, adds `EditorState.readOnly` + `EditorView.editable.of(false)`); `onChange` becomes optional when `readOnly` is true.
- `imageDecorations` now accepts `ImageDecorationsOptions.resolveSrc` to transform raw image paths before rendering; regex broadened to match any `[alt](url)`. Default behaviour (notes-asset:// only) is unchanged.
- New `<MarkdownPreview>` wrapper exported from `shared/markdown-editor`; canonical entry point for any future read-only markdown surface.

## Tests

351 tests total (up from 315 on main):
- `card-expansion-layout.test.ts` — 11 tests: `computeExpansionLayout` up/down flip, cardTop, cardWidth, edge cases
- `usePreviewSize.test.ts` — 9 tests: load (6) + save path incl. quota-exceeded (3)
- `useCardExpansion.test.ts` — 10 tests: click suppression after drag, loading→loaded state, toggle-off, stale-fetch discard, mid-load collapse, `collapse()`, Escape key (active + inactive + wrong key)
- `markdown-editor.test.tsx` — 2 new tests: readOnly mount, non-editable contenteditable assertion
- `markdown-preview.test.tsx` — 3 new smoke tests: renders without onChange, className applied, read-only CM editor
- `image-decorations.test.ts` — updated + 2 new tests: broadened regex finds https/relative images, resolveSrc behaviour

## Scope check

`git diff --name-only main...HEAD | grep -v "^desktop/"` → empty. Zero changes outside `./desktop/`.

## Test plan

- [ ] Open a campaign, click a card → preview expands with markdown body (or "Loading…" briefly)
- [ ] Click same card again → collapses
- [ ] Click a different card → first collapses, second opens
- [ ] Press Escape → collapses
- [ ] Drag-pan the timeline, release → click suppressed (no expansion)
- [ ] Drag a resize handle → panel resizes; size persists after closing and reopening
- [ ] Card near the top of the viewport expands downward; card with room above expands upward
- [ ] Event with tags → chips visible in expanded state, hidden when collapsed
- [ ] Edit/delete buttons visible when expanded
- [ ] Images in event body with relative paths render correctly (via notes-asset:// rewrite)

https://claude.ai/code/session_01L2Pgwduh9gn2tTJRJqEP41