### PR TITLE
docs(desktop): add planning workflow for issue-driven tasks

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -15,10 +15,36 @@ Only use `npx <tool>` when there is genuinely no npm script for the task.
 
 ## Planning workflow for issue-driven tasks
 
-When the task originates from a GitHub issue (the prompt is the issue body, or you've been told to "pick up" an issue):
+When you've been pointed at a GitHub issue (e.g. given a URL with a "title" prefix and told to use the ticket as your prompt):
 
-1. **Plan first.** Before editing any code, spawn the `Plan` subagent with the issue body and any relevant context. Do not skip this step even if the issue looks small — if it's trivial, the plan will be short.
-2. **Post the plan.** Add the returned plan as a comment on the originating issue (or PR, if one already exists) so it's reviewable.
-3. **Build a TodoWrite list from the plan.** Convert each plan step into a todo item before writing code. Keep exactly one item `in_progress` at a time and mark items `completed` as you finish them.
-4. **Work the list.** Implement step-by-step against the todos. If you discover the plan is wrong mid-implementation, stop, update the todo list (and ideally the issue comment), then continue — don't silently deviate.
-5. **No skipping.** If you find yourself about to edit a file without an active todo covering that work, that's the signal to go back to step 1 or 3.
+### 1. Fetch the issue first
+
+Before doing anything else, fetch both the **body** and the **labels** of the issue via the GitHub MCP tools. The body is your task description; the labels determine how much oversight is required.
+
+### 2. Read the oversight tier from the labels
+
+| Label | Plan stage | Pre-PR review |
+| --- | --- | --- |
+| `oversight:none` | Sonnet plans inline. | No opus review required. |
+| `oversight:basic` | Sonnet plans inline. | Opus advisor reviews the diff before the PR is opened. |
+| `oversight:extended` | Spawn the `Plan` subagent first and post its plan as a comment on the issue. | Opus advisor reviews the diff before the PR is opened. |
+| (no `oversight:*` label) | Treat as `oversight:basic`. | Treat as `oversight:basic`. |
+
+The ticket body may add **extra** reviewer criteria (e.g. "zero changes outside `./desktop/`"). It cannot waive the ones below.
+
+### 3. Build a TodoWrite list
+
+Convert the plan (the Plan subagent's output for `extended`, or your own sketch for `basic`/`none`) into a `TodoWrite` list before writing code. Keep exactly one item `in_progress` at a time and mark items `completed` as you go. If you discover the plan is wrong mid-implementation, stop, update the todos (and the plan comment, if `extended`), then continue — don't silently deviate.
+
+If you're about to edit a file without an active todo covering that work, that's the signal to go back to step 3.
+
+### 4. Pre-PR opus advisor review (`basic` and `extended`)
+
+Before opening the PR, spawn an opus advisor on the diff. The advisor must verify, on top of any ticket-specific checks:
+
+- **Spec coverage** — every "Features to preserve" / "New features" / "Acceptance" bullet from the issue body is actually implemented.
+- **De-duplication** — flag repeated logic that should be a shared helper, hook, or component.
+- **Abstraction & pattern adherence** — render / interaction / IO / state stay cleanly separated; the change follows the patterns documented in the nearest `AGENTS.md` / `CLAUDE.md`.
+- **Meaningful tests** — tests exercise behaviour and edge cases, not just mirror the implementation.
+
+Address the advisor's findings (or push back with a reason) before opening the PR.

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -12,3 +12,13 @@ Prefer npm scripts over calling binaries directly. Check `package.json` first an
 - `npm run lint:fix` — lint and auto-fix
 
 Only use `npx <tool>` when there is genuinely no npm script for the task.
+
+## Planning workflow for issue-driven tasks
+
+When the task originates from a GitHub issue (the prompt is the issue body, or you've been told to "pick up" an issue):
+
+1. **Plan first.** Before editing any code, spawn the `Plan` subagent with the issue body and any relevant context. Do not skip this step even if the issue looks small — if it's trivial, the plan will be short.
+2. **Post the plan.** Add the returned plan as a comment on the originating issue (or PR, if one already exists) so it's reviewable.
+3. **Build a TodoWrite list from the plan.** Convert each plan step into a todo item before writing code. Keep exactly one item `in_progress` at a time and mark items `completed` as you finish them.
+4. **Work the list.** Implement step-by-step against the todos. If you discover the plan is wrong mid-implementation, stop, update the todo list (and ideally the issue comment), then continue — don't silently deviate.
+5. **No skipping.** If you find yourself about to edit a file without an active todo covering that work, that's the signal to go back to step 1 or 3.

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -42,7 +42,7 @@ If you're about to edit a file without an active todo covering that work, that's
 
 Before opening the PR, spawn an opus advisor on the diff. The advisor must verify, on top of any ticket-specific checks:
 
-- **Spec coverage** — every "Features to preserve" / "New features" / "Acceptance" bullet from the issue body is actually implemented.
+- **Spec coverage** — whatever the ticket body specifies as the work to be done is actually implemented.
 - **De-duplication** — flag repeated logic that should be a shared helper, hook, or component.
 - **Abstraction & pattern adherence** — render / interaction / IO / state stay cleanly separated; the change follows the patterns documented in the nearest `AGENTS.md` / `CLAUDE.md`.
 - **Meaningful tests** — tests exercise behaviour and edge cases, not just mirror the implementation.


### PR DESCRIPTION
## Summary
- Adds a "Planning workflow for issue-driven tasks" section to `desktop/CLAUDE.md` so agents picking up a GitHub issue must run the `Plan` subagent, post the plan as a comment, and drive the work through a `TodoWrite` list rather than diving straight into edits.
- Goal: prevent the silent-deviation failure mode where issue-body instructions ("have opus plan first") get skipped or generate a plan that never actually governs the session.

## Test plan
- [ ] Open a new web session against a GitHub issue in `desktop/` and confirm the agent (a) spawns `Plan`, (b) posts the plan as an issue comment, (c) creates a `TodoWrite` list before editing code.
- [ ] Verify the agent keeps exactly one todo `in_progress` and marks items `completed` as it goes.
- [ ] Try a trivially small issue and confirm the agent still produces a (short) plan rather than skipping the step.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFs4ZM7g5CkEfaTrVrMReE)_