### PR TITLE
[Timeline][Mutation] Event editor integration (#88)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -19,6 +19,7 @@
     "rebuild:win": "taskkill /F /IM \"TableTop Timeline.exe\" /T /FI \"STATUS eq RUNNING\" & npm run package:win && start \"\" \"release/TableTop Timeline Setup 1.0.0.exe\"",
     "test": "vitest",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
     "preview": "vite preview"
   },
   "build": {

--- a/desktop/src/renderer/timeline/event-editor/EventEditorModal.css
+++ b/desktop/src/renderer/timeline/event-editor/EventEditorModal.css
@@ -16,8 +16,8 @@
   border: 1px solid var(--theme-border-strong, #5a4530);
   border-radius: 4px;
   box-shadow: 0 16px 48px rgba(0, 0, 0, 0.8);
-  width: min(960px, 92vw);
-  max-height: 90vh;
+  width: calc(100vw - 48px);
+  height: calc(100vh - 48px);
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/desktop/src/renderer/timeline/event-editor/EventEditorModal.css
+++ b/desktop/src/renderer/timeline/event-editor/EventEditorModal.css
@@ -1,0 +1,297 @@
+/* ===== Event Editor Modal ===== */
+
+.event-editor-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.event-editor-modal {
+  position: relative;
+  background: var(--theme-surface, #1e1e1a);
+  border: 1px solid var(--theme-border-strong, #5a4530);
+  border-radius: 4px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.8);
+  width: min(960px, 92vw);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* ===== Header ===== */
+
+.event-editor-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--theme-border, #3a3a30);
+  flex-shrink: 0;
+}
+
+.event-editor-title {
+  flex: 1;
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--theme-text-secondary, #a89a80);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.event-editor-save-status {
+  font-size: 12px;
+  color: var(--theme-text-muted, #7a6f58);
+  flex-shrink: 0;
+}
+
+.event-editor-save-status--dirty {
+  color: var(--theme-accent-gold, #c9a860);
+}
+
+.event-editor-save-status--saved {
+  color: var(--theme-accent, #6a9a4a);
+}
+
+.event-editor-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--theme-text-muted, #7a6f58);
+  font-size: 18px;
+  line-height: 1;
+  padding: 2px 4px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.event-editor-close:hover {
+  color: var(--theme-text-primary, #d8d0b8);
+  background: var(--theme-panel-accent, #3a4d35);
+}
+
+/* ===== Error banner ===== */
+
+.event-editor-error {
+  padding: 8px 14px;
+  background: rgba(192, 96, 64, 0.15);
+  border-bottom: 1px solid var(--theme-danger, #c06040);
+  color: var(--theme-danger, #c06040);
+  font-size: 13px;
+  flex-shrink: 0;
+}
+
+/* ===== Loading state ===== */
+
+.event-editor-loading {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--theme-text-muted, #7a6f58);
+  font-style: italic;
+  font-size: 14px;
+  padding: 32px;
+}
+
+.event-editor-loading--error {
+  color: var(--theme-danger, #c06040);
+}
+
+/* ===== Frontmatter fields ===== */
+
+.event-editor-fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px 16px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--theme-border, #3a3a30);
+  flex-shrink: 0;
+}
+
+.event-editor-field {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.event-editor-field-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--theme-text-muted, #7a6f58);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.event-editor-input {
+  background: var(--theme-bg, #09090b);
+  border: 1px solid var(--theme-border, #3a3a30);
+  border-radius: 2px;
+  color: var(--theme-text-primary, #d8d0b8);
+  font-size: 13px;
+  padding: 4px 7px;
+  outline: none;
+  font-family: inherit;
+}
+
+.event-editor-input:focus {
+  border-color: var(--theme-accent, #6a9a4a);
+}
+
+/* ===== Color row ===== */
+
+.event-editor-color-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.event-editor-color-select {
+  flex: 1;
+}
+
+.event-editor-color-custom {
+  width: 80px;
+  flex-shrink: 0;
+}
+
+.event-editor-color-swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 2px;
+  border: 1px solid var(--theme-border, #3a3a30);
+  flex-shrink: 0;
+}
+
+/* ===== Markdown editor body ===== */
+
+.event-editor-body {
+  flex: 1 1 auto;
+  min-height: 200px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.event-editor-body .markdown-editor-container {
+  flex: 1;
+  overflow: auto;
+}
+
+/* ===== Conflict overlay ===== */
+
+.event-editor-conflict-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(9, 9, 11, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  border-radius: 4px;
+}
+
+.event-editor-conflict-panel {
+  background: var(--theme-surface, #1e1e1a);
+  border: 1px solid var(--theme-border-strong, #5a4530);
+  border-radius: 4px;
+  padding: 20px 24px;
+  max-width: 400px;
+  text-align: center;
+}
+
+.event-editor-conflict-msg {
+  margin: 0 0 16px;
+  font-size: 14px;
+  color: var(--theme-text-primary, #d8d0b8);
+  line-height: 1.5;
+}
+
+.event-editor-conflict-btns {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+
+/* ===== Buttons ===== */
+
+.event-editor-btn {
+  padding: 5px 14px;
+  border: 1px solid var(--theme-border, #3a3a30);
+  border-radius: 2px;
+  background: var(--theme-surface, #1e1e1a);
+  color: var(--theme-text-secondary, #a89a80);
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.event-editor-btn:hover:not(:disabled) {
+  background: var(--theme-panel-accent, #3a4d35);
+  color: var(--theme-text-primary, #d8d0b8);
+}
+
+.event-editor-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.event-editor-btn--primary {
+  background: var(--theme-panel-accent, #3a4d35);
+  border-color: var(--theme-accent, #6a9a4a);
+  color: var(--theme-accent, #6a9a4a);
+  font-weight: 600;
+}
+
+.event-editor-btn--primary:hover:not(:disabled) {
+  background: #4d6640;
+  color: #8aba6a;
+}
+
+.event-editor-btn--danger {
+  color: var(--theme-danger, #c06040);
+}
+
+.event-editor-btn--danger:hover:not(:disabled) {
+  background: rgba(192, 96, 64, 0.15);
+  border-color: var(--theme-danger, #c06040);
+}
+
+/* ===== Footer slot buttons (inside FormatToolbar .ftb-right) ===== */
+
+.event-editor-footer-btns {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+/* ===== New Event floating button ===== */
+
+.timeline-new-event-btn {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  z-index: 10;
+  pointer-events: auto;
+  padding: 7px 14px;
+  background: var(--theme-panel-accent, #3a4d35);
+  border: 1px solid var(--theme-accent, #6a9a4a);
+  border-radius: 3px;
+  color: var(--theme-accent, #6a9a4a);
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+}
+
+.timeline-new-event-btn:hover {
+  background: #4d6640;
+  color: #8aba6a;
+}

--- a/desktop/src/renderer/timeline/event-editor/EventEditorModal.css
+++ b/desktop/src/renderer/timeline/event-editor/EventEditorModal.css
@@ -2,7 +2,10 @@
 
 .event-editor-overlay {
   position: fixed;
-  inset: 0;
+  top: 0;
+  right: 0;
+  bottom: 50px; /* footer height — don't cover the footer */
+  left: 0;
   background: rgba(0, 0, 0, 0.65);
   z-index: 1000;
   display: flex;
@@ -17,7 +20,7 @@
   border-radius: 4px;
   box-shadow: 0 16px 48px rgba(0, 0, 0, 0.8);
   width: calc(100vw - 48px);
-  height: calc(100vh - 48px);
+  height: calc(100vh - 50px - 48px); /* viewport minus footer minus 24px margins */
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/desktop/src/renderer/timeline/event-editor/EventEditorModal.tsx
+++ b/desktop/src/renderer/timeline/event-editor/EventEditorModal.tsx
@@ -74,7 +74,8 @@ export function EventEditorModal({
         console.error('[EventEditorModal] failed to load event', err);
         setLoadState('load-error');
       });
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps — intentional mount-once
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional mount-once: mode and campaignPath are stable per modal instance (key prop ensures remount on target change)
+  }, []);
 
   // Escape: close the modal (capture phase wins over useCardExpansion's handler)
   useEffect(() => {

--- a/desktop/src/renderer/timeline/event-editor/EventEditorModal.tsx
+++ b/desktop/src/renderer/timeline/event-editor/EventEditorModal.tsx
@@ -1,0 +1,404 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { EditorView } from '@codemirror/view';
+import { MarkdownEditor, FormatToolbar } from '../../shared/markdown-editor';
+import { timelinePort, ConflictError } from '../data/ports';
+import {
+  emptyBuffer,
+  bufferFromEvent,
+  bufferToFrontmatter,
+  validateBuffer,
+  deriveFilename,
+  getColorPresetValue,
+  COLOR_PRESETS,
+  type EditorBuffer,
+  type EditorMode,
+} from './domain';
+import './EventEditorModal.css';
+
+type SaveState = 'clean' | 'dirty' | 'saving' | 'error' | 'saved';
+type LoadState = 'loading' | 'ready' | 'load-error';
+type ConflictPending = { kind: 'save' } | { kind: 'delete' };
+
+const SAVED_BANNER_MS = 900;
+
+export interface EventEditorModalProps {
+  campaignPath: string;
+  mode: EditorMode;
+  onClose: () => void;
+  onSaved: (filename: string) => void;
+  onDeleted: (filename: string) => void;
+}
+
+export function EventEditorModal({
+  campaignPath,
+  mode,
+  onClose,
+  onSaved,
+  onDeleted,
+}: EventEditorModalProps) {
+  const [loadState, setLoadState] = useState<LoadState>(
+    mode.kind === 'edit' ? 'loading' : 'ready',
+  );
+  const [buffer, setBuffer] = useState<EditorBuffer>(
+    mode.kind === 'create' ? emptyBuffer(mode.initialDate) : emptyBuffer(),
+  );
+  const [saveState, setSaveState] = useState<SaveState>('clean');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [conflictPending, setConflictPending] = useState<ConflictPending | null>(null);
+
+  // Refs for stable access inside async callbacks without needing deps
+  const lastModifiedRef = useRef<string | null>(null);
+  const filenameRef = useRef<string | null>(mode.kind === 'edit' ? mode.filename : null);
+  const bufferRef = useRef<EditorBuffer>(buffer);
+  bufferRef.current = buffer;
+
+  const viewRef = useRef<EditorView | null>(null);
+
+  // Load event on mount in edit mode
+  useEffect(() => {
+    if (mode.kind !== 'edit') return;
+    timelinePort
+      .getEvent(campaignPath, mode.filename)
+      .then(({ event, lastModified }) => {
+        setBuffer(bufferFromEvent(event));
+        lastModifiedRef.current = lastModified;
+        setLoadState('ready');
+      })
+      .catch((err) => {
+        console.error('[EventEditorModal] failed to load event', err);
+        setLoadState('load-error');
+      });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps — intentional mount-once
+
+  // Escape: close the modal (capture phase wins over useCardExpansion's handler)
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      e.stopPropagation();
+      if (saveState === 'saving') return;
+      if (saveState === 'dirty' || saveState === 'error') {
+        if (!window.confirm('You have unsaved changes — close anyway?')) return;
+      }
+      onClose();
+    };
+    document.addEventListener('keydown', onKey, { capture: true });
+    return () => document.removeEventListener('keydown', onKey, { capture: true });
+  }, [saveState, onClose]);
+
+  const updateBuffer = useCallback((patch: Partial<EditorBuffer>) => {
+    setBuffer((prev) => ({ ...prev, ...patch }));
+    setSaveState((s) => (s === 'saving' ? s : 'dirty'));
+    setErrorMessage(null);
+  }, []);
+
+  // ---- Save ----
+
+  const doSave = useCallback(
+    async (overrideMtime?: string) => {
+      const current = bufferRef.current;
+      const validationError = validateBuffer(current);
+      if (validationError) {
+        setErrorMessage(validationError);
+        setSaveState('error');
+        return;
+      }
+      setSaveState('saving');
+      const frontmatter = bufferToFrontmatter(current);
+      const mtime = overrideMtime ?? lastModifiedRef.current;
+
+      try {
+        let result;
+        if (mode.kind === 'edit') {
+          result = await timelinePort.updateEvent(
+            campaignPath,
+            filenameRef.current!,
+            frontmatter,
+            current.body,
+            mtime!,
+          );
+        } else {
+          const filename = deriveFilename(current);
+          result = await timelinePort.createEvent(campaignPath, filename, frontmatter, current.body);
+          filenameRef.current = result.event.filename;
+        }
+        lastModifiedRef.current = result.lastModified;
+        setConflictPending(null);
+        setSaveState('saved');
+        setTimeout(() => onSaved(filenameRef.current!), SAVED_BANNER_MS);
+      } catch (err) {
+        if (err instanceof ConflictError) {
+          setSaveState('dirty');
+          setConflictPending({ kind: 'save' });
+          return;
+        }
+        setSaveState('error');
+        setErrorMessage(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [campaignPath, mode, onSaved],
+  );
+
+  // ---- Delete ----
+
+  const doDelete = useCallback(
+    async (overrideMtime?: string) => {
+      if (mode.kind !== 'edit') return;
+      const mtime = overrideMtime ?? lastModifiedRef.current;
+      setSaveState('saving');
+      try {
+        await timelinePort.deleteEvent(campaignPath, mode.filename, mtime!);
+        setConflictPending(null);
+        onDeleted(mode.filename);
+      } catch (err) {
+        if (err instanceof ConflictError) {
+          setSaveState('dirty');
+          setConflictPending({ kind: 'delete' });
+          return;
+        }
+        setSaveState('error');
+        setErrorMessage(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [campaignPath, mode, onDeleted],
+  );
+
+  // ---- Conflict overwrite: re-fetch mtime, then retry ----
+
+  const handleOverwrite = useCallback(async () => {
+    if (!conflictPending) return;
+    const filename = filenameRef.current ?? (mode.kind === 'edit' ? mode.filename : null);
+    if (!filename) return;
+    try {
+      const { lastModified: freshMtime } = await timelinePort.getEvent(campaignPath, filename);
+      if (conflictPending.kind === 'save') {
+        await doSave(freshMtime);
+      } else {
+        await doDelete(freshMtime);
+      }
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : String(err));
+      setSaveState('error');
+      setConflictPending(null);
+    }
+  }, [conflictPending, campaignPath, mode, doSave, doDelete]);
+
+  // Ctrl/Cmd+S shortcut
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 's') {
+        e.preventDefault();
+        if (saveState !== 'saving' && saveState !== 'saved') void doSave();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [saveState, doSave]);
+
+  const handleDeleteClick = useCallback(() => {
+    if (mode.kind !== 'edit') return;
+    const displayName = buffer.title || mode.filename;
+    if (!window.confirm(`Move "${displayName}" to trash?\n\nRecoverable via Settings → Trash.`)) return;
+    void doDelete();
+  }, [mode, buffer.title, doDelete]);
+
+  const colorPresetValue = getColorPresetValue(buffer.color);
+  const isEditMode = mode.kind === 'edit';
+  const isBusy = saveState === 'saving' || saveState === 'saved';
+
+  const footerSlot = (
+    <div className="event-editor-footer-btns">
+      {isEditMode && (
+        <button
+          type="button"
+          className="event-editor-btn event-editor-btn--danger"
+          onClick={handleDeleteClick}
+          disabled={isBusy || loadState !== 'ready'}
+        >
+          Delete
+        </button>
+      )}
+      <button
+        type="button"
+        className="event-editor-btn"
+        onClick={onClose}
+        disabled={saveState === 'saving'}
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        className="event-editor-btn event-editor-btn--primary"
+        onClick={() => void doSave()}
+        disabled={isBusy || saveState === 'clean' || loadState !== 'ready'}
+      >
+        {saveState === 'saving' ? 'Saving…' : saveState === 'saved' ? '✓ Saved' : 'Save'}
+      </button>
+    </div>
+  );
+
+  return (
+    <div
+      className="event-editor-overlay"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !isBusy) onClose();
+      }}
+    >
+      <div className="event-editor-modal">
+        {/* Header */}
+        <div className="event-editor-header">
+          <h2 className="event-editor-title">
+            {isEditMode ? `Edit: ${mode.filename}` : 'New event'}
+          </h2>
+          <div className={`event-editor-save-status event-editor-save-status--${saveState}`}>
+            {saveState === 'dirty'
+              ? '• unsaved'
+              : saveState === 'saving'
+                ? 'saving…'
+                : saveState === 'saved'
+                  ? '✓ saved'
+                  : ''}
+          </div>
+          <button
+            type="button"
+            className="event-editor-close"
+            aria-label="Close"
+            onClick={onClose}
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Error banner */}
+        {saveState === 'error' && errorMessage && (
+          <div className="event-editor-error">⚠ {errorMessage}</div>
+        )}
+
+        {/* Loading / load-error */}
+        {loadState === 'loading' && <div className="event-editor-loading">Loading…</div>}
+        {loadState === 'load-error' && (
+          <div className="event-editor-loading event-editor-loading--error">
+            Failed to load event.
+          </div>
+        )}
+
+        {loadState === 'ready' && (
+          <>
+            {/* Frontmatter fields */}
+            <div className="event-editor-fields">
+              <label className="event-editor-field">
+                <span className="event-editor-field-label">Title</span>
+                <input
+                  type="text"
+                  className="event-editor-input"
+                  value={buffer.title}
+                  onChange={(e) => updateBuffer({ title: e.target.value })}
+                  autoComplete="off"
+                />
+              </label>
+
+              <label className="event-editor-field">
+                <span className="event-editor-field-label">Date (Golarian ISO)</span>
+                <input
+                  type="text"
+                  className="event-editor-input"
+                  value={buffer.date}
+                  onChange={(e) => updateBuffer({ date: e.target.value })}
+                  placeholder="4726-05-04T09:30"
+                  autoComplete="off"
+                />
+              </label>
+
+              <label className="event-editor-field">
+                <span className="event-editor-field-label">Tags (comma-separated)</span>
+                <input
+                  type="text"
+                  className="event-editor-input"
+                  value={buffer.tagsText}
+                  onChange={(e) => updateBuffer({ tagsText: e.target.value })}
+                  placeholder="plot:beast, location:fort"
+                  autoComplete="off"
+                />
+              </label>
+
+              <div className="event-editor-field">
+                <span className="event-editor-field-label">Colour</span>
+                <div className="event-editor-color-row">
+                  <select
+                    className="event-editor-input event-editor-color-select"
+                    value={colorPresetValue}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      // Switching to Custom clears color so the user can type; other presets set directly
+                      updateBuffer({ color: val === '__custom__' ? '' : val });
+                    }}
+                  >
+                    {COLOR_PRESETS.map((p) => (
+                      <option key={p.value} value={p.value}>
+                        {p.label}
+                      </option>
+                    ))}
+                  </select>
+                  {colorPresetValue === '__custom__' && (
+                    <input
+                      type="text"
+                      className="event-editor-input event-editor-color-custom"
+                      value={buffer.color}
+                      onChange={(e) => updateBuffer({ color: e.target.value })}
+                      placeholder="#c43"
+                      autoComplete="off"
+                    />
+                  )}
+                  <span
+                    className="event-editor-color-swatch"
+                    style={{ background: buffer.color || 'transparent' }}
+                    title={buffer.color || 'weekday default'}
+                  />
+                </div>
+              </div>
+            </div>
+
+            {/* Markdown editor */}
+            <div className="event-editor-body">
+              <MarkdownEditor
+                content={buffer.body}
+                onChange={(s) => updateBuffer({ body: s })}
+                viewRef={viewRef}
+              />
+            </div>
+
+            {/* Toolbar with footer controls in right slot */}
+            <FormatToolbar viewRef={viewRef} isEditable footerSlot={footerSlot} />
+          </>
+        )}
+
+        {/* Conflict overlay */}
+        {conflictPending && (
+          <div className="event-editor-conflict-overlay">
+            <div className="event-editor-conflict-panel">
+              <p className="event-editor-conflict-msg">
+                This file changed on disk since you opened it. Overwrite the on-disk version
+                anyway, or cancel to keep the editor open?
+              </p>
+              <div className="event-editor-conflict-btns">
+                <button
+                  type="button"
+                  className="event-editor-btn"
+                  onClick={() => setConflictPending(null)}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="event-editor-btn event-editor-btn--danger"
+                  onClick={() => void handleOverwrite()}
+                >
+                  Overwrite
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/timeline/event-editor/EventEditorModal.tsx
+++ b/desktop/src/renderer/timeline/event-editor/EventEditorModal.tsx
@@ -36,9 +36,7 @@ export function EventEditorModal({
   onSaved,
   onDeleted,
 }: EventEditorModalProps) {
-  const [loadState, setLoadState] = useState<LoadState>(
-    mode.kind === 'edit' ? 'loading' : 'ready',
-  );
+  const [loadState, setLoadState] = useState<LoadState>(mode.kind === 'edit' ? 'loading' : 'ready');
   const [buffer, setBuffer] = useState<EditorBuffer>(
     mode.kind === 'create' ? emptyBuffer(mode.initialDate) : emptyBuffer(),
   );
@@ -126,14 +124,22 @@ export function EventEditorModal({
           );
         } else {
           const filename = deriveFilename(current);
-          result = await timelinePort.createEvent(campaignPath, filename, frontmatter, current.body);
+          result = await timelinePort.createEvent(
+            campaignPath,
+            filename,
+            frontmatter,
+            current.body,
+          );
           filenameRef.current = result.event.filename;
         }
         lastModifiedRef.current = result.lastModified;
         setConflictPending(null);
         setSaveState('saved');
         // Timer is cleared on unmount so onSaved doesn't fire on a stale modal
-        savedTimerRef.current = window.setTimeout(() => onSaved(filenameRef.current!), SAVED_BANNER_MS);
+        savedTimerRef.current = window.setTimeout(
+          () => onSaved(filenameRef.current!),
+          SAVED_BANNER_MS,
+        );
       } catch (err) {
         if (err instanceof ConflictError) {
           setSaveState('dirty');
@@ -206,7 +212,8 @@ export function EventEditorModal({
   const handleDeleteClick = useCallback(() => {
     if (mode.kind !== 'edit') return;
     const displayName = buffer.title || mode.filename;
-    if (!window.confirm(`Move "${displayName}" to trash?\n\nRecoverable via Settings → Trash.`)) return;
+    if (!window.confirm(`Move "${displayName}" to trash?\n\nRecoverable via Settings → Trash.`))
+      return;
     void doDelete();
   }, [mode, buffer.title, doDelete]);
 
@@ -267,12 +274,7 @@ export function EventEditorModal({
                   ? '✓ saved'
                   : ''}
           </div>
-          <button
-            type="button"
-            className="event-editor-close"
-            aria-label="Close"
-            onClick={onClose}
-          >
+          <button type="button" className="event-editor-close" aria-label="Close" onClick={onClose}>
             ×
           </button>
         </div>
@@ -385,8 +387,8 @@ export function EventEditorModal({
           <div className="event-editor-conflict-overlay">
             <div className="event-editor-conflict-panel">
               <p className="event-editor-conflict-msg">
-                This file changed on disk since you opened it. Overwrite the on-disk version
-                anyway, or cancel to keep the editor open?
+                This file changed on disk since you opened it. Overwrite the on-disk version anyway,
+                or cancel to keep the editor open?
               </p>
               <div className="event-editor-conflict-btns">
                 <button

--- a/desktop/src/renderer/timeline/event-editor/EventEditorModal.tsx
+++ b/desktop/src/renderer/timeline/event-editor/EventEditorModal.tsx
@@ -51,8 +51,16 @@ export function EventEditorModal({
   const filenameRef = useRef<string | null>(mode.kind === 'edit' ? mode.filename : null);
   const bufferRef = useRef<EditorBuffer>(buffer);
   bufferRef.current = buffer;
+  const savedTimerRef = useRef<number | null>(null);
 
   const viewRef = useRef<EditorView | null>(null);
+
+  // Clear the saved-banner timer if the modal unmounts during the delay
+  useEffect(() => {
+    return () => {
+      if (savedTimerRef.current !== null) window.clearTimeout(savedTimerRef.current);
+    };
+  }, []);
 
   // Load event on mount in edit mode
   useEffect(() => {
@@ -124,7 +132,8 @@ export function EventEditorModal({
         lastModifiedRef.current = result.lastModified;
         setConflictPending(null);
         setSaveState('saved');
-        setTimeout(() => onSaved(filenameRef.current!), SAVED_BANNER_MS);
+        // Timer is cleared on unmount so onSaved doesn't fire on a stale modal
+        savedTimerRef.current = window.setTimeout(() => onSaved(filenameRef.current!), SAVED_BANNER_MS);
       } catch (err) {
         if (err instanceof ConflictError) {
           setSaveState('dirty');

--- a/desktop/src/renderer/timeline/event-editor/EventEditorModal.tsx
+++ b/desktop/src/renderer/timeline/event-editor/EventEditorModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import type { EditorView } from '@codemirror/view';
 import { MarkdownEditor, FormatToolbar } from '../../shared/markdown-editor';
+import { FooterPortal } from '../../components/footer-portal';
 import { timelinePort, ConflictError } from '../data/ports';
 import {
   emptyBuffer,
@@ -60,11 +61,19 @@ export function EventEditorModal({
     };
   }, []);
 
+  // Capture mount-time values in a ref so the effect can have an empty deps array.
+  // The key prop on EventEditorModal ensures a full remount when the target changes,
+  // so reading from refs here is always correct.
+  const loadTargetRef = useRef(
+    mode.kind === 'edit' ? { campaignPath, filename: mode.filename } : null,
+  );
+
   // Load event on mount in edit mode
   useEffect(() => {
-    if (mode.kind !== 'edit') return;
+    const target = loadTargetRef.current;
+    if (!target) return;
     timelinePort
-      .getEvent(campaignPath, mode.filename)
+      .getEvent(target.campaignPath, target.filename)
       .then(({ event, lastModified }) => {
         setBuffer(bufferFromEvent(event));
         lastModifiedRef.current = lastModified;
@@ -74,7 +83,6 @@ export function EventEditorModal({
         console.error('[EventEditorModal] failed to load event', err);
         setLoadState('load-error');
       });
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional mount-once: mode and campaignPath are stable per modal instance (key prop ensures remount on target change)
   }, []);
 
   // Escape: close the modal (capture phase wins over useCardExpansion's handler)
@@ -254,163 +262,175 @@ export function EventEditorModal({
   );
 
   return (
-    <div
-      className="event-editor-overlay"
-      onClick={(e) => {
-        if (e.target === e.currentTarget && !isBusy) onClose();
-      }}
-    >
-      <div className="event-editor-modal">
-        {/* Header */}
-        <div className="event-editor-header">
-          <h2 className="event-editor-title">
-            {isEditMode ? `Edit: ${mode.filename}` : 'New event'}
-          </h2>
-          <div className={`event-editor-save-status event-editor-save-status--${saveState}`}>
-            {saveState === 'dirty'
-              ? '• unsaved'
-              : saveState === 'saving'
-                ? 'saving…'
-                : saveState === 'saved'
-                  ? '✓ saved'
-                  : ''}
+    <>
+      <div
+        className="event-editor-overlay"
+        onClick={(e) => {
+          if (e.target === e.currentTarget && !isBusy) onClose();
+        }}
+      >
+        <div className="event-editor-modal">
+          {/* Header */}
+          <div className="event-editor-header">
+            <h2 className="event-editor-title">
+              {isEditMode ? `Edit: ${mode.filename}` : 'New event'}
+            </h2>
+            <div className={`event-editor-save-status event-editor-save-status--${saveState}`}>
+              {saveState === 'dirty'
+                ? '• unsaved'
+                : saveState === 'saving'
+                  ? 'saving…'
+                  : saveState === 'saved'
+                    ? '✓ saved'
+                    : ''}
+            </div>
+            <button
+              type="button"
+              className="event-editor-close"
+              aria-label="Close"
+              onClick={onClose}
+            >
+              ×
+            </button>
           </div>
-          <button type="button" className="event-editor-close" aria-label="Close" onClick={onClose}>
-            ×
-          </button>
-        </div>
 
-        {/* Error banner */}
-        {saveState === 'error' && errorMessage && (
-          <div className="event-editor-error">⚠ {errorMessage}</div>
-        )}
+          {/* Error banner */}
+          {saveState === 'error' && errorMessage && (
+            <div className="event-editor-error">⚠ {errorMessage}</div>
+          )}
 
-        {/* Loading / load-error */}
-        {loadState === 'loading' && <div className="event-editor-loading">Loading…</div>}
-        {loadState === 'load-error' && (
-          <div className="event-editor-loading event-editor-loading--error">
-            Failed to load event.
-          </div>
-        )}
+          {/* Loading / load-error */}
+          {loadState === 'loading' && <div className="event-editor-loading">Loading…</div>}
+          {loadState === 'load-error' && (
+            <div className="event-editor-loading event-editor-loading--error">
+              Failed to load event.
+            </div>
+          )}
 
-        {loadState === 'ready' && (
-          <>
-            {/* Frontmatter fields */}
-            <div className="event-editor-fields">
-              <label className="event-editor-field">
-                <span className="event-editor-field-label">Title</span>
-                <input
-                  type="text"
-                  className="event-editor-input"
-                  value={buffer.title}
-                  onChange={(e) => updateBuffer({ title: e.target.value })}
-                  autoComplete="off"
-                />
-              </label>
-
-              <label className="event-editor-field">
-                <span className="event-editor-field-label">Date (Golarian ISO)</span>
-                <input
-                  type="text"
-                  className="event-editor-input"
-                  value={buffer.date}
-                  onChange={(e) => updateBuffer({ date: e.target.value })}
-                  placeholder="4726-05-04T09:30"
-                  autoComplete="off"
-                />
-              </label>
-
-              <label className="event-editor-field">
-                <span className="event-editor-field-label">Tags (comma-separated)</span>
-                <input
-                  type="text"
-                  className="event-editor-input"
-                  value={buffer.tagsText}
-                  onChange={(e) => updateBuffer({ tagsText: e.target.value })}
-                  placeholder="plot:beast, location:fort"
-                  autoComplete="off"
-                />
-              </label>
-
-              <div className="event-editor-field">
-                <span className="event-editor-field-label">Colour</span>
-                <div className="event-editor-color-row">
-                  <select
-                    className="event-editor-input event-editor-color-select"
-                    value={colorPresetValue}
-                    onChange={(e) => {
-                      const val = e.target.value;
-                      // Switching to Custom clears color so the user can type; other presets set directly
-                      updateBuffer({ color: val === '__custom__' ? '' : val });
-                    }}
-                  >
-                    {COLOR_PRESETS.map((p) => (
-                      <option key={p.value} value={p.value}>
-                        {p.label}
-                      </option>
-                    ))}
-                  </select>
-                  {colorPresetValue === '__custom__' && (
-                    <input
-                      type="text"
-                      className="event-editor-input event-editor-color-custom"
-                      value={buffer.color}
-                      onChange={(e) => updateBuffer({ color: e.target.value })}
-                      placeholder="#c43"
-                      autoComplete="off"
-                    />
-                  )}
-                  <span
-                    className="event-editor-color-swatch"
-                    style={{ background: buffer.color || 'transparent' }}
-                    title={buffer.color || 'weekday default'}
+          {loadState === 'ready' && (
+            <>
+              {/* Frontmatter fields */}
+              <div className="event-editor-fields">
+                <label className="event-editor-field">
+                  <span className="event-editor-field-label">Title</span>
+                  <input
+                    type="text"
+                    className="event-editor-input"
+                    value={buffer.title}
+                    onChange={(e) => updateBuffer({ title: e.target.value })}
+                    autoComplete="off"
                   />
+                </label>
+
+                <label className="event-editor-field">
+                  <span className="event-editor-field-label">Date (Golarian ISO)</span>
+                  <input
+                    type="text"
+                    className="event-editor-input"
+                    value={buffer.date}
+                    onChange={(e) => updateBuffer({ date: e.target.value })}
+                    placeholder="4726-05-04T09:30"
+                    autoComplete="off"
+                  />
+                </label>
+
+                <label className="event-editor-field">
+                  <span className="event-editor-field-label">Tags (comma-separated)</span>
+                  <input
+                    type="text"
+                    className="event-editor-input"
+                    value={buffer.tagsText}
+                    onChange={(e) => updateBuffer({ tagsText: e.target.value })}
+                    placeholder="plot:beast, location:fort"
+                    autoComplete="off"
+                  />
+                </label>
+
+                <div className="event-editor-field">
+                  <span className="event-editor-field-label">Colour</span>
+                  <div className="event-editor-color-row">
+                    <select
+                      className="event-editor-input event-editor-color-select"
+                      value={colorPresetValue}
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        // Switching to Custom clears color so the user can type; other presets set directly
+                        updateBuffer({ color: val === '__custom__' ? '' : val });
+                      }}
+                    >
+                      {COLOR_PRESETS.map((p) => (
+                        <option key={p.value} value={p.value}>
+                          {p.label}
+                        </option>
+                      ))}
+                    </select>
+                    {colorPresetValue === '__custom__' && (
+                      <input
+                        type="text"
+                        className="event-editor-input event-editor-color-custom"
+                        value={buffer.color}
+                        onChange={(e) => updateBuffer({ color: e.target.value })}
+                        placeholder="#c43"
+                        autoComplete="off"
+                      />
+                    )}
+                    <span
+                      className="event-editor-color-swatch"
+                      style={{ background: buffer.color || 'transparent' }}
+                      title={buffer.color || 'weekday default'}
+                    />
+                  </div>
+                </div>
+              </div>
+
+              {/* Markdown editor */}
+              <div className="event-editor-body">
+                <MarkdownEditor
+                  content={buffer.body}
+                  onChange={(s) => updateBuffer({ body: s })}
+                  viewRef={viewRef}
+                />
+              </div>
+            </>
+          )}
+
+          {/* Conflict overlay */}
+          {conflictPending && (
+            <div className="event-editor-conflict-overlay">
+              <div className="event-editor-conflict-panel">
+                <p className="event-editor-conflict-msg">
+                  This file changed on disk since you opened it. Overwrite the on-disk version
+                  anyway, or cancel to keep the editor open?
+                </p>
+                <div className="event-editor-conflict-btns">
+                  <button
+                    type="button"
+                    className="event-editor-btn"
+                    onClick={() => setConflictPending(null)}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    className="event-editor-btn event-editor-btn--danger"
+                    onClick={() => void handleOverwrite()}
+                  >
+                    Overwrite
+                  </button>
                 </div>
               </div>
             </div>
-
-            {/* Markdown editor */}
-            <div className="event-editor-body">
-              <MarkdownEditor
-                content={buffer.body}
-                onChange={(s) => updateBuffer({ body: s })}
-                viewRef={viewRef}
-              />
-            </div>
-
-            {/* Toolbar with footer controls in right slot */}
-            <FormatToolbar viewRef={viewRef} isEditable footerSlot={footerSlot} />
-          </>
-        )}
-
-        {/* Conflict overlay */}
-        {conflictPending && (
-          <div className="event-editor-conflict-overlay">
-            <div className="event-editor-conflict-panel">
-              <p className="event-editor-conflict-msg">
-                This file changed on disk since you opened it. Overwrite the on-disk version anyway,
-                or cancel to keep the editor open?
-              </p>
-              <div className="event-editor-conflict-btns">
-                <button
-                  type="button"
-                  className="event-editor-btn"
-                  onClick={() => setConflictPending(null)}
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  className="event-editor-btn event-editor-btn--danger"
-                  onClick={() => void handleOverwrite()}
-                >
-                  Overwrite
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
-    </div>
+
+      <FooterPortal>
+        <FormatToolbar
+          viewRef={viewRef}
+          isEditable={loadState === 'ready'}
+          footerSlot={footerSlot}
+        />
+      </FooterPortal>
+    </>
   );
 }

--- a/desktop/src/renderer/timeline/event-editor/__tests__/domain.test.ts
+++ b/desktop/src/renderer/timeline/event-editor/__tests__/domain.test.ts
@@ -14,7 +14,14 @@ import type { Event } from '../../data/types';
 // ---- helpers ----
 
 function buf(overrides: Partial<EditorBuffer> = {}): EditorBuffer {
-  return { title: 'Test Event', date: '4726-05-04', tagsText: '', color: '', body: '', ...overrides };
+  return {
+    title: 'Test Event',
+    date: '4726-05-04',
+    tagsText: '',
+    color: '',
+    body: '',
+    ...overrides,
+  };
 }
 
 function event(overrides: Partial<Event> = {}): Event {
@@ -48,7 +55,13 @@ describe('emptyBuffer', () => {
 
 describe('bufferFromEvent', () => {
   it('maps event fields to buffer', () => {
-    const ev = event({ title: 'Big Battle', date: '4726-05-04T09:30', tags: ['combat', 'plot'], color: '#a83030', body: '# Notes\nHello' });
+    const ev = event({
+      title: 'Big Battle',
+      date: '4726-05-04T09:30',
+      tags: ['combat', 'plot'],
+      color: '#a83030',
+      body: '# Notes\nHello',
+    });
     const b = bufferFromEvent(ev);
     expect(b.title).toBe('Big Battle');
     expect(b.date).toBe('4726-05-04T09:30');
@@ -104,9 +117,20 @@ describe('bufferToFrontmatter', () => {
   });
 
   it('round-trips through bufferFromEvent', () => {
-    const original = buf({ title: 'Round-trip', date: '4726-03-15', tagsText: 'a, b', color: '#3d7a38', body: 'Hello' });
+    const original = buf({
+      title: 'Round-trip',
+      date: '4726-03-15',
+      tagsText: 'a, b',
+      color: '#3d7a38',
+      body: 'Hello',
+    });
     const fm = bufferToFrontmatter(original);
-    const ev = event({ ...fm, tags: fm.tags ?? [], color: fm.color ?? undefined, body: original.body });
+    const ev = event({
+      ...fm,
+      tags: fm.tags ?? [],
+      color: fm.color ?? undefined,
+      body: original.body,
+    });
     const restored = bufferFromEvent(ev);
     expect(restored.title).toBe(original.title);
     expect(restored.date).toBe(original.date);
@@ -150,11 +174,15 @@ describe('validateBuffer', () => {
 
 describe('deriveFilename', () => {
   it('derives slug from title and date prefix', () => {
-    expect(deriveFilename(buf({ title: 'The Big Heist', date: '4726-05-04T09:30' }))).toBe('4726-05-04-the-big-heist.md');
+    expect(deriveFilename(buf({ title: 'The Big Heist', date: '4726-05-04T09:30' }))).toBe(
+      '4726-05-04-the-big-heist.md',
+    );
   });
 
   it('strips apostrophes from title', () => {
-    expect(deriveFilename(buf({ title: "It's Time", date: '4726-05-04' }))).toBe('4726-05-04-its-time.md');
+    expect(deriveFilename(buf({ title: "It's Time", date: '4726-05-04' }))).toBe(
+      '4726-05-04-its-time.md',
+    );
   });
 
   it('uses "event" fallback when title is blank', () => {
@@ -169,11 +197,15 @@ describe('deriveFilename', () => {
   });
 
   it('replaces non-alphanumeric runs with single dash', () => {
-    expect(deriveFilename(buf({ title: 'Battle!!! At Dawn', date: '4726-01-01' }))).toBe('4726-01-01-battle-at-dawn.md');
+    expect(deriveFilename(buf({ title: 'Battle!!! At Dawn', date: '4726-01-01' }))).toBe(
+      '4726-01-01-battle-at-dawn.md',
+    );
   });
 
   it('strips leading/trailing dashes from slug', () => {
-    expect(deriveFilename(buf({ title: '---Test---', date: '4726-01-01' }))).toBe('4726-01-01-test.md');
+    expect(deriveFilename(buf({ title: '---Test---', date: '4726-01-01' }))).toBe(
+      '4726-01-01-test.md',
+    );
   });
 });
 

--- a/desktop/src/renderer/timeline/event-editor/__tests__/domain.test.ts
+++ b/desktop/src/renderer/timeline/event-editor/__tests__/domain.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest';
+import {
+  emptyBuffer,
+  bufferFromEvent,
+  bufferToFrontmatter,
+  validateBuffer,
+  deriveFilename,
+  COLOR_PRESETS,
+  getColorPresetValue,
+  type EditorBuffer,
+} from '../domain';
+import type { Event } from '../../data/types';
+
+// ---- helpers ----
+
+function buf(overrides: Partial<EditorBuffer> = {}): EditorBuffer {
+  return { title: 'Test Event', date: '4726-05-04', tagsText: '', color: '', body: '', ...overrides };
+}
+
+function event(overrides: Partial<Event> = {}): Event {
+  return {
+    filename: '4726-05-04-test.md',
+    title: 'Test Event',
+    date: '4726-05-04',
+    tags: [],
+    body: '',
+    mtime: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+// ---- emptyBuffer ----
+
+describe('emptyBuffer', () => {
+  it('returns all empty strings when no initialDate', () => {
+    const b = emptyBuffer();
+    expect(b).toEqual({ title: '', date: '', tagsText: '', color: '', body: '' });
+  });
+
+  it('places initialDate in the date field', () => {
+    const b = emptyBuffer('4726-03-01');
+    expect(b.date).toBe('4726-03-01');
+    expect(b.title).toBe('');
+  });
+});
+
+// ---- bufferFromEvent ----
+
+describe('bufferFromEvent', () => {
+  it('maps event fields to buffer', () => {
+    const ev = event({ title: 'Big Battle', date: '4726-05-04T09:30', tags: ['combat', 'plot'], color: '#a83030', body: '# Notes\nHello' });
+    const b = bufferFromEvent(ev);
+    expect(b.title).toBe('Big Battle');
+    expect(b.date).toBe('4726-05-04T09:30');
+    expect(b.tagsText).toBe('combat, plot');
+    expect(b.color).toBe('#a83030');
+    expect(b.body).toBe('# Notes\nHello');
+  });
+
+  it('produces empty tagsText when event has no tags', () => {
+    expect(bufferFromEvent(event({ tags: [] })).tagsText).toBe('');
+  });
+
+  it('handles missing tags array gracefully', () => {
+    const ev = event();
+    (ev as unknown as { tags?: string[] }).tags = undefined;
+    expect(bufferFromEvent(ev).tagsText).toBe('');
+  });
+
+  it('maps missing color to empty string', () => {
+    const ev = event();
+    delete (ev as Partial<Event>).color;
+    expect(bufferFromEvent(ev).color).toBe('');
+  });
+});
+
+// ---- bufferToFrontmatter ----
+
+describe('bufferToFrontmatter', () => {
+  it('splits tagsText by comma and trims whitespace', () => {
+    const fm = bufferToFrontmatter(buf({ tagsText: 'a, b,  c' }));
+    expect(fm.tags).toEqual(['a', 'b', 'c']);
+  });
+
+  it('omits tags field when tagsText is empty', () => {
+    const fm = bufferToFrontmatter(buf({ tagsText: '' }));
+    expect('tags' in fm).toBe(false);
+  });
+
+  it('omits color field when color is empty', () => {
+    const fm = bufferToFrontmatter(buf({ color: '' }));
+    expect('color' in fm).toBe(false);
+  });
+
+  it('includes color when set', () => {
+    const fm = bufferToFrontmatter(buf({ color: '#a83030' }));
+    expect(fm.color).toBe('#a83030');
+  });
+
+  it('trims title and date', () => {
+    const fm = bufferToFrontmatter(buf({ title: '  My Event  ', date: '  4726-05-04  ' }));
+    expect(fm.title).toBe('My Event');
+    expect(fm.date).toBe('4726-05-04');
+  });
+
+  it('round-trips through bufferFromEvent', () => {
+    const original = buf({ title: 'Round-trip', date: '4726-03-15', tagsText: 'a, b', color: '#3d7a38', body: 'Hello' });
+    const fm = bufferToFrontmatter(original);
+    const ev = event({ ...fm, tags: fm.tags ?? [], color: fm.color ?? undefined, body: original.body });
+    const restored = bufferFromEvent(ev);
+    expect(restored.title).toBe(original.title);
+    expect(restored.date).toBe(original.date);
+    expect(restored.color).toBe(original.color);
+    // Tags may have whitespace differences
+    expect(restored.tagsText.split(', ').sort()).toEqual(original.tagsText.split(', ').sort());
+  });
+});
+
+// ---- validateBuffer ----
+
+describe('validateBuffer', () => {
+  it('returns null for a valid buffer', () => {
+    expect(validateBuffer(buf())).toBeNull();
+  });
+
+  it('returns error when title is empty', () => {
+    expect(validateBuffer(buf({ title: '' }))).toBe('Title is required.');
+  });
+
+  it('returns error when title is whitespace only', () => {
+    expect(validateBuffer(buf({ title: '   ' }))).toBe('Title is required.');
+  });
+
+  it('returns error when date is empty', () => {
+    expect(validateBuffer(buf({ date: '' }))).toBe('Date is required.');
+  });
+
+  it('returns error when date is invalid Golarian format', () => {
+    const err = validateBuffer(buf({ date: 'not-a-date' }));
+    expect(err).not.toBeNull();
+    expect(err).toMatch(/golarian date/i);
+  });
+
+  it('accepts date with time component', () => {
+    expect(validateBuffer(buf({ date: '4726-05-04T09:30' }))).toBeNull();
+  });
+});
+
+// ---- deriveFilename ----
+
+describe('deriveFilename', () => {
+  it('derives slug from title and date prefix', () => {
+    expect(deriveFilename(buf({ title: 'The Big Heist', date: '4726-05-04T09:30' }))).toBe('4726-05-04-the-big-heist.md');
+  });
+
+  it('strips apostrophes from title', () => {
+    expect(deriveFilename(buf({ title: "It's Time", date: '4726-05-04' }))).toBe('4726-05-04-its-time.md');
+  });
+
+  it('uses "event" fallback when title is blank', () => {
+    expect(deriveFilename(buf({ title: '', date: '4726-05-04' }))).toBe('4726-05-04-event.md');
+  });
+
+  it('truncates slug at 60 characters', () => {
+    const longTitle = 'a'.repeat(80);
+    const filename = deriveFilename(buf({ title: longTitle, date: '4726-05-04' }));
+    const slug = filename.replace('4726-05-04-', '').replace('.md', '');
+    expect(slug.length).toBeLessThanOrEqual(60);
+  });
+
+  it('replaces non-alphanumeric runs with single dash', () => {
+    expect(deriveFilename(buf({ title: 'Battle!!! At Dawn', date: '4726-01-01' }))).toBe('4726-01-01-battle-at-dawn.md');
+  });
+
+  it('strips leading/trailing dashes from slug', () => {
+    expect(deriveFilename(buf({ title: '---Test---', date: '4726-01-01' }))).toBe('4726-01-01-test.md');
+  });
+});
+
+// ---- COLOR_PRESETS ----
+
+describe('COLOR_PRESETS', () => {
+  it('contains the default (empty) preset', () => {
+    expect(COLOR_PRESETS.some((p) => p.value === '')).toBe(true);
+  });
+
+  it('contains the custom sentinel', () => {
+    expect(COLOR_PRESETS.some((p) => p.value === '__custom__')).toBe(true);
+  });
+
+  it('has named color presets', () => {
+    expect(COLOR_PRESETS.some((p) => p.value === '#a83030')).toBe(true);
+  });
+});
+
+// ---- getColorPresetValue ----
+
+describe('getColorPresetValue', () => {
+  it('returns empty string for empty color', () => {
+    expect(getColorPresetValue('')).toBe('');
+  });
+
+  it('returns the preset value when color matches a preset', () => {
+    expect(getColorPresetValue('#a83030')).toBe('#a83030');
+  });
+
+  it('returns __custom__ for a non-preset hex value', () => {
+    expect(getColorPresetValue('#ff1234')).toBe('__custom__');
+  });
+
+  it('does not treat __custom__ itself as a valid preset', () => {
+    expect(getColorPresetValue('__custom__')).toBe('__custom__');
+  });
+});

--- a/desktop/src/renderer/timeline/event-editor/__tests__/useEventEditor.test.ts
+++ b/desktop/src/renderer/timeline/event-editor/__tests__/useEventEditor.test.ts
@@ -196,9 +196,7 @@ describe('resolveCardDeleteConflict', () => {
 
   it('overwrite re-fetches mtime, retries delete, and refreshes', async () => {
     const onChanged = vi.fn();
-    mockDelete
-      .mockRejectedValueOnce(new ConflictError())
-      .mockResolvedValueOnce(undefined);
+    mockDelete.mockRejectedValueOnce(new ConflictError()).mockResolvedValueOnce(undefined);
     mockGetEvent.mockResolvedValue(EVENT_WITH_MTIME);
     const { result } = renderHook(() => useEventEditor(CAMPAIGN, onChanged));
 

--- a/desktop/src/renderer/timeline/event-editor/__tests__/useEventEditor.test.ts
+++ b/desktop/src/renderer/timeline/event-editor/__tests__/useEventEditor.test.ts
@@ -1,0 +1,239 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useEventEditor } from '../useEventEditor';
+import { ConflictError } from '../../data/ports';
+import type { EventListItem, EventWithMtime } from '../../data/types';
+
+// ---- Mocks ----
+
+vi.mock('../../data/ports', () => ({
+  timelinePort: {
+    deleteEvent: vi.fn(),
+    getEvent: vi.fn(),
+  },
+  ConflictError: class ConflictError extends Error {
+    constructor() {
+      super('Conflict');
+      this.name = 'ConflictError';
+    }
+  },
+}));
+
+import { timelinePort } from '../../data/ports';
+const mockDelete = vi.mocked(timelinePort.deleteEvent);
+const mockGetEvent = vi.mocked(timelinePort.getEvent);
+
+const CAMPAIGN = '/fake/campaign';
+const MTIME = '2026-01-01T00:00:00.000Z';
+const FRESH_MTIME = '2026-01-02T00:00:00.000Z';
+
+const ITEM: EventListItem = {
+  filename: '4726-05-04-battle.md',
+  title: 'Big Battle',
+  date: '4726-05-04',
+  mtime: MTIME,
+};
+
+const EVENT_WITH_MTIME: EventWithMtime = {
+  event: {
+    filename: ITEM.filename,
+    title: ITEM.title,
+    date: ITEM.date,
+    tags: [],
+    body: '',
+    mtime: FRESH_MTIME,
+  },
+  lastModified: FRESH_MTIME,
+};
+
+const confirmMock = vi.fn(() => true);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  confirmMock.mockReturnValue(true);
+  vi.stubGlobal('confirm', confirmMock);
+});
+
+// ---- Initial state ----
+
+describe('initial state', () => {
+  it('starts with editorMode null and no conflict', () => {
+    const { result } = renderHook(() => useEventEditor(CAMPAIGN, vi.fn()));
+    expect(result.current.editorMode).toBeNull();
+    expect(result.current.cardDeleteConflict).toBeNull();
+  });
+});
+
+// ---- openCreate / openEdit / closeEditor ----
+
+describe('editor mode transitions', () => {
+  it('openCreate sets create mode', () => {
+    const { result } = renderHook(() => useEventEditor(CAMPAIGN, vi.fn()));
+    act(() => result.current.openCreate());
+    expect(result.current.editorMode).toEqual({ kind: 'create' });
+  });
+
+  it('openCreate with initialDate includes it', () => {
+    const { result } = renderHook(() => useEventEditor(CAMPAIGN, vi.fn()));
+    act(() => result.current.openCreate('4726-03-01'));
+    expect(result.current.editorMode).toEqual({ kind: 'create', initialDate: '4726-03-01' });
+  });
+
+  it('openEdit sets edit mode with filename', () => {
+    const { result } = renderHook(() => useEventEditor(CAMPAIGN, vi.fn()));
+    act(() => result.current.openEdit('foo.md'));
+    expect(result.current.editorMode).toEqual({ kind: 'edit', filename: 'foo.md' });
+  });
+
+  it('closeEditor resets to null', () => {
+    const { result } = renderHook(() => useEventEditor(CAMPAIGN, vi.fn()));
+    act(() => result.current.openEdit('foo.md'));
+    act(() => result.current.closeEditor());
+    expect(result.current.editorMode).toBeNull();
+  });
+});
+
+// ---- handleSaved / handleDeleted ----
+
+describe('handleSaved', () => {
+  it('closes editor and triggers refresh', () => {
+    const onChanged = vi.fn();
+    const { result } = renderHook(() => useEventEditor(CAMPAIGN, onChanged));
+    act(() => result.current.openEdit('foo.md'));
+    act(() => result.current.handleSaved('foo.md'));
+    expect(result.current.editorMode).toBeNull();
+    expect(onChanged).toHaveBeenCalledOnce();
+  });
+});
+
+describe('handleDeleted', () => {
+  it('closes editor and triggers refresh', () => {
+    const onChanged = vi.fn();
+    const { result } = renderHook(() => useEventEditor(CAMPAIGN, onChanged));
+    act(() => result.current.openEdit('foo.md'));
+    act(() => result.current.handleDeleted('foo.md'));
+    expect(result.current.editorMode).toBeNull();
+    expect(onChanged).toHaveBeenCalledOnce();
+  });
+});
+
+// ---- requestDeleteFromCard ----
+
+describe('requestDeleteFromCard', () => {
+  it('calls deleteEvent and refreshes on success', async () => {
+    const onChanged = vi.fn();
+    mockDelete.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useEventEditor(CAMPAIGN, onChanged));
+    await act(async () => {
+      await result.current.requestDeleteFromCard(ITEM);
+    });
+    expect(confirmMock).toHaveBeenCalled();
+    expect(mockDelete).toHaveBeenCalledWith(CAMPAIGN, ITEM.filename, ITEM.mtime);
+    expect(onChanged).toHaveBeenCalledOnce();
+  });
+
+  it('does nothing when user declines confirm', async () => {
+    const onChanged = vi.fn();
+    confirmMock.mockReturnValue(false);
+    const { result } = renderHook(() => useEventEditor(CAMPAIGN, onChanged));
+    await act(async () => {
+      await result.current.requestDeleteFromCard(ITEM);
+    });
+    expect(mockDelete).not.toHaveBeenCalled();
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  it('sets cardDeleteConflict on ConflictError', async () => {
+    const onChanged = vi.fn();
+    mockDelete.mockRejectedValue(new ConflictError());
+    const { result } = renderHook(() => useEventEditor(CAMPAIGN, onChanged));
+    await act(async () => {
+      await result.current.requestDeleteFromCard(ITEM);
+    });
+    expect(result.current.cardDeleteConflict).toEqual({
+      filename: ITEM.filename,
+      title: ITEM.title,
+    });
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  it('does not set conflict on non-ConflictError', async () => {
+    const onChanged = vi.fn();
+    mockDelete.mockRejectedValue(new Error('network error'));
+    const { result } = renderHook(() => useEventEditor(CAMPAIGN, onChanged));
+    await act(async () => {
+      await result.current.requestDeleteFromCard(ITEM);
+    });
+    expect(result.current.cardDeleteConflict).toBeNull();
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+});
+
+// ---- resolveCardDeleteConflict ----
+
+describe('resolveCardDeleteConflict', () => {
+  it('cancel clears conflict without calling deleteEvent', async () => {
+    const onChanged = vi.fn();
+    mockDelete.mockRejectedValue(new ConflictError());
+    const { result } = renderHook(() => useEventEditor(CAMPAIGN, onChanged));
+
+    // Trigger conflict
+    await act(async () => {
+      await result.current.requestDeleteFromCard(ITEM);
+    });
+    await waitFor(() => expect(result.current.cardDeleteConflict).not.toBeNull());
+
+    await act(async () => {
+      await result.current.resolveCardDeleteConflict('cancel');
+    });
+
+    expect(result.current.cardDeleteConflict).toBeNull();
+    expect(onChanged).not.toHaveBeenCalled();
+    // Only the initial failing delete was called, not a second one
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('overwrite re-fetches mtime, retries delete, and refreshes', async () => {
+    const onChanged = vi.fn();
+    mockDelete
+      .mockRejectedValueOnce(new ConflictError())
+      .mockResolvedValueOnce(undefined);
+    mockGetEvent.mockResolvedValue(EVENT_WITH_MTIME);
+    const { result } = renderHook(() => useEventEditor(CAMPAIGN, onChanged));
+
+    // Trigger conflict
+    await act(async () => {
+      await result.current.requestDeleteFromCard(ITEM);
+    });
+    await waitFor(() => expect(result.current.cardDeleteConflict).not.toBeNull());
+
+    await act(async () => {
+      await result.current.resolveCardDeleteConflict('overwrite');
+    });
+
+    expect(mockGetEvent).toHaveBeenCalledWith(CAMPAIGN, ITEM.filename);
+    expect(mockDelete).toHaveBeenNthCalledWith(2, CAMPAIGN, ITEM.filename, FRESH_MTIME);
+    expect(result.current.cardDeleteConflict).toBeNull();
+    expect(onChanged).toHaveBeenCalledOnce();
+  });
+
+  it('overwrite clears conflict even on failure', async () => {
+    const onChanged = vi.fn();
+    mockDelete.mockRejectedValue(new ConflictError());
+    mockGetEvent.mockRejectedValue(new Error('network'));
+    const { result } = renderHook(() => useEventEditor(CAMPAIGN, onChanged));
+
+    await act(async () => {
+      await result.current.requestDeleteFromCard(ITEM);
+    });
+    await waitFor(() => expect(result.current.cardDeleteConflict).not.toBeNull());
+
+    await act(async () => {
+      await result.current.resolveCardDeleteConflict('overwrite');
+    });
+
+    expect(result.current.cardDeleteConflict).toBeNull();
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+});

--- a/desktop/src/renderer/timeline/event-editor/domain.ts
+++ b/desktop/src/renderer/timeline/event-editor/domain.ts
@@ -1,0 +1,95 @@
+import { parseISOString } from '../calendar/golarian';
+import type { Event, EventFrontmatter } from '../data/types';
+
+export interface EditorBuffer {
+  title: string;
+  date: string;
+  tagsText: string;
+  color: string;
+  body: string;
+}
+
+export type EditorMode =
+  | { kind: 'create'; initialDate?: string }
+  | { kind: 'edit'; filename: string };
+
+export interface ColorPreset {
+  label: string;
+  value: string;
+}
+
+export const COLOR_PRESETS: ColorPreset[] = [
+  { label: 'Default (weekday)', value: '' },
+  { label: '■ Crimson', value: '#a83030' },
+  { label: '■ Amber', value: '#b87030' },
+  { label: '■ Gold', value: '#c09820' },
+  { label: '■ Forest', value: '#3d7a38' },
+  { label: '■ Teal', value: '#287868' },
+  { label: '■ Blue', value: '#2858a0' },
+  { label: '■ Indigo', value: '#483898' },
+  { label: '■ Violet', value: '#783888' },
+  { label: '■ Rose', value: '#a03068' },
+  { label: '■ Slate', value: '#505870' },
+  { label: 'Custom…', value: '__custom__' },
+];
+
+export function emptyBuffer(initialDate?: string): EditorBuffer {
+  return { title: '', date: initialDate ?? '', tagsText: '', color: '', body: '' };
+}
+
+export function bufferFromEvent(ev: Event): EditorBuffer {
+  return {
+    title: ev.title,
+    date: ev.date,
+    tagsText: (ev.tags ?? []).join(', '),
+    color: ev.color ?? '',
+    body: ev.body,
+  };
+}
+
+export function bufferToFrontmatter(buf: EditorBuffer): EventFrontmatter {
+  const tags = buf.tagsText
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean);
+  const fm: EventFrontmatter = {
+    title: buf.title.trim(),
+    date: buf.date.trim(),
+  };
+  if (tags.length > 0) fm.tags = tags;
+  if (buf.color) fm.color = buf.color;
+  return fm;
+}
+
+export function validateBuffer(buf: EditorBuffer): string | null {
+  if (!buf.title.trim()) return 'Title is required.';
+  if (!buf.date.trim()) return 'Date is required.';
+  try {
+    parseISOString(buf.date.trim());
+  } catch (err: unknown) {
+    return `Date is not a valid Golarian date: ${err instanceof Error ? err.message : String(err)}`;
+  }
+  return null;
+}
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[''`]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+}
+
+export function deriveFilename(buf: EditorBuffer): string {
+  const dateOnly = buf.date.trim().slice(0, 10);
+  const slug = slugify(buf.title);
+  return `${dateOnly}-${slug || 'event'}.md`;
+}
+
+/** Returns the <select> value for the color field (or '__custom__' for non-preset hex). */
+export function getColorPresetValue(color: string): string {
+  if (!color) return '';
+  if (COLOR_PRESETS.some((p) => p.value === color && p.value !== '__custom__')) return color;
+  return '__custom__';
+}

--- a/desktop/src/renderer/timeline/event-editor/useEventEditor.ts
+++ b/desktop/src/renderer/timeline/event-editor/useEventEditor.ts
@@ -1,0 +1,110 @@
+import { useState, useCallback } from 'react';
+import { timelinePort, ConflictError } from '../data/ports';
+import type { EventListItem } from '../data/types';
+import type { EditorMode } from './domain';
+
+export type { EditorMode };
+
+export interface CardDeleteConflict {
+  filename: string;
+  title: string;
+}
+
+export interface UseEventEditorResult {
+  editorMode: EditorMode | null;
+  openCreate: (initialDate?: string) => void;
+  openEdit: (filename: string) => void;
+  closeEditor: () => void;
+  handleSaved: (filename: string) => void;
+  handleDeleted: (filename: string) => void;
+  requestDeleteFromCard: (item: EventListItem) => Promise<void>;
+  cardDeleteConflict: CardDeleteConflict | null;
+  resolveCardDeleteConflict: (choice: 'overwrite' | 'cancel') => Promise<void>;
+}
+
+export function useEventEditor(
+  campaignPath: string,
+  onEventsChanged: () => void,
+): UseEventEditorResult {
+  const [editorMode, setEditorMode] = useState<EditorMode | null>(null);
+  const [cardDeleteConflict, setCardDeleteConflict] = useState<CardDeleteConflict | null>(null);
+
+  const openCreate = useCallback((initialDate?: string) => {
+    setEditorMode({ kind: 'create', ...(initialDate ? { initialDate } : {}) });
+  }, []);
+
+  const openEdit = useCallback((filename: string) => {
+    setEditorMode({ kind: 'edit', filename });
+  }, []);
+
+  const closeEditor = useCallback(() => {
+    setEditorMode(null);
+  }, []);
+
+  const handleSaved = useCallback(() => {
+    setEditorMode(null);
+    onEventsChanged();
+  }, [onEventsChanged]);
+
+  const handleDeleted = useCallback(() => {
+    setEditorMode(null);
+    onEventsChanged();
+  }, [onEventsChanged]);
+
+  const requestDeleteFromCard = useCallback(
+    async (item: EventListItem) => {
+      const displayName = item.title || item.filename;
+      const ok = window.confirm(
+        `Move "${displayName}" to trash?\n\nRecoverable via Settings → Trash.`,
+      );
+      if (!ok) return;
+      try {
+        await timelinePort.deleteEvent(campaignPath, item.filename, item.mtime);
+        onEventsChanged();
+      } catch (err) {
+        if (err instanceof ConflictError) {
+          setCardDeleteConflict({ filename: item.filename, title: item.title });
+          return;
+        }
+        console.error('[useEventEditor] delete failed', err);
+      }
+    },
+    [campaignPath, onEventsChanged],
+  );
+
+  const resolveCardDeleteConflict = useCallback(
+    async (choice: 'overwrite' | 'cancel') => {
+      if (choice === 'cancel') {
+        setCardDeleteConflict(null);
+        return;
+      }
+      if (!cardDeleteConflict) return;
+      try {
+        // Re-fetch current mtime so the server accepts the delete
+        const { lastModified } = await timelinePort.getEvent(
+          campaignPath,
+          cardDeleteConflict.filename,
+        );
+        await timelinePort.deleteEvent(campaignPath, cardDeleteConflict.filename, lastModified);
+        setCardDeleteConflict(null);
+        onEventsChanged();
+      } catch (err) {
+        console.error('[useEventEditor] force delete failed', err);
+        setCardDeleteConflict(null);
+      }
+    },
+    [campaignPath, cardDeleteConflict, onEventsChanged],
+  );
+
+  return {
+    editorMode,
+    openCreate,
+    openEdit,
+    closeEditor,
+    handleSaved,
+    handleDeleted,
+    requestDeleteFromCard,
+    cardDeleteConflict,
+    resolveCardDeleteConflict,
+  };
+}

--- a/desktop/src/renderer/timeline/render/cards.tsx
+++ b/desktop/src/renderer/timeline/render/cards.tsx
@@ -44,6 +44,8 @@ interface CardsProps {
   onCardClick: (filename: string) => void;
   onPreviewSizeChange: (s: PreviewSize) => void;
   onResizeDragChange: (active: boolean) => void;
+  onEditClick: (filename: string) => void;
+  onDeleteClick: (item: EventListItem) => void;
 }
 
 export function Cards({
@@ -57,6 +59,8 @@ export function Cards({
   onCardClick,
   onPreviewSizeChange,
   onResizeDragChange,
+  onEditClick,
+  onDeleteClick,
 }: CardsProps): ReactElement | null {
   const laidOut = useMemo(
     () => layoutCards(events, view, size, inGameNowSeconds),
@@ -121,6 +125,8 @@ export function Cards({
             onCardClick={onCardClick}
             onPreviewSizeChange={onPreviewSizeChange}
             onResizeDragChange={onResizeDragChange}
+            onEditClick={onEditClick}
+            onDeleteClick={onDeleteClick}
           />
         );
       })}
@@ -140,6 +146,8 @@ interface CardItemProps {
   onCardClick: (filename: string) => void;
   onPreviewSizeChange: (s: PreviewSize) => void;
   onResizeDragChange: (active: boolean) => void;
+  onEditClick: (filename: string) => void;
+  onDeleteClick: (item: EventListItem) => void;
 }
 
 function CardItem({
@@ -154,6 +162,8 @@ function CardItem({
   onCardClick,
   onPreviewSizeChange,
   onResizeDragChange,
+  onEditClick,
+  onDeleteClick,
 }: CardItemProps): ReactElement {
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
@@ -202,7 +212,7 @@ function CardItem({
               className="event-card-action-btn event-card-action-btn--danger"
               data-action="delete"
               title="Delete"
-              onClick={(e) => e.stopPropagation()}
+              onClick={(e) => { e.stopPropagation(); void onDeleteClick(card.event); }}
             >
               {ICON_DELETE}
             </button>
@@ -210,7 +220,7 @@ function CardItem({
               className="event-card-action-btn event-card-action-btn--primary"
               data-action="edit"
               title="Edit"
-              onClick={(e) => e.stopPropagation()}
+              onClick={(e) => { e.stopPropagation(); onEditClick(card.event.filename); }}
             >
               {ICON_EDIT}
             </button>

--- a/desktop/src/renderer/timeline/render/cards.tsx
+++ b/desktop/src/renderer/timeline/render/cards.tsx
@@ -212,7 +212,10 @@ function CardItem({
               className="event-card-action-btn event-card-action-btn--danger"
               data-action="delete"
               title="Delete"
-              onClick={(e) => { e.stopPropagation(); void onDeleteClick(card.event); }}
+              onClick={(e) => {
+                e.stopPropagation();
+                void onDeleteClick(card.event);
+              }}
             >
               {ICON_DELETE}
             </button>
@@ -220,7 +223,10 @@ function CardItem({
               className="event-card-action-btn event-card-action-btn--primary"
               data-action="edit"
               title="Edit"
-              onClick={(e) => { e.stopPropagation(); onEditClick(card.event.filename); }}
+              onClick={(e) => {
+                e.stopPropagation();
+                onEditClick(card.event.filename);
+              }}
             >
               {ICON_EDIT}
             </button>

--- a/desktop/src/renderer/views/timeline/timeline-view.tsx
+++ b/desktop/src/renderer/views/timeline/timeline-view.tsx
@@ -163,7 +163,10 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
         {/* New Event button — mouseDown stops pan from starting */}
         <button
           className="timeline-new-event-btn"
-          onClick={(e) => { e.stopPropagation(); editor.openCreate(); }}
+          onClick={(e) => {
+            e.stopPropagation();
+            editor.openCreate();
+          }}
           onMouseDown={(e) => e.stopPropagation()}
         >
           + New Event
@@ -200,8 +203,9 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
                   lineHeight: 1.5,
                 }}
               >
-                &ldquo;{editor.cardDeleteConflict.title || editor.cardDeleteConflict.filename}&rdquo;
-                changed on disk since the events list was loaded. Delete the current version anyway?
+                &ldquo;{editor.cardDeleteConflict.title || editor.cardDeleteConflict.filename}
+                &rdquo; changed on disk since the events list was loaded. Delete the current version
+                anyway?
               </p>
               <div style={{ display: 'flex', gap: 8, justifyContent: 'center' }}>
                 <button

--- a/desktop/src/renderer/views/timeline/timeline-view.tsx
+++ b/desktop/src/renderer/views/timeline/timeline-view.tsx
@@ -225,6 +225,7 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
       {/* Event editor modal — rendered outside viewport to avoid pan/zoom transform */}
       {editor.editorMode && (
         <EventEditorModal
+          key={editor.editorMode.kind === 'edit' ? editor.editorMode.filename : 'new'}
           campaignPath={campaignPath}
           mode={editor.editorMode}
           onClose={editor.closeEditor}

--- a/desktop/src/renderer/views/timeline/timeline-view.tsx
+++ b/desktop/src/renderer/views/timeline/timeline-view.tsx
@@ -16,6 +16,8 @@ import { usePan } from '../../timeline/interactions/usePan';
 import { useZoom } from '../../timeline/interactions/useZoom';
 import { useCardExpansion } from '../../timeline/interactions/useCardExpansion';
 import { usePreviewSize } from '../../timeline/interactions/usePreviewSize';
+import { useEventEditor } from '../../timeline/event-editor/useEventEditor';
+import { EventEditorModal } from '../../timeline/event-editor/EventEditorModal';
 
 interface TimelineViewProps {
   campaignPath: string;
@@ -41,7 +43,6 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
     sessions: [],
   });
 
-  // Whether a resize drag is in progress — used to suppress pan during resize
   const resizingRef = useRef(false);
   const handleResizeDragChange = useCallback((active: boolean) => {
     resizingRef.current = active;
@@ -49,7 +50,6 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
 
   const viewportRef = useRef<HTMLDivElement>(null);
 
-  // Keep refs in sync so event-handler closures always see the latest state.
   const viewRef = useRef<ViewState>(viewState);
   const sizeRef = useRef<ViewportSize>(viewportSize);
   viewRef.current = viewState;
@@ -61,7 +61,19 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
   useZoom(viewportRef, viewRef, sizeRef, setViewState);
 
   const [previewSize, savePreviewSize] = usePreviewSize();
-  const { expansion, handleCardClick } = useCardExpansion(campaignPath, pan);
+  const { expansion, handleCardClick, collapse } = useCardExpansion(campaignPath, pan);
+
+  const refreshEvents = useCallback(async () => {
+    try {
+      const events = await timelinePort.listEvents(campaignPath);
+      setLoadedData((d) => ({ ...d, events }));
+      collapse();
+    } catch (err) {
+      console.error('[TimelineView] failed to refresh events', err);
+    }
+  }, [campaignPath, collapse]);
+
+  const editor = useEventEditor(campaignPath, refreshEvents);
 
   useEffect(() => {
     const el = viewportRef.current;
@@ -76,7 +88,6 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
 
   useEffect(() => {
     let cancelled = false;
-    // gameState/events/sessions pre-wired here; consumed by render layers in follow-up issues.
     Promise.all([
       timelinePort.loadPalette(campaignPath),
       timelinePort.getState(campaignPath),
@@ -97,54 +108,130 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
   const inGameNowSeconds = inGameNow ? toAbsoluteSeconds(parseISOString(inGameNow)) : Infinity;
 
   return (
-    <div
-      ref={viewportRef}
-      data-timeline-viewport
-      data-width={viewportSize.width}
-      data-height={viewportSize.height}
-      data-center={viewState.centerSeconds}
-      data-scale={viewState.secondsPerPixel}
-      style={{
-        position: 'relative',
-        width: '100%',
-        height: '100%',
-        backgroundColor: bgColor,
-        overflow: 'hidden',
-        cursor: 'grab',
-        ...(loadedData.palette ? paletteToCssVars(loadedData.palette) : {}),
-      }}
-    >
-      {loadedData.palette && <Axis view={viewState} size={viewportSize} />}
-      {loadedData.palette && (
-        <SessionBands
-          sessions={loadedData.sessions}
-          events={loadedData.events}
-          view={viewState}
-          size={viewportSize}
+    <>
+      <div
+        ref={viewportRef}
+        data-timeline-viewport
+        data-width={viewportSize.width}
+        data-height={viewportSize.height}
+        data-center={viewState.centerSeconds}
+        data-scale={viewState.secondsPerPixel}
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          backgroundColor: bgColor,
+          overflow: 'hidden',
+          cursor: 'grab',
+          ...(loadedData.palette ? paletteToCssVars(loadedData.palette) : {}),
+        }}
+      >
+        {loadedData.palette && <Axis view={viewState} size={viewportSize} />}
+        {loadedData.palette && (
+          <SessionBands
+            sessions={loadedData.sessions}
+            events={loadedData.events}
+            view={viewState}
+            size={viewportSize}
+          />
+        )}
+        {loadedData.palette && (
+          <Cards
+            events={loadedData.events}
+            view={viewState}
+            size={viewportSize}
+            palette={loadedData.palette}
+            inGameNowSeconds={inGameNowSeconds}
+            expansion={expansion}
+            previewSize={previewSize}
+            onCardClick={handleCardClick}
+            onPreviewSizeChange={savePreviewSize}
+            onResizeDragChange={handleResizeDragChange}
+            onEditClick={editor.openEdit}
+            onDeleteClick={editor.requestDeleteFromCard}
+          />
+        )}
+        {loadedData.palette && inGameNow && (
+          <NowMarker
+            view={viewState}
+            size={viewportSize}
+            inGameNow={inGameNow}
+            inGameNowSeconds={inGameNowSeconds}
+          />
+        )}
+
+        {/* New Event button — mouseDown stops pan from starting */}
+        <button
+          className="timeline-new-event-btn"
+          onClick={(e) => { e.stopPropagation(); editor.openCreate(); }}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          + New Event
+        </button>
+
+        {/* Card-delete conflict overlay (inline modal) */}
+        {editor.cardDeleteConflict && (
+          <div
+            style={{
+              position: 'fixed',
+              inset: 0,
+              background: 'rgba(0,0,0,0.65)',
+              zIndex: 1001,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <div
+              style={{
+                background: 'var(--theme-surface, #1e1e1a)',
+                border: '1px solid var(--theme-border-strong, #5a4530)',
+                borderRadius: 4,
+                padding: '20px 24px',
+                maxWidth: 400,
+                textAlign: 'center',
+              }}
+            >
+              <p
+                style={{
+                  margin: '0 0 16px',
+                  color: 'var(--theme-text-primary, #d8d0b8)',
+                  fontSize: 14,
+                  lineHeight: 1.5,
+                }}
+              >
+                &ldquo;{editor.cardDeleteConflict.title || editor.cardDeleteConflict.filename}&rdquo;
+                changed on disk since the events list was loaded. Delete the current version anyway?
+              </p>
+              <div style={{ display: 'flex', gap: 8, justifyContent: 'center' }}>
+                <button
+                  className="event-editor-btn"
+                  onClick={() => void editor.resolveCardDeleteConflict('cancel')}
+                >
+                  Cancel
+                </button>
+                <button
+                  className="event-editor-btn event-editor-btn--danger"
+                  onClick={() => void editor.resolveCardDeleteConflict('overwrite')}
+                >
+                  Delete anyway
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Event editor modal — rendered outside viewport to avoid pan/zoom transform */}
+      {editor.editorMode && (
+        <EventEditorModal
+          campaignPath={campaignPath}
+          mode={editor.editorMode}
+          onClose={editor.closeEditor}
+          onSaved={editor.handleSaved}
+          onDeleted={editor.handleDeleted}
         />
       )}
-      {loadedData.palette && (
-        <Cards
-          events={loadedData.events}
-          view={viewState}
-          size={viewportSize}
-          palette={loadedData.palette}
-          inGameNowSeconds={inGameNowSeconds}
-          expansion={expansion}
-          previewSize={previewSize}
-          onCardClick={handleCardClick}
-          onPreviewSizeChange={savePreviewSize}
-          onResizeDragChange={handleResizeDragChange}
-        />
-      )}
-      {loadedData.palette && inGameNow && (
-        <NowMarker
-          view={viewState}
-          size={viewportSize}
-          inGameNow={inGameNow}
-          inGameNowSeconds={inGameNowSeconds}
-        />
-      )}
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
Closes #88.

## Summary

- **`event-editor/domain.ts`** — pure domain logic: `EditorBuffer` type, validation, `deriveFilename` (slugify), `bufferToFrontmatter`, `bufferFromEvent`, `COLOR_PRESETS`, `getColorPresetValue`. Zero React/IO dependencies.
- **`event-editor/useEventEditor.ts`** — orchestration hook: modal open/close state, direct card-delete flow with `ConflictError` handling (re-fetches fresh mtime before retry), post-mutation events-list refresh.
- **`event-editor/EventEditorModal.tsx`** — React modal with frontmatter form (title / date / tags / colour picker), `MarkdownEditor` body, `FormatToolbar` footer with Save/Cancel/Delete in `footerSlot`. Handles load state, conflict overlay, Ctrl+S shortcut, and Escape (capture phase to win over card expansion listener).
- **`event-editor/EventEditorModal.css`** — modal styles using existing CSS-variable design language.
- **`timeline/render/cards.tsx`** — `onEditClick(filename)` and `onDeleteClick(item)` props wired into the action buttons on expanded cards (CSS already hides them when collapsed).
- **`views/timeline/timeline-view.tsx`** — integrates `useEventEditor`, renders `<EventEditorModal>`, adds "New Event" floating button, calls `collapse()` + `refreshEvents()` after mutations to avoid stale expansion.

## Key design notes

**Conflict detection bypass**: `ifUnmodifiedSince = ''` does NOT bypass the IPC handler's strict mtime equality check. Force-overwrite re-fetches the current `lastModified` via `getEvent()` then retries with that fresh mtime.

**Scope**: Zero changes outside `./desktop/` (verified via `git diff --stat main...HEAD -- ':!desktop'` → empty).

## Test plan

- [x] `event-editor/__tests__/domain.test.ts` — validates all pure functions (slugify edge cases, frontmatter omission rules, round-trip, color preset sentinel)
- [x] `event-editor/__tests__/useEventEditor.test.ts` — mode transitions, delete confirm/decline, `ConflictError` → conflict state, overwrite re-fetch choreography, cancel path
- [x] All 396 existing tests continue to pass

## Opus advisor review

Two Opus reviews were conducted per issue instructions:
1. **Planning phase** — architecture, design decisions, and file-by-file plan produced before coding.
2. **Pre-PR review** — confirmed: scope clean, abstraction by concern correct, conflict-bypass logic verified, tests exercise real edge cases. **Verdict: APPROVE.** Post-review fixes applied: `setTimeout` cleanup on unmount, `key` prop on `<EventEditorModal>` for explicit remount semantics.

https://claude.ai/code/session_01SGkZkDhbYFKJxsbok4VSBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGkZkDhbYFKJxsbok4VSBZ)_