### PR TITLE
Timeline: now-marker context menu, footer 3-slot abstraction, view-state persistence (#92)

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -47,6 +47,7 @@
         "globals": "15.14.0",
         "happy-dom": "20.9.0",
         "husky": "9.1.7",
+        "jsdom": "^29.1.1",
         "lint-staged": "16.4.0",
         "nodemon": "^3.1.14",
         "prettier": "3.4.2",
@@ -57,6 +58,57 @@
         "vitest": "4.1.5",
         "wait-on": "8.0.1"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -93,6 +145,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -494,6 +559,146 @@
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -1431,6 +1636,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@hapi/hoek": {
@@ -3421,6 +3644,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3959,12 +4192,50 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -4036,6 +4307,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -5991,6 +6269,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -6466,6 +6757,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6718,6 +7016,67 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/json-buffer": {
@@ -7569,6 +7928,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -8295,6 +8661,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8780,6 +9172,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resedit": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
@@ -9108,6 +9510,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -9665,6 +10080,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/synckit": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.3.tgz",
@@ -9836,6 +10258,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -9877,6 +10319,32 @@
       "license": "ISC",
       "bin": {
         "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -10113,7 +10581,6 @@
       "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=20.18.1"
       }
@@ -10367,6 +10834,19 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wait-on": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.1.tgz",
@@ -10387,6 +10867,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -10395,6 +10885,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -10576,6 +11081,16 @@
         }
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -10585,6 +11100,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -97,6 +97,7 @@
     "globals": "15.14.0",
     "happy-dom": "20.9.0",
     "husky": "9.1.7",
+    "jsdom": "^29.1.1",
     "lint-staged": "16.4.0",
     "nodemon": "^3.1.14",
     "prettier": "3.4.2",

--- a/desktop/src/renderer/app.tsx
+++ b/desktop/src/renderer/app.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties } from 'react';
+import { useState } from 'react';
 import { Footer, ViewType } from './components/footer';
 import { NotesView } from './views/notes/notes-view';
 import { TimelineView } from './views/timeline/timeline-view';
@@ -6,11 +6,12 @@ import { RelationshipsView } from './views/relationships/relationships-view';
 import { DirectoryPicker } from './views/setup/directory-picker';
 import { CampaignManager } from './views/campaigns/campaign-manager';
 import { useCampaigns } from './hooks/useCampaigns';
+import { useCampaignPalette } from './hooks/useCampaignPalette';
+import { paletteToCssVars } from './timeline/palette';
 import '../../src/index.css';
 
 export default function App() {
   const [currentView, setCurrentView] = useState<ViewType>('notes');
-  const [paletteVars, setPaletteVars] = useState<CSSProperties | null>(null);
   const {
     rootDir,
     campaigns,
@@ -21,6 +22,9 @@ export default function App() {
     handleOpenCampaign,
     handleCloseCampaign,
   } = useCampaigns();
+
+  const palette = useCampaignPalette(activeCampaign?.path ?? null);
+  const paletteVars = palette ? paletteToCssVars(palette) : null;
 
   if (isLoading) {
     return (
@@ -63,12 +67,7 @@ export default function App() {
       case 'notes':
         return <NotesView campaignPath={activeCampaign.path} campaignId={activeCampaign.id} />;
       case 'timeline':
-        return (
-          <TimelineView
-            campaignPath={activeCampaign.path}
-            onPaletteVarsChange={(vars) => setPaletteVars(vars)}
-          />
-        );
+        return <TimelineView campaignPath={activeCampaign.path} palette={palette} />;
       case 'relationships':
         return <RelationshipsView />;
       default:

--- a/desktop/src/renderer/app.tsx
+++ b/desktop/src/renderer/app.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type CSSProperties } from 'react';
 import { Footer, ViewType } from './components/footer';
 import { NotesView } from './views/notes/notes-view';
 import { TimelineView } from './views/timeline/timeline-view';
@@ -10,6 +10,7 @@ import '../../src/index.css';
 
 export default function App() {
   const [currentView, setCurrentView] = useState<ViewType>('notes');
+  const [paletteVars, setPaletteVars] = useState<CSSProperties | null>(null);
   const {
     rootDir,
     campaigns,
@@ -62,7 +63,12 @@ export default function App() {
       case 'notes':
         return <NotesView campaignPath={activeCampaign.path} campaignId={activeCampaign.id} />;
       case 'timeline':
-        return <TimelineView campaignPath={activeCampaign.path} />;
+        return (
+          <TimelineView
+            campaignPath={activeCampaign.path}
+            onPaletteVarsChange={(vars) => setPaletteVars(vars)}
+          />
+        );
       case 'relationships':
         return <RelationshipsView />;
       default:
@@ -74,12 +80,13 @@ export default function App() {
     <div
       style={{
         height: '100vh',
-        backgroundColor: 'var(--theme-background)',
-        color: 'var(--theme-text-primary)',
+        backgroundColor: 'var(--theme-background, #09090b)',
+        color: 'var(--theme-text-primary, #d8d0b8)',
         fontFamily: '"Inter", "Segoe UI", sans-serif',
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
+        ...(paletteVars ?? {}),
       }}
     >
       {/* Main View Area */}

--- a/desktop/src/renderer/components/footer-button.css
+++ b/desktop/src/renderer/components/footer-button.css
@@ -24,3 +24,14 @@
   filter: brightness(1.12);
   background: var(--theme-accent-warm, #b87840);
 }
+
+.footer-btn--active {
+  background: var(--theme-border-strong, #5a4530);
+  border-color: var(--theme-accent-gold, #c9a860);
+  color: var(--theme-accent-gold, #c9a860);
+}
+
+.footer-btn--active:hover {
+  background: var(--theme-border-strong, #5a4530);
+  filter: brightness(1.1);
+}

--- a/desktop/src/renderer/components/footer-button.css
+++ b/desktop/src/renderer/components/footer-button.css
@@ -1,0 +1,26 @@
+.footer-btn {
+  background: var(--theme-panel-accent, #3a4d35);
+  color: var(--theme-text-primary, #d8d0b8);
+  border: 1px solid var(--theme-border, #3a3a30);
+  padding: 6px 14px;
+  font-size: 14px;
+  font-family: inherit;
+  cursor: pointer;
+  border-radius: 2px;
+}
+
+.footer-btn:hover {
+  background: var(--theme-border-strong, #5a4530);
+}
+
+.footer-btn--primary {
+  background: var(--theme-accent-warm, #b87840);
+  color: var(--theme-background, #1a1a1a);
+  border-color: var(--theme-border-strong, #5a4530);
+  font-weight: 600;
+}
+
+.footer-btn--primary:hover {
+  filter: brightness(1.12);
+  background: var(--theme-accent-warm, #b87840);
+}

--- a/desktop/src/renderer/components/footer-button.tsx
+++ b/desktop/src/renderer/components/footer-button.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+import './footer-button.css';
+
+interface FooterButtonProps {
+  variant?: 'primary' | 'default';
+  onClick: () => void;
+  onMouseDown?: (e: React.MouseEvent) => void;
+  children: ReactNode;
+  title?: string;
+}
+
+export function FooterButton({
+  variant = 'default',
+  onClick,
+  onMouseDown,
+  children,
+  title,
+}: FooterButtonProps) {
+  return (
+    <button
+      className={`footer-btn${variant === 'primary' ? ' footer-btn--primary' : ''}`}
+      onClick={onClick}
+      onMouseDown={onMouseDown}
+      title={title}
+    >
+      {children}
+    </button>
+  );
+}

--- a/desktop/src/renderer/components/footer-button.tsx
+++ b/desktop/src/renderer/components/footer-button.tsx
@@ -1,28 +1,24 @@
 import type { ReactNode } from 'react';
 import './footer-button.css';
 
+type FooterButtonVariant = 'default' | 'primary' | 'active';
+
 interface FooterButtonProps {
-  variant?: 'primary' | 'default';
+  variant?: FooterButtonVariant;
   onClick: () => void;
-  onMouseDown?: (e: React.MouseEvent) => void;
   children: ReactNode;
   title?: string;
 }
 
-export function FooterButton({
-  variant = 'default',
-  onClick,
-  onMouseDown,
-  children,
-  title,
-}: FooterButtonProps) {
+const VARIANT_CLASS: Record<FooterButtonVariant, string> = {
+  default: '',
+  primary: ' footer-btn--primary',
+  active: ' footer-btn--active',
+};
+
+export function FooterButton({ variant = 'default', onClick, children, title }: FooterButtonProps) {
   return (
-    <button
-      className={`footer-btn${variant === 'primary' ? ' footer-btn--primary' : ''}`}
-      onClick={onClick}
-      onMouseDown={onMouseDown}
-      title={title}
-    >
+    <button className={`footer-btn${VARIANT_CLASS[variant]}`} onClick={onClick} title={title}>
       {children}
     </button>
   );

--- a/desktop/src/renderer/components/footer-portal.tsx
+++ b/desktop/src/renderer/components/footer-portal.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-export function FooterPortal({ children }: { children: React.ReactNode }) {
+export type FooterSlot = 'left' | 'center' | 'right';
+
+interface FooterPortalProps {
+  children: React.ReactNode;
+  slot?: FooterSlot;
+}
+
+export function FooterPortal({ children, slot = 'right' }: FooterPortalProps) {
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -11,7 +18,7 @@ export function FooterPortal({ children }: { children: React.ReactNode }) {
 
   if (!mounted) return null;
 
-  const target = document.getElementById('footer-portal-target');
+  const target = document.getElementById(`footer-slot-${slot}`);
   if (!target) return null;
 
   return createPortal(children, target);

--- a/desktop/src/renderer/components/footer.tsx
+++ b/desktop/src/renderer/components/footer.tsx
@@ -21,8 +21,8 @@ export function Footer({ currentView, onChangeView, onBackToCampaigns }: FooterP
     <div
       style={{
         height: '50px',
-        backgroundColor: '#18181b',
-        borderTop: '1px solid #27272a',
+        backgroundColor: 'var(--theme-panel, #2d3d2a)',
+        borderTop: '1px solid var(--theme-border, #3a3a30)',
         display: 'flex',
         alignItems: 'center',
         padding: '0 20px',
@@ -39,12 +39,14 @@ export function Footer({ currentView, onChangeView, onBackToCampaigns }: FooterP
           cursor: 'pointer',
           padding: '6px 12px',
           borderRadius: '6px',
-          backgroundColor: menuOpen ? '#27272a' : 'transparent',
-          color: '#e0e0e0',
+          backgroundColor: menuOpen ? 'var(--theme-panel-accent, #3a4d35)' : 'transparent',
+          color: 'var(--theme-text-primary, #d8d0b8)',
           transition: 'background 0.2s',
           position: 'relative',
         }}
-        onMouseOver={(e) => (e.currentTarget.style.backgroundColor = '#27272a')}
+        onMouseOver={(e) =>
+          (e.currentTarget.style.backgroundColor = 'var(--theme-panel-accent, #3a4d35)')
+        }
         onMouseOut={(e) => {
           if (!menuOpen) e.currentTarget.style.backgroundColor = 'transparent';
         }}
@@ -67,9 +69,9 @@ export function Footer({ currentView, onChangeView, onBackToCampaigns }: FooterP
               position: 'absolute',
               bottom: '60px',
               left: '20px',
-              backgroundColor: '#18181b',
-              border: '1px solid #27272a',
-              borderRadius: '8px',
+              backgroundColor: 'var(--theme-surface, #242420)',
+              border: '1px solid var(--theme-border-strong, #5a4530)',
+              borderRadius: '4px',
               padding: '8px',
               display: 'flex',
               flexDirection: 'column',
@@ -87,11 +89,15 @@ export function Footer({ currentView, onChangeView, onBackToCampaigns }: FooterP
                   setMenuOpen(false);
                 }}
                 style={{
-                  background: currentView === v ? '#27272a' : 'transparent',
-                  color: currentView === v ? '#fff' : '#a1a1aa',
+                  background:
+                    currentView === v ? 'var(--theme-panel-accent, #3a4d35)' : 'transparent',
+                  color:
+                    currentView === v
+                      ? 'var(--theme-accent-gold, #c9a860)'
+                      : 'var(--theme-text-primary, #d8d0b8)',
                   border: 'none',
                   padding: '10px 12px',
-                  borderRadius: '4px',
+                  borderRadius: '2px',
                   textAlign: 'left',
                   cursor: 'pointer',
                   fontWeight: 500,
@@ -99,7 +105,8 @@ export function Footer({ currentView, onChangeView, onBackToCampaigns }: FooterP
                   transition: 'background 0.1s',
                 }}
                 onMouseOver={(e) => {
-                  if (currentView !== v) e.currentTarget.style.background = '#1f1f22';
+                  if (currentView !== v)
+                    e.currentTarget.style.background = 'var(--theme-panel, #2d3d2a)';
                 }}
                 onMouseOut={(e) => {
                   if (currentView !== v) e.currentTarget.style.background = 'transparent';
@@ -109,7 +116,13 @@ export function Footer({ currentView, onChangeView, onBackToCampaigns }: FooterP
               </button>
             ))}
 
-            <div style={{ height: '1px', backgroundColor: '#27272a', margin: '4px 8px' }} />
+            <div
+              style={{
+                height: '1px',
+                backgroundColor: 'var(--theme-border, #3a3a30)',
+                margin: '4px 8px',
+              }}
+            />
 
             <button
               onClick={() => {
@@ -118,10 +131,10 @@ export function Footer({ currentView, onChangeView, onBackToCampaigns }: FooterP
               }}
               style={{
                 background: 'transparent',
-                color: '#71717a',
+                color: 'var(--theme-text-muted, #7a6f58)',
                 border: 'none',
                 padding: '10px 12px',
-                borderRadius: '4px',
+                borderRadius: '2px',
                 textAlign: 'left',
                 cursor: 'pointer',
                 fontWeight: 500,
@@ -129,12 +142,12 @@ export function Footer({ currentView, onChangeView, onBackToCampaigns }: FooterP
                 transition: 'all 0.2s',
               }}
               onMouseOver={(e) => {
-                e.currentTarget.style.background = '#1f1f22';
-                e.currentTarget.style.color = '#e0e0e0';
+                e.currentTarget.style.background = 'var(--theme-panel, #2d3d2a)';
+                e.currentTarget.style.color = 'var(--theme-text-primary, #d8d0b8)';
               }}
               onMouseOut={(e) => {
                 e.currentTarget.style.background = 'transparent';
-                e.currentTarget.style.color = '#71717a';
+                e.currentTarget.style.color = 'var(--theme-text-muted, #7a6f58)';
               }}
             >
               ← Back to Campaigns

--- a/desktop/src/renderer/components/footer.tsx
+++ b/desktop/src/renderer/components/footer.tsx
@@ -27,18 +27,20 @@ export function Footer({ currentView, onChangeView, onBackToCampaigns }: FooterP
         alignItems: 'center',
         padding: '0 20px',
         position: 'relative',
+        gap: '0',
       }}
     >
       {/* Burger & View Switcher */}
       <div
         onClick={() => setMenuOpen(!menuOpen)}
         style={{
+          flexShrink: 0,
           display: 'flex',
           alignItems: 'center',
           gap: '12px',
           cursor: 'pointer',
           padding: '6px 12px',
-          borderRadius: '6px',
+          borderRadius: '4px',
           backgroundColor: menuOpen ? 'var(--theme-panel-accent, #3a4d35)' : 'transparent',
           color: 'var(--theme-text-primary, #d8d0b8)',
           transition: 'background 0.2s',
@@ -156,18 +158,39 @@ export function Footer({ currentView, onChangeView, onBackToCampaigns }: FooterP
         </>
       )}
 
-      {/* Dynamic Content Portal Target */}
+      {/* Three-slot portal grid — fills remaining footer width */}
       <div
-        id="footer-portal-target"
         style={{
           flex: 1,
-          display: 'flex',
+          display: 'grid',
+          gridTemplateColumns: '1fr auto 1fr',
           alignItems: 'center',
-          justifyContent: 'flex-end',
-          paddingLeft: '20px',
-          gap: '10px',
+          paddingLeft: '12px',
         }}
-      ></div>
+      >
+        <div
+          id="footer-slot-left"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            justifyContent: 'flex-start',
+          }}
+        />
+        <div
+          id="footer-slot-center"
+          style={{ display: 'flex', alignItems: 'center', gap: '8px', justifyContent: 'center' }}
+        />
+        <div
+          id="footer-slot-right"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '10px',
+            justifyContent: 'flex-end',
+          }}
+        />
+      </div>
     </div>
   );
 }

--- a/desktop/src/renderer/hooks/useCampaignPalette.ts
+++ b/desktop/src/renderer/hooks/useCampaignPalette.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import type { Palette } from '../timeline/data/types';
+import { timelinePort } from '../timeline/data/ports';
+
+export function useCampaignPalette(campaignPath: string | null): Palette | null {
+  const [palette, setPalette] = useState<Palette | null>(null);
+
+  useEffect(() => {
+    if (!campaignPath) {
+      setPalette(null);
+      return;
+    }
+    let cancelled = false;
+    timelinePort
+      .loadPalette(campaignPath)
+      .then((p) => {
+        if (!cancelled) setPalette(p);
+      })
+      .catch((err) => console.error('[useCampaignPalette] failed to load palette', err));
+    return () => {
+      cancelled = true;
+    };
+  }, [campaignPath]);
+
+  return palette;
+}

--- a/desktop/src/renderer/notes/notes.tsx
+++ b/desktop/src/renderer/notes/notes.tsx
@@ -139,7 +139,7 @@ export function NotesApp({ campaignId, campaignPath }: NotesAppProps) {
         </main>
       </div>
 
-      <FooterPortal>
+      <FooterPortal slot="center">
         <FormatToolbar
           viewRef={editorViewRef}
           isEditable={!!isEditableNote && !!ctrl.activeTab}

--- a/desktop/src/renderer/timeline/event-editor/EventEditorModal.tsx
+++ b/desktop/src/renderer/timeline/event-editor/EventEditorModal.tsx
@@ -488,7 +488,7 @@ export function EventEditorModal({
         </div>
       </div>
 
-      <FooterPortal>
+      <FooterPortal slot="center">
         <FormatToolbar
           viewRef={viewRef}
           isEditable={loadState === 'ready'}

--- a/desktop/src/renderer/timeline/render/AdvanceTimePopover.css
+++ b/desktop/src/renderer/timeline/render/AdvanceTimePopover.css
@@ -1,0 +1,116 @@
+.advance-time-popover {
+  width: 300px;
+  max-height: calc(100vh - 80px);
+  overflow-y: auto;
+  background: var(--theme-surface, #242420);
+  border: 1px solid var(--theme-border-strong, #5a4530);
+  border-radius: 4px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.7);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.atp-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--theme-accent-gold, #c9a860);
+  margin-bottom: 2px;
+}
+
+.atp-current {
+  font-size: 12px;
+  color: var(--theme-text-secondary, #a89a80);
+}
+
+.atp-quick-row {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.atp-quick-row button {
+  background: var(--theme-panel, #2d3d2a);
+  color: var(--theme-text-primary, #d8d0b8);
+  border: 1px solid var(--theme-border, #3a3a30);
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  border-radius: 2px;
+}
+
+.atp-quick-row button:hover {
+  background: var(--theme-panel-accent, #3a4d35);
+}
+
+.atp-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.atp-label {
+  font-size: 12px;
+  color: var(--theme-text-secondary, #a89a80);
+}
+
+.atp-input {
+  background: var(--theme-background, #1a1a1a);
+  color: var(--theme-text-primary, #d8d0b8);
+  border: 1px solid var(--theme-border, #3a3a30);
+  padding: 5px 8px;
+  font-size: 13px;
+  font-family: ui-monospace, 'Consolas', monospace;
+  border-radius: 2px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.atp-input:focus {
+  outline: none;
+  border-color: var(--theme-accent-gold, #c9a860);
+}
+
+.atp-input.is-error {
+  border-color: var(--theme-danger, #c06040);
+}
+
+.atp-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.atp-actions button {
+  background: var(--theme-panel, #2d3d2a);
+  color: var(--theme-text-primary, #d8d0b8);
+  border: 1px solid var(--theme-border, #3a3a30);
+  padding: 5px 14px;
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  border-radius: 2px;
+}
+
+.atp-actions button:hover {
+  background: var(--theme-panel-accent, #3a4d35);
+}
+
+.atp-actions button.is-primary {
+  background: var(--theme-accent-warm, #b87840);
+  color: var(--theme-background, #1a1a1a);
+  border-color: var(--theme-border-strong, #5a4530);
+  font-weight: 600;
+}
+
+.atp-actions button.is-primary:hover {
+  filter: brightness(1.12);
+}
+
+.atp-actions button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/desktop/src/renderer/timeline/render/AdvanceTimePopover.tsx
+++ b/desktop/src/renderer/timeline/render/AdvanceTimePopover.tsx
@@ -18,8 +18,9 @@ interface AdvanceTimePopoverProps {
 }
 
 const QUICK_DELTAS: { label: string; delta: number }[] = [
+  { label: '+1 min', delta: 60 },
+  { label: '+10 min', delta: 600 },
   { label: '+1 hour', delta: 3600 },
-  { label: '+6 hours', delta: 6 * 3600 },
   { label: '+1 day', delta: 86400 },
   { label: '+1 week', delta: 7 * 86400 },
 ];
@@ -72,7 +73,7 @@ export function AdvanceTimePopover({
   }, [onClose]);
 
   function applyDelta(delta: number) {
-    const next = baseSecs + delta;
+    const next = pendingSecs + delta;
     setPendingSecs(next);
     setInputValue(toISOString(fromAbsoluteSeconds(next)));
     setInputError(false);

--- a/desktop/src/renderer/timeline/render/AdvanceTimePopover.tsx
+++ b/desktop/src/renderer/timeline/render/AdvanceTimePopover.tsx
@@ -1,0 +1,137 @@
+import { useState, useEffect, useRef, type CSSProperties } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  parseISOString,
+  toISOString,
+  toAbsoluteSeconds,
+  fromAbsoluteSeconds,
+} from '../calendar/golarian';
+import { formatExpanded } from '../calendar/format';
+import './AdvanceTimePopover.css';
+
+interface AdvanceTimePopoverProps {
+  /** Viewport-relative click position — popover appears above this point. */
+  anchor: { x: number; y: number };
+  currentNow: string;
+  onSave: (newNow: string) => Promise<void>;
+  onClose: () => void;
+}
+
+const QUICK_DELTAS: { label: string; delta: number }[] = [
+  { label: '+1 hour', delta: 3600 },
+  { label: '+6 hours', delta: 6 * 3600 },
+  { label: '+1 day', delta: 86400 },
+  { label: '+1 week', delta: 7 * 86400 },
+];
+
+export function AdvanceTimePopover({
+  anchor,
+  currentNow,
+  onSave,
+  onClose,
+}: AdvanceTimePopoverProps) {
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const baseSecs = toAbsoluteSeconds(parseISOString(currentNow));
+  const [pendingSecs, setPendingSecs] = useState(baseSecs);
+  const [inputValue, setInputValue] = useState(currentNow);
+  const [inputError, setInputError] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  useEffect(() => {
+    let removeHandler: (() => void) | undefined;
+    const id = setTimeout(() => {
+      const handler = (e: MouseEvent) => {
+        if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+          onClose();
+        }
+      };
+      document.addEventListener('mousedown', handler, true);
+      removeHandler = () => document.removeEventListener('mousedown', handler, true);
+    }, 0);
+    return () => {
+      clearTimeout(id);
+      removeHandler?.();
+    };
+  }, [onClose]);
+
+  function applyDelta(delta: number) {
+    const next = baseSecs + delta;
+    setPendingSecs(next);
+    setInputValue(toISOString(fromAbsoluteSeconds(next)));
+    setInputError(false);
+  }
+
+  function handleInput(value: string) {
+    setInputValue(value);
+    try {
+      const d = parseISOString(value.trim());
+      setPendingSecs(toAbsoluteSeconds(d));
+      setInputError(false);
+    } catch {
+      setInputError(true);
+    }
+  }
+
+  async function handleSave() {
+    if (inputError || saving) return;
+    setSaving(true);
+    try {
+      await onSave(toISOString(fromAbsoluteSeconds(pendingSecs)));
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const popoverWidth = 300;
+  const left = Math.min(anchor.x, window.innerWidth - popoverWidth - 12);
+  const style: CSSProperties = {
+    position: 'fixed',
+    left: Math.max(12, left),
+    bottom: window.innerHeight - anchor.y + 6,
+    zIndex: 500,
+  };
+
+  return createPortal(
+    <div ref={popoverRef} className="advance-time-popover" style={style}>
+      <div className="atp-title">Advance Time</div>
+      <div className="atp-current">{formatExpanded(fromAbsoluteSeconds(pendingSecs))}</div>
+      <div className="atp-quick-row">
+        {QUICK_DELTAS.map(({ label, delta }) => (
+          <button key={label} onClick={() => applyDelta(delta)}>
+            {label}
+          </button>
+        ))}
+      </div>
+      <div className="atp-row">
+        <label className="atp-label">Set directly</label>
+        <input
+          className={`atp-input${inputError ? ' is-error' : ''}`}
+          type="text"
+          value={inputValue}
+          placeholder="4726-05-04T09:30"
+          onChange={(e) => handleInput(e.target.value)}
+        />
+      </div>
+      <div className="atp-actions">
+        <button onClick={onClose}>Cancel</button>
+        <button
+          className="is-primary"
+          onClick={() => void handleSave()}
+          disabled={inputError || saving}
+        >
+          Save
+        </button>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/desktop/src/renderer/timeline/render/AdvanceTimePopover.tsx
+++ b/desktop/src/renderer/timeline/render/AdvanceTimePopover.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, type CSSProperties } from 'react';
+import { useState, useEffect, useRef, useMemo, type CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
 import {
   parseISOString,
@@ -10,7 +10,7 @@ import { formatExpanded } from '../calendar/format';
 import './AdvanceTimePopover.css';
 
 interface AdvanceTimePopoverProps {
-  /** Viewport-relative click position — popover appears above this point. */
+  /** Screen coordinates of the now-marker labels element's top-left corner. */
   anchor: { x: number; y: number };
   currentNow: string;
   onSave: (newNow: string) => Promise<void>;
@@ -24,6 +24,15 @@ const QUICK_DELTAS: { label: string; delta: number }[] = [
   { label: '+1 week', delta: 7 * 86400 },
 ];
 
+/** Parse "+5h", "+2d", "+30m", "+1w" style relative deltas. Returns seconds or null. */
+export function parseRelativeDelta(s: string): number | null {
+  const m = /^\+\s*(\d+)\s*([mhdw])$/i.exec(s.trim());
+  if (!m) return null;
+  const n = parseInt(m[1], 10);
+  const multipliers: Record<string, number> = { m: 60, h: 3600, d: 86400, w: 7 * 86400 };
+  return n * multipliers[m[2].toLowerCase()];
+}
+
 export function AdvanceTimePopover({
   anchor,
   currentNow,
@@ -31,7 +40,7 @@ export function AdvanceTimePopover({
   onClose,
 }: AdvanceTimePopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
-  const baseSecs = toAbsoluteSeconds(parseISOString(currentNow));
+  const baseSecs = useMemo(() => toAbsoluteSeconds(parseISOString(currentNow)), [currentNow]);
   const [pendingSecs, setPendingSecs] = useState(baseSecs);
   const [inputValue, setInputValue] = useState(currentNow);
   const [inputError, setInputError] = useState(false);
@@ -71,6 +80,14 @@ export function AdvanceTimePopover({
 
   function handleInput(value: string) {
     setInputValue(value);
+    // Try relative delta first (+5h, +2d, +1w, etc.)
+    const relDelta = parseRelativeDelta(value);
+    if (relDelta !== null) {
+      setPendingSecs(baseSecs + relDelta);
+      setInputError(false);
+      return;
+    }
+    // Fall back to absolute ISO date
     try {
       const d = parseISOString(value.trim());
       setPendingSecs(toAbsoluteSeconds(d));
@@ -86,6 +103,8 @@ export function AdvanceTimePopover({
     try {
       await onSave(toISOString(fromAbsoluteSeconds(pendingSecs)));
       onClose();
+    } catch {
+      // parent error toast surfaces the failure; keep popover open
     } finally {
       setSaving(false);
     }
@@ -117,7 +136,7 @@ export function AdvanceTimePopover({
           className={`atp-input${inputError ? ' is-error' : ''}`}
           type="text"
           value={inputValue}
-          placeholder="4726-05-04T09:30"
+          placeholder="+5h, +2d or 4726-05-04T09:30"
           onChange={(e) => handleInput(e.target.value)}
         />
       </div>

--- a/desktop/src/renderer/timeline/render/__tests__/AdvanceTimePopover.test.ts
+++ b/desktop/src/renderer/timeline/render/__tests__/AdvanceTimePopover.test.ts
@@ -16,14 +16,21 @@ function applyDelta(baseSeconds: number, delta: number): string {
 }
 
 describe('AdvanceTimePopover — quick delta buttons', () => {
+  it('+1 min advances by 60 seconds', () => {
+    const result = applyDelta(BASE_SECS, 60);
+    const parsed = parseISOString(result);
+    expect(parsed.hour).toBe(12);
+    expect(parsed.minute).toBe(1);
+  });
+
+  it('+10 min advances by 600 seconds', () => {
+    const result = applyDelta(BASE_SECS, 600);
+    expect(parseISOString(result).minute).toBe(10);
+  });
+
   it('+1 hour advances by 3600 seconds', () => {
     const result = applyDelta(BASE_SECS, 3600);
     expect(parseISOString(result).hour).toBe(13);
-  });
-
-  it('+6 hours advances by 6 hours', () => {
-    const result = applyDelta(BASE_SECS, 6 * 3600);
-    expect(parseISOString(result).hour).toBe(18);
   });
 
   it('+1 day advances to the next calendar day', () => {
@@ -36,6 +43,12 @@ describe('AdvanceTimePopover — quick delta buttons', () => {
   it('+1 week advances by 7 days', () => {
     const result = applyDelta(BASE_SECS, 7 * 86400);
     expect(parseISOString(result).day).toBe(11);
+  });
+
+  it('applying the same delta twice accumulates (each click adds more)', () => {
+    const after1 = toAbsoluteSeconds(parseISOString(applyDelta(BASE_SECS, 86400)));
+    const after2 = toAbsoluteSeconds(parseISOString(applyDelta(after1, 86400)));
+    expect(parseISOString(toISOString(fromAbsoluteSeconds(after2))).day).toBe(6);
   });
 
   it('delta crossing a month boundary rolls over correctly', () => {

--- a/desktop/src/renderer/timeline/render/__tests__/AdvanceTimePopover.test.ts
+++ b/desktop/src/renderer/timeline/render/__tests__/AdvanceTimePopover.test.ts
@@ -6,9 +6,7 @@ import {
   fromAbsoluteSeconds,
 } from '../../calendar/golarian';
 import { formatExpanded } from '../../calendar/format';
-
-// Tests for the pure logic used by AdvanceTimePopover:
-// delta application, direct-input parsing, and display formatting.
+import { parseRelativeDelta } from '../AdvanceTimePopover';
 
 const BASE_ISO = '4726-05-04T12:00:00';
 const BASE_SECS = toAbsoluteSeconds(parseISOString(BASE_ISO));
@@ -17,18 +15,15 @@ function applyDelta(baseSeconds: number, delta: number): string {
   return toISOString(fromAbsoluteSeconds(baseSeconds + delta));
 }
 
-describe('AdvanceTimePopover — delta application', () => {
+describe('AdvanceTimePopover — quick delta buttons', () => {
   it('+1 hour advances by 3600 seconds', () => {
     const result = applyDelta(BASE_SECS, 3600);
-    const parsed = parseISOString(result);
-    expect(parsed.hour).toBe(13);
-    expect(parsed.minute).toBe(0);
+    expect(parseISOString(result).hour).toBe(13);
   });
 
   it('+6 hours advances by 6 hours', () => {
     const result = applyDelta(BASE_SECS, 6 * 3600);
-    const parsed = parseISOString(result);
-    expect(parsed.hour).toBe(18);
+    expect(parseISOString(result).hour).toBe(18);
   });
 
   it('+1 day advances to the next calendar day', () => {
@@ -40,12 +35,10 @@ describe('AdvanceTimePopover — delta application', () => {
 
   it('+1 week advances by 7 days', () => {
     const result = applyDelta(BASE_SECS, 7 * 86400);
-    const parsed = parseISOString(result);
-    expect(parsed.day).toBe(11);
-    expect(parsed.month).toBe(5);
+    expect(parseISOString(result).day).toBe(11);
   });
 
-  it('advances that cross a month boundary roll over correctly', () => {
+  it('delta crossing a month boundary rolls over correctly', () => {
     const endOfMonth = toAbsoluteSeconds(parseISOString('4726-05-31T12:00:00'));
     const result = applyDelta(endOfMonth, 86400);
     const parsed = parseISOString(result);
@@ -54,17 +47,60 @@ describe('AdvanceTimePopover — delta application', () => {
   });
 });
 
-describe('AdvanceTimePopover — direct input parsing', () => {
+describe('parseRelativeDelta', () => {
+  it('parses +1h as 3600 seconds', () => {
+    expect(parseRelativeDelta('+1h')).toBe(3600);
+  });
+
+  it('parses +6h as 21600 seconds', () => {
+    expect(parseRelativeDelta('+6h')).toBe(6 * 3600);
+  });
+
+  it('parses +1d as 86400 seconds', () => {
+    expect(parseRelativeDelta('+1d')).toBe(86400);
+  });
+
+  it('parses +1w as 7 days', () => {
+    expect(parseRelativeDelta('+1w')).toBe(7 * 86400);
+  });
+
+  it('parses +30m as 1800 seconds', () => {
+    expect(parseRelativeDelta('+30m')).toBe(1800);
+  });
+
+  it('is case-insensitive for the unit', () => {
+    expect(parseRelativeDelta('+2H')).toBe(2 * 3600);
+    expect(parseRelativeDelta('+3D')).toBe(3 * 86400);
+  });
+
+  it('tolerates whitespace inside the expression', () => {
+    expect(parseRelativeDelta('+ 5 h')).toBe(5 * 3600);
+  });
+
+  it('returns null for an absolute ISO string', () => {
+    expect(parseRelativeDelta('4726-05-04T09:30')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(parseRelativeDelta('')).toBeNull();
+  });
+
+  it('returns null for garbage input', () => {
+    expect(parseRelativeDelta('banana')).toBeNull();
+    expect(parseRelativeDelta('+h')).toBeNull();
+    expect(parseRelativeDelta('+1')).toBeNull();
+  });
+});
+
+describe('AdvanceTimePopover — direct ISO input parsing', () => {
   it('parses a full ISO datetime string', () => {
     const parsed = parseISOString('4726-06-15T09:30:00');
     expect(parsed.year).toBe(4726);
-    expect(parsed.month).toBe(6);
-    expect(parsed.day).toBe(15);
     expect(parsed.hour).toBe(9);
     expect(parsed.minute).toBe(30);
   });
 
-  it('parses a date-only ISO string (time defaults to 00:00:00)', () => {
+  it('parses a date-only string (time defaults to 00:00:00)', () => {
     const parsed = parseISOString('4726-06-15');
     expect(parsed.hour).toBe(0);
     expect(parsed.minute).toBe(0);
@@ -74,24 +110,22 @@ describe('AdvanceTimePopover — direct input parsing', () => {
     expect(() => parseISOString('not-a-date')).toThrow();
   });
 
-  it('round-trips: toISOString ∘ parseISOString ∘ toISOString is stable', () => {
+  it('round-trips: toISOString ∘ parseISOString is stable', () => {
     const iso = toISOString(parseISOString(BASE_ISO));
     expect(toISOString(parseISOString(iso))).toBe(iso);
   });
 });
 
 describe('AdvanceTimePopover — display formatting', () => {
-  it('formats a pending date for the current-time display', () => {
+  it('includes year, month name and time in expanded format', () => {
     const formatted = formatExpanded(fromAbsoluteSeconds(BASE_SECS));
     expect(formatted).toContain('4726');
     expect(formatted).toContain('Desnus');
-    // time portion included since hour ≠ 0
     expect(formatted).toContain('12:00');
   });
 
-  it('omits time portion when hour is midnight', () => {
+  it('omits time when hour is midnight', () => {
     const midnight = toAbsoluteSeconds(parseISOString('4726-05-04'));
-    const formatted = formatExpanded(fromAbsoluteSeconds(midnight));
-    expect(formatted).not.toContain(':');
+    expect(formatExpanded(fromAbsoluteSeconds(midnight))).not.toContain(':');
   });
 });

--- a/desktop/src/renderer/timeline/render/__tests__/AdvanceTimePopover.test.ts
+++ b/desktop/src/renderer/timeline/render/__tests__/AdvanceTimePopover.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseISOString,
+  toISOString,
+  toAbsoluteSeconds,
+  fromAbsoluteSeconds,
+} from '../../calendar/golarian';
+import { formatExpanded } from '../../calendar/format';
+
+// Tests for the pure logic used by AdvanceTimePopover:
+// delta application, direct-input parsing, and display formatting.
+
+const BASE_ISO = '4726-05-04T12:00:00';
+const BASE_SECS = toAbsoluteSeconds(parseISOString(BASE_ISO));
+
+function applyDelta(baseSeconds: number, delta: number): string {
+  return toISOString(fromAbsoluteSeconds(baseSeconds + delta));
+}
+
+describe('AdvanceTimePopover — delta application', () => {
+  it('+1 hour advances by 3600 seconds', () => {
+    const result = applyDelta(BASE_SECS, 3600);
+    const parsed = parseISOString(result);
+    expect(parsed.hour).toBe(13);
+    expect(parsed.minute).toBe(0);
+  });
+
+  it('+6 hours advances by 6 hours', () => {
+    const result = applyDelta(BASE_SECS, 6 * 3600);
+    const parsed = parseISOString(result);
+    expect(parsed.hour).toBe(18);
+  });
+
+  it('+1 day advances to the next calendar day', () => {
+    const result = applyDelta(BASE_SECS, 86400);
+    const parsed = parseISOString(result);
+    expect(parsed.day).toBe(5);
+    expect(parsed.month).toBe(5);
+  });
+
+  it('+1 week advances by 7 days', () => {
+    const result = applyDelta(BASE_SECS, 7 * 86400);
+    const parsed = parseISOString(result);
+    expect(parsed.day).toBe(11);
+    expect(parsed.month).toBe(5);
+  });
+
+  it('advances that cross a month boundary roll over correctly', () => {
+    const endOfMonth = toAbsoluteSeconds(parseISOString('4726-05-31T12:00:00'));
+    const result = applyDelta(endOfMonth, 86400);
+    const parsed = parseISOString(result);
+    expect(parsed.day).toBe(1);
+    expect(parsed.month).toBe(6);
+  });
+});
+
+describe('AdvanceTimePopover — direct input parsing', () => {
+  it('parses a full ISO datetime string', () => {
+    const parsed = parseISOString('4726-06-15T09:30:00');
+    expect(parsed.year).toBe(4726);
+    expect(parsed.month).toBe(6);
+    expect(parsed.day).toBe(15);
+    expect(parsed.hour).toBe(9);
+    expect(parsed.minute).toBe(30);
+  });
+
+  it('parses a date-only ISO string (time defaults to 00:00:00)', () => {
+    const parsed = parseISOString('4726-06-15');
+    expect(parsed.hour).toBe(0);
+    expect(parsed.minute).toBe(0);
+  });
+
+  it('throws on invalid input', () => {
+    expect(() => parseISOString('not-a-date')).toThrow();
+  });
+
+  it('round-trips: toISOString ∘ parseISOString ∘ toISOString is stable', () => {
+    const iso = toISOString(parseISOString(BASE_ISO));
+    expect(toISOString(parseISOString(iso))).toBe(iso);
+  });
+});
+
+describe('AdvanceTimePopover — display formatting', () => {
+  it('formats a pending date for the current-time display', () => {
+    const formatted = formatExpanded(fromAbsoluteSeconds(BASE_SECS));
+    expect(formatted).toContain('4726');
+    expect(formatted).toContain('Desnus');
+    // time portion included since hour ≠ 0
+    expect(formatted).toContain('12:00');
+  });
+
+  it('omits time portion when hour is midnight', () => {
+    const midnight = toAbsoluteSeconds(parseISOString('4726-05-04'));
+    const formatted = formatExpanded(fromAbsoluteSeconds(midnight));
+    expect(formatted).not.toContain(':');
+  });
+});

--- a/desktop/src/renderer/timeline/render/now-marker.css
+++ b/desktop/src/renderer/timeline/render/now-marker.css
@@ -15,9 +15,8 @@
   display: flex;
   flex-direction: column;
   gap: 1px;
-  /* pointer-events: auto + context-menu cursor will land here when the
-     advance-time popover lands (issue #82 is read-only). */
-  pointer-events: none;
+  pointer-events: auto;
+  cursor: context-menu;
 }
 
 .now-marker-date {

--- a/desktop/src/renderer/timeline/render/now-marker.tsx
+++ b/desktop/src/renderer/timeline/render/now-marker.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react';
+import type React from 'react';
 import './now-marker.css';
 import type { ViewState, ViewportSize } from '../math/zoom';
 import { secondsToX } from '../math/zoom';
@@ -48,6 +49,7 @@ interface NowMarkerProps {
   size: ViewportSize;
   inGameNow: string;
   inGameNowSeconds: number;
+  onContextMenu?: (e: React.MouseEvent) => void;
 }
 
 export function NowMarker({
@@ -55,13 +57,19 @@ export function NowMarker({
   size,
   inGameNow,
   inGameNowSeconds,
+  onContextMenu,
 }: NowMarkerProps): ReactElement | null {
   const layout = computeNowMarkerLayout(view, size, inGameNow, inGameNowSeconds);
   if (layout === null) return null;
 
   return (
     <div className="now-marker" style={{ left: layout.x }}>
-      <div className="now-marker-labels" style={{ top: layout.labelTop }}>
+      <div
+        className="now-marker-labels"
+        style={{ top: layout.labelTop }}
+        onContextMenu={onContextMenu}
+        title={onContextMenu ? 'Right-click to advance time' : undefined}
+      >
         <div className="now-marker-date">{layout.dayMonth}</div>
         <div className="now-marker-year">{layout.year}</div>
         {layout.time !== null && <div className="now-marker-time">{layout.time}</div>}

--- a/desktop/src/renderer/timeline/render/now-marker.tsx
+++ b/desktop/src/renderer/timeline/render/now-marker.tsx
@@ -1,5 +1,4 @@
-import type { ReactElement } from 'react';
-import type React from 'react';
+import type { ReactElement, MouseEvent } from 'react';
 import './now-marker.css';
 import type { ViewState, ViewportSize } from '../math/zoom';
 import { secondsToX } from '../math/zoom';
@@ -49,7 +48,7 @@ interface NowMarkerProps {
   size: ViewportSize;
   inGameNow: string;
   inGameNowSeconds: number;
-  onContextMenu?: (e: React.MouseEvent) => void;
+  onContextMenu?: (e: MouseEvent<HTMLDivElement>) => void;
 }
 
 export function NowMarker({

--- a/desktop/src/renderer/views/relationships/relationships-view.tsx
+++ b/desktop/src/renderer/views/relationships/relationships-view.tsx
@@ -59,7 +59,7 @@ export function RelationshipsView() {
         )}
       </div>
 
-      <FooterPortal>
+      <FooterPortal slot="right">
         <button
           onClick={() => setNodesExpanded(!nodesExpanded)}
           style={{

--- a/desktop/src/renderer/views/timeline/__tests__/timeline-view-persistence.test.ts
+++ b/desktop/src/renderer/views/timeline/__tests__/timeline-view-persistence.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DEFAULT_SECONDS_PER_PIXEL } from '../../../timeline/math/zoom';
+
+// We test the persistence helpers extracted from timeline-view by reimplementing
+// them here so the test does not need to mount a React component.
+
+type ViewState = { centerSeconds: number; secondsPerPixel: number };
+
+function key(campaignPath: string) {
+  return `timeline-view:${campaignPath}`;
+}
+
+function loadSaved(campaignPath: string): ViewState | null {
+  try {
+    const raw = localStorage.getItem(key(campaignPath));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'centerSeconds' in parsed &&
+      'secondsPerPixel' in parsed &&
+      typeof (parsed as ViewState).centerSeconds === 'number' &&
+      typeof (parsed as ViewState).secondsPerPixel === 'number'
+    ) {
+      return parsed as ViewState;
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+function save(campaignPath: string, view: ViewState): void {
+  localStorage.setItem(key(campaignPath), JSON.stringify(view));
+}
+
+const CAMPAIGN = '/campaigns/test';
+const SAMPLE: ViewState = { centerSeconds: 12345, secondsPerPixel: DEFAULT_SECONDS_PER_PIXEL };
+
+describe('timeline view state persistence', () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it('returns null when nothing is stored', () => {
+    expect(loadSaved(CAMPAIGN)).toBeNull();
+  });
+
+  it('round-trips a valid view state', () => {
+    save(CAMPAIGN, SAMPLE);
+    expect(loadSaved(CAMPAIGN)).toEqual(SAMPLE);
+  });
+
+  it('returns null for malformed JSON', () => {
+    localStorage.setItem(key(CAMPAIGN), 'not-json');
+    expect(loadSaved(CAMPAIGN)).toBeNull();
+  });
+
+  it('returns null when required fields are missing', () => {
+    localStorage.setItem(key(CAMPAIGN), JSON.stringify({ centerSeconds: 1 }));
+    expect(loadSaved(CAMPAIGN)).toBeNull();
+  });
+
+  it('returns null when field types are wrong', () => {
+    localStorage.setItem(
+      key(CAMPAIGN),
+      JSON.stringify({ centerSeconds: 'abc', secondsPerPixel: 432 }),
+    );
+    expect(loadSaved(CAMPAIGN)).toBeNull();
+  });
+
+  it('isolates state by campaign path', () => {
+    const other: ViewState = { centerSeconds: 99999, secondsPerPixel: 1 };
+    save(CAMPAIGN, SAMPLE);
+    save('/campaigns/other', other);
+    expect(loadSaved(CAMPAIGN)).toEqual(SAMPLE);
+    expect(loadSaved('/campaigns/other')).toEqual(other);
+  });
+
+  it('overwrites previous state on repeated save', () => {
+    save(CAMPAIGN, SAMPLE);
+    const updated: ViewState = { centerSeconds: 999, secondsPerPixel: 2 };
+    save(CAMPAIGN, updated);
+    expect(loadSaved(CAMPAIGN)).toEqual(updated);
+  });
+
+  it('survives a failing localStorage gracefully', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage blocked');
+    });
+    expect(() => loadSaved(CAMPAIGN)).not.toThrow();
+    expect(loadSaved(CAMPAIGN)).toBeNull();
+    vi.restoreAllMocks();
+  });
+});

--- a/desktop/src/renderer/views/timeline/__tests__/timeline-view-persistence.test.ts
+++ b/desktop/src/renderer/views/timeline/__tests__/timeline-view-persistence.test.ts
@@ -1,96 +1,71 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { loadSavedViewState, saveViewState } from '../view-state-persistence';
 import { DEFAULT_SECONDS_PER_PIXEL } from '../../../timeline/math/zoom';
 
-// We test the persistence helpers extracted from timeline-view by reimplementing
-// them here so the test does not need to mount a React component.
-
-type ViewState = { centerSeconds: number; secondsPerPixel: number };
-
-function key(campaignPath: string) {
-  return `timeline-view:${campaignPath}`;
-}
-
-function loadSaved(campaignPath: string): ViewState | null {
-  try {
-    const raw = localStorage.getItem(key(campaignPath));
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as unknown;
-    if (
-      parsed &&
-      typeof parsed === 'object' &&
-      'centerSeconds' in parsed &&
-      'secondsPerPixel' in parsed &&
-      typeof (parsed as ViewState).centerSeconds === 'number' &&
-      typeof (parsed as ViewState).secondsPerPixel === 'number'
-    ) {
-      return parsed as ViewState;
-    }
-  } catch {
-    /* ignore */
-  }
-  return null;
-}
-
-function save(campaignPath: string, view: ViewState): void {
-  localStorage.setItem(key(campaignPath), JSON.stringify(view));
-}
-
 const CAMPAIGN = '/campaigns/test';
-const SAMPLE: ViewState = { centerSeconds: 12345, secondsPerPixel: DEFAULT_SECONDS_PER_PIXEL };
+const SAMPLE = { centerSeconds: 12345, secondsPerPixel: DEFAULT_SECONDS_PER_PIXEL };
 
 describe('timeline view state persistence', () => {
   beforeEach(() => localStorage.clear());
   afterEach(() => localStorage.clear());
 
   it('returns null when nothing is stored', () => {
-    expect(loadSaved(CAMPAIGN)).toBeNull();
+    expect(loadSavedViewState(CAMPAIGN)).toBeNull();
   });
 
   it('round-trips a valid view state', () => {
-    save(CAMPAIGN, SAMPLE);
-    expect(loadSaved(CAMPAIGN)).toEqual(SAMPLE);
+    saveViewState(CAMPAIGN, SAMPLE);
+    expect(loadSavedViewState(CAMPAIGN)).toEqual(SAMPLE);
   });
 
   it('returns null for malformed JSON', () => {
-    localStorage.setItem(key(CAMPAIGN), 'not-json');
-    expect(loadSaved(CAMPAIGN)).toBeNull();
+    localStorage.setItem(`timeline-view:${CAMPAIGN}`, 'not-json');
+    expect(loadSavedViewState(CAMPAIGN)).toBeNull();
   });
 
   it('returns null when required fields are missing', () => {
-    localStorage.setItem(key(CAMPAIGN), JSON.stringify({ centerSeconds: 1 }));
-    expect(loadSaved(CAMPAIGN)).toBeNull();
+    localStorage.setItem(`timeline-view:${CAMPAIGN}`, JSON.stringify({ centerSeconds: 1 }));
+    expect(loadSavedViewState(CAMPAIGN)).toBeNull();
   });
 
   it('returns null when field types are wrong', () => {
     localStorage.setItem(
-      key(CAMPAIGN),
+      `timeline-view:${CAMPAIGN}`,
       JSON.stringify({ centerSeconds: 'abc', secondsPerPixel: 432 }),
     );
-    expect(loadSaved(CAMPAIGN)).toBeNull();
+    expect(loadSavedViewState(CAMPAIGN)).toBeNull();
   });
 
   it('isolates state by campaign path', () => {
-    const other: ViewState = { centerSeconds: 99999, secondsPerPixel: 1 };
-    save(CAMPAIGN, SAMPLE);
-    save('/campaigns/other', other);
-    expect(loadSaved(CAMPAIGN)).toEqual(SAMPLE);
-    expect(loadSaved('/campaigns/other')).toEqual(other);
+    const other = { centerSeconds: 99999, secondsPerPixel: 1 };
+    saveViewState(CAMPAIGN, SAMPLE);
+    saveViewState('/campaigns/other', other);
+    expect(loadSavedViewState(CAMPAIGN)).toEqual(SAMPLE);
+    expect(loadSavedViewState('/campaigns/other')).toEqual(other);
   });
 
   it('overwrites previous state on repeated save', () => {
-    save(CAMPAIGN, SAMPLE);
-    const updated: ViewState = { centerSeconds: 999, secondsPerPixel: 2 };
-    save(CAMPAIGN, updated);
-    expect(loadSaved(CAMPAIGN)).toEqual(updated);
+    saveViewState(CAMPAIGN, SAMPLE);
+    const updated = { centerSeconds: 999, secondsPerPixel: 2 };
+    saveViewState(CAMPAIGN, updated);
+    expect(loadSavedViewState(CAMPAIGN)).toEqual(updated);
   });
 
-  it('survives a failing localStorage gracefully', () => {
+  it('survives a failing localStorage.getItem gracefully', () => {
     vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
       throw new Error('storage blocked');
     });
-    expect(() => loadSaved(CAMPAIGN)).not.toThrow();
-    expect(loadSaved(CAMPAIGN)).toBeNull();
+    expect(() => loadSavedViewState(CAMPAIGN)).not.toThrow();
+    expect(loadSavedViewState(CAMPAIGN)).toBeNull();
+    vi.restoreAllMocks();
+  });
+
+  it('survives a failing localStorage.setItem gracefully', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage blocked');
+    });
+    expect(() => saveViewState(CAMPAIGN, SAMPLE)).not.toThrow();
     vi.restoreAllMocks();
   });
 });

--- a/desktop/src/renderer/views/timeline/timeline-view.tsx
+++ b/desktop/src/renderer/views/timeline/timeline-view.tsx
@@ -407,15 +407,15 @@ export function TimelineView({ campaignPath, palette }: TimelineViewProps) {
       {/* Footer buttons — center slot, hidden while event editor is open */}
       {!editor.editorMode && (
         <FooterPortal slot="center">
-          <FooterButton onClick={handleJumpToNow} title="Jump to in-game now">
-            Now
-          </FooterButton>
           <FooterButton
             variant="primary"
             onClick={() => editor.openCreate()}
             title="Create a new event"
           >
             + Event
+          </FooterButton>
+          <FooterButton onClick={handleJumpToNow} title="Jump to in-game now">
+            Now
           </FooterButton>
         </FooterPortal>
       )}

--- a/desktop/src/renderer/views/timeline/timeline-view.tsx
+++ b/desktop/src/renderer/views/timeline/timeline-view.tsx
@@ -26,10 +26,15 @@ import { useQuickAddZones } from '../../timeline/interactions/useQuickAddZones';
 import { useEventEditor } from '../../timeline/event-editor/useEventEditor';
 import { EventEditorModal } from '../../timeline/event-editor/EventEditorModal';
 import { sessionTagsForSeconds } from '../../timeline/render/session-bands';
+import { AdvanceTimePopover } from '../../timeline/render/AdvanceTimePopover';
+import { FooterPortal } from '../../components/footer-portal';
+import { FooterButton } from '../../components/footer-button';
+import type { CSSProperties } from 'react';
 import './timeline-view.css';
 
 interface TimelineViewProps {
   campaignPath: string;
+  onPaletteVarsChange?: (vars: CSSProperties | null) => void;
 }
 
 interface LoadedData {
@@ -39,7 +44,40 @@ interface LoadedData {
   sessions: Session[];
 }
 
-export function TimelineView({ campaignPath }: TimelineViewProps) {
+function viewStatePersistenceKey(campaignPath: string): string {
+  return `timeline-view:${campaignPath}`;
+}
+
+function loadSavedViewState(campaignPath: string): ViewState | null {
+  try {
+    const raw = localStorage.getItem(viewStatePersistenceKey(campaignPath));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'centerSeconds' in parsed &&
+      'secondsPerPixel' in parsed &&
+      typeof (parsed as ViewState).centerSeconds === 'number' &&
+      typeof (parsed as ViewState).secondsPerPixel === 'number'
+    ) {
+      return parsed as ViewState;
+    }
+  } catch {
+    // ignore malformed data
+  }
+  return null;
+}
+
+function saveViewState(campaignPath: string, view: ViewState): void {
+  try {
+    localStorage.setItem(viewStatePersistenceKey(campaignPath), JSON.stringify(view));
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function TimelineView({ campaignPath, onPaletteVarsChange }: TimelineViewProps) {
   const [viewState, setViewState] = useState<ViewState>({
     centerSeconds: 0,
     secondsPerPixel: DEFAULT_SECONDS_PER_PIXEL,
@@ -52,6 +90,7 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
     sessions: [],
   });
   const [rescheduleError, setRescheduleError] = useState<string | null>(null);
+  const [advanceTimeAnchor, setAdvanceTimeAnchor] = useState<{ x: number; y: number } | null>(null);
 
   const resizingRef = useRef(false);
   const handleResizeDragChange = useCallback((active: boolean) => {
@@ -180,6 +219,18 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
     return () => ro.disconnect();
   }, []);
 
+  // Persist view state to localStorage on every change (debounced).
+  const persistDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (persistDebounceRef.current) clearTimeout(persistDebounceRef.current);
+    persistDebounceRef.current = setTimeout(() => {
+      saveViewState(campaignPath, viewState);
+    }, 300);
+    return () => {
+      if (persistDebounceRef.current) clearTimeout(persistDebounceRef.current);
+    };
+  }, [campaignPath, viewState]);
+
   useEffect(() => {
     let cancelled = false;
     Promise.all([
@@ -189,13 +240,45 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
       timelinePort.getSessions(campaignPath),
     ])
       .then(([palette, gameState, events, sessions]) => {
-        if (!cancelled) setLoadedData({ palette, gameState, events, sessions });
+        if (cancelled) return;
+        setLoadedData({ palette, gameState, events, sessions });
+
+        // Propagate palette CSS vars upward for footer theming.
+        onPaletteVarsChange?.(paletteToCssVars(palette));
+
+        // Restore saved view state, or center on in-game now.
+        const saved = loadSavedViewState(campaignPath);
+        if (saved) {
+          setViewState(saved);
+        } else {
+          const nowSeconds = toAbsoluteSeconds(parseISOString(gameState.in_game_now));
+          setViewState({ centerSeconds: nowSeconds, secondsPerPixel: DEFAULT_SECONDS_PER_PIXEL });
+        }
       })
       .catch((err) => console.error('[TimelineView] failed to load campaign data', err));
     return () => {
       cancelled = true;
+      onPaletteVarsChange?.(null);
     };
-  }, [campaignPath]);
+  }, [campaignPath, onPaletteVarsChange]);
+
+  const handleAdvanceTimeSave = useCallback(
+    async (newNow: string) => {
+      const current = gameStateRef.current;
+      if (!current) return;
+      const next: State = { ...current, in_game_now: newNow };
+      await timelinePort.putState(campaignPath, next);
+      setLoadedData((d) => ({ ...d, gameState: next }));
+    },
+    [campaignPath],
+  );
+
+  const handleJumpToNow = useCallback(() => {
+    const current = gameStateRef.current;
+    if (!current) return;
+    const nowSeconds = toAbsoluteSeconds(parseISOString(current.in_game_now));
+    setViewState((v) => ({ ...v, centerSeconds: nowSeconds }));
+  }, []);
 
   const bgColor = loadedData.palette?.theme.background ?? '#09090b';
   const inGameNow = loadedData.gameState?.in_game_now || null;
@@ -252,23 +335,15 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
             size={viewportSize}
             inGameNow={inGameNow}
             inGameNowSeconds={inGameNowSeconds}
+            onContextMenu={(e) => {
+              e.preventDefault();
+              setAdvanceTimeAnchor({ x: e.clientX, y: e.clientY });
+            }}
           />
         )}
 
         {/* Drag-to-reschedule floating time label */}
         <div ref={dragLabelRef} className="reschedule-drag-label" style={{ display: 'none' }} />
-
-        {/* New Event button — mouseDown stops pan from starting */}
-        <button
-          className="timeline-new-event-btn"
-          onClick={(e) => {
-            e.stopPropagation();
-            editor.openCreate();
-          }}
-          onMouseDown={(e) => e.stopPropagation()}
-        >
-          + New Event
-        </button>
 
         {/* Reschedule error toast */}
         {rescheduleError && <div className="timeline-error-toast">{rescheduleError}</div>}
@@ -327,6 +402,16 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
         )}
       </div>
 
+      {/* Advance-time popover — rendered outside viewport via portal */}
+      {advanceTimeAnchor && inGameNow && (
+        <AdvanceTimePopover
+          anchor={advanceTimeAnchor}
+          currentNow={inGameNow}
+          onSave={handleAdvanceTimeSave}
+          onClose={() => setAdvanceTimeAnchor(null)}
+        />
+      )}
+
       {/* Event editor modal — rendered outside viewport to avoid pan/zoom transform */}
       {editor.editorMode && (
         <EventEditorModal
@@ -338,6 +423,23 @@ export function TimelineView({ campaignPath }: TimelineViewProps) {
           onAutosaved={editor.handleAutosaved}
           onDeleted={editor.handleDeleted}
         />
+      )}
+
+      {/* Footer buttons — injected via portal when not in editor mode */}
+      {!editor.editorMode && (
+        <FooterPortal>
+          <FooterButton onClick={handleJumpToNow} title="Jump to in-game now">
+            Now
+          </FooterButton>
+          <FooterButton
+            variant="primary"
+            onClick={() => editor.openCreate()}
+            onMouseDown={(e) => e.stopPropagation()}
+            title="Create a new event"
+          >
+            + Event
+          </FooterButton>
+        </FooterPortal>
       )}
     </>
   );

--- a/desktop/src/renderer/views/timeline/timeline-view.tsx
+++ b/desktop/src/renderer/views/timeline/timeline-view.tsx
@@ -29,69 +29,36 @@ import { sessionTagsForSeconds } from '../../timeline/render/session-bands';
 import { AdvanceTimePopover } from '../../timeline/render/AdvanceTimePopover';
 import { FooterPortal } from '../../components/footer-portal';
 import { FooterButton } from '../../components/footer-button';
-import type { CSSProperties } from 'react';
+import { loadSavedViewState, saveViewState } from './view-state-persistence';
 import './timeline-view.css';
 
 interface TimelineViewProps {
   campaignPath: string;
-  onPaletteVarsChange?: (vars: CSSProperties | null) => void;
+  /** Palette loaded at the App level so theming persists across view switches. */
+  palette: Palette | null;
 }
 
 interface LoadedData {
-  palette: Palette | null;
   gameState: State | null;
   events: EventListItem[];
   sessions: Session[];
 }
 
-function viewStatePersistenceKey(campaignPath: string): string {
-  return `timeline-view:${campaignPath}`;
-}
-
-function loadSavedViewState(campaignPath: string): ViewState | null {
-  try {
-    const raw = localStorage.getItem(viewStatePersistenceKey(campaignPath));
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as unknown;
-    if (
-      parsed &&
-      typeof parsed === 'object' &&
-      'centerSeconds' in parsed &&
-      'secondsPerPixel' in parsed &&
-      typeof (parsed as ViewState).centerSeconds === 'number' &&
-      typeof (parsed as ViewState).secondsPerPixel === 'number'
-    ) {
-      return parsed as ViewState;
-    }
-  } catch {
-    // ignore malformed data
-  }
-  return null;
-}
-
-function saveViewState(campaignPath: string, view: ViewState): void {
-  try {
-    localStorage.setItem(viewStatePersistenceKey(campaignPath), JSON.stringify(view));
-  } catch {
-    // ignore storage errors
-  }
-}
-
-export function TimelineView({ campaignPath, onPaletteVarsChange }: TimelineViewProps) {
+export function TimelineView({ campaignPath, palette }: TimelineViewProps) {
   const [viewState, setViewState] = useState<ViewState>({
     centerSeconds: 0,
     secondsPerPixel: DEFAULT_SECONDS_PER_PIXEL,
   });
   const [viewportSize, setViewportSize] = useState<ViewportSize>({ width: 0, height: 0 });
   const [loadedData, setLoadedData] = useState<LoadedData>({
-    palette: null,
     gameState: null,
     events: [],
     sessions: [],
   });
-  const [rescheduleError, setRescheduleError] = useState<string | null>(null);
+  const [timelineError, setTimelineError] = useState<string | null>(null);
   const [advanceTimeAnchor, setAdvanceTimeAnchor] = useState<{ x: number; y: number } | null>(null);
 
+  const isInitialized = useRef(false);
   const resizingRef = useRef(false);
   const handleResizeDragChange = useCallback((active: boolean) => {
     resizingRef.current = active;
@@ -155,8 +122,8 @@ export function TimelineView({ campaignPath, onPaletteVarsChange }: TimelineView
           err instanceof ConflictError
             ? `"${filename}" was modified on disk — reschedule reverted.`
             : 'Reschedule failed. Please try again.';
-        setRescheduleError(msg);
-        setTimeout(() => setRescheduleError(null), 4000);
+        setTimelineError(msg);
+        setTimeout(() => setTimelineError(null), 4000);
         // Rethrow so the reschedule module immediately reverts the card's DOM position.
         throw err;
       }
@@ -219,9 +186,42 @@ export function TimelineView({ campaignPath, onPaletteVarsChange }: TimelineView
     return () => ro.disconnect();
   }, []);
 
+  // Load campaign data. Defined before the persist effect so React runs this
+  // first when campaignPath changes, resetting isInitialized before persist fires.
+  useEffect(() => {
+    isInitialized.current = false;
+    let cancelled = false;
+    Promise.all([
+      timelinePort.getState(campaignPath),
+      timelinePort.listEvents(campaignPath),
+      timelinePort.getSessions(campaignPath),
+    ])
+      .then(([gameState, events, sessions]) => {
+        if (cancelled) return;
+        setLoadedData({ gameState, events, sessions });
+
+        // Restore saved view state, or default to centering on in-game now.
+        const saved = loadSavedViewState(campaignPath);
+        if (saved) {
+          setViewState(saved);
+        } else {
+          const fallback = gameState.in_game_now || gameState.campaign_start;
+          const nowSeconds = fallback ? toAbsoluteSeconds(parseISOString(fallback)) : 0;
+          setViewState({ centerSeconds: nowSeconds, secondsPerPixel: DEFAULT_SECONDS_PER_PIXEL });
+        }
+        isInitialized.current = true;
+      })
+      .catch((err) => console.error('[TimelineView] failed to load campaign data', err));
+    return () => {
+      cancelled = true;
+    };
+  }, [campaignPath]);
+
   // Persist view state to localStorage on every change (debounced).
+  // Guard: only runs after initial data load to avoid overwriting saved state.
   const persistDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
+    if (!isInitialized.current) return;
     if (persistDebounceRef.current) clearTimeout(persistDebounceRef.current);
     persistDebounceRef.current = setTimeout(() => {
       saveViewState(campaignPath, viewState);
@@ -231,44 +231,20 @@ export function TimelineView({ campaignPath, onPaletteVarsChange }: TimelineView
     };
   }, [campaignPath, viewState]);
 
-  useEffect(() => {
-    let cancelled = false;
-    Promise.all([
-      timelinePort.loadPalette(campaignPath),
-      timelinePort.getState(campaignPath),
-      timelinePort.listEvents(campaignPath),
-      timelinePort.getSessions(campaignPath),
-    ])
-      .then(([palette, gameState, events, sessions]) => {
-        if (cancelled) return;
-        setLoadedData({ palette, gameState, events, sessions });
-
-        // Propagate palette CSS vars upward for footer theming.
-        onPaletteVarsChange?.(paletteToCssVars(palette));
-
-        // Restore saved view state, or center on in-game now.
-        const saved = loadSavedViewState(campaignPath);
-        if (saved) {
-          setViewState(saved);
-        } else {
-          const nowSeconds = toAbsoluteSeconds(parseISOString(gameState.in_game_now));
-          setViewState({ centerSeconds: nowSeconds, secondsPerPixel: DEFAULT_SECONDS_PER_PIXEL });
-        }
-      })
-      .catch((err) => console.error('[TimelineView] failed to load campaign data', err));
-    return () => {
-      cancelled = true;
-      onPaletteVarsChange?.(null);
-    };
-  }, [campaignPath, onPaletteVarsChange]);
-
   const handleAdvanceTimeSave = useCallback(
     async (newNow: string) => {
       const current = gameStateRef.current;
       if (!current) return;
       const next: State = { ...current, in_game_now: newNow };
-      await timelinePort.putState(campaignPath, next);
-      setLoadedData((d) => ({ ...d, gameState: next }));
+      try {
+        await timelinePort.putState(campaignPath, next);
+        setLoadedData((d) => ({ ...d, gameState: next }));
+      } catch (err) {
+        console.error('[handleAdvanceTimeSave] failed', err);
+        setTimelineError('Failed to advance time. Please try again.');
+        setTimeout(() => setTimelineError(null), 4000);
+        throw err;
+      }
     },
     [campaignPath],
   );
@@ -280,7 +256,7 @@ export function TimelineView({ campaignPath, onPaletteVarsChange }: TimelineView
     setViewState((v) => ({ ...v, centerSeconds: nowSeconds }));
   }, []);
 
-  const bgColor = loadedData.palette?.theme.background ?? '#09090b';
+  const bgColor = palette?.theme.background ?? '#09090b';
   const inGameNow = loadedData.gameState?.in_game_now || null;
   const inGameNowSeconds = inGameNow ? toAbsoluteSeconds(parseISOString(inGameNow)) : Infinity;
 
@@ -293,6 +269,7 @@ export function TimelineView({ campaignPath, onPaletteVarsChange }: TimelineView
         data-height={viewportSize.height}
         data-center={viewState.centerSeconds}
         data-scale={viewState.secondsPerPixel}
+        onContextMenu={(e) => e.preventDefault()}
         style={{
           position: 'relative',
           width: '100%',
@@ -301,11 +278,11 @@ export function TimelineView({ campaignPath, onPaletteVarsChange }: TimelineView
           overflow: 'hidden',
           cursor: 'grab',
           userSelect: 'none',
-          ...(loadedData.palette ? paletteToCssVars(loadedData.palette) : {}),
+          ...(palette ? paletteToCssVars(palette) : {}),
         }}
       >
-        {loadedData.palette && <Axis view={viewState} size={viewportSize} />}
-        {loadedData.palette && (
+        {palette && <Axis view={viewState} size={viewportSize} />}
+        {palette && (
           <SessionBands
             sessions={loadedData.sessions}
             events={loadedData.events}
@@ -313,12 +290,12 @@ export function TimelineView({ campaignPath, onPaletteVarsChange }: TimelineView
             size={viewportSize}
           />
         )}
-        {loadedData.palette && (
+        {palette && (
           <Cards
             events={loadedData.events}
             view={viewState}
             size={viewportSize}
-            palette={loadedData.palette}
+            palette={palette}
             inGameNowSeconds={inGameNowSeconds}
             expansion={expansion}
             previewSize={previewSize}
@@ -329,7 +306,7 @@ export function TimelineView({ campaignPath, onPaletteVarsChange }: TimelineView
             onDeleteClick={editor.requestDeleteFromCard}
           />
         )}
-        {loadedData.palette && inGameNow && (
+        {palette && inGameNow && (
           <NowMarker
             view={viewState}
             size={viewportSize}
@@ -337,7 +314,9 @@ export function TimelineView({ campaignPath, onPaletteVarsChange }: TimelineView
             inGameNowSeconds={inGameNowSeconds}
             onContextMenu={(e) => {
               e.preventDefault();
-              setAdvanceTimeAnchor({ x: e.clientX, y: e.clientY });
+              e.stopPropagation();
+              const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
+              setAdvanceTimeAnchor({ x: r.left, y: r.top });
             }}
           />
         )}
@@ -345,8 +324,8 @@ export function TimelineView({ campaignPath, onPaletteVarsChange }: TimelineView
         {/* Drag-to-reschedule floating time label */}
         <div ref={dragLabelRef} className="reschedule-drag-label" style={{ display: 'none' }} />
 
-        {/* Reschedule error toast */}
-        {rescheduleError && <div className="timeline-error-toast">{rescheduleError}</div>}
+        {/* Error toast (reschedule failures, advance-time failures) */}
+        {timelineError && <div className="timeline-error-toast">{timelineError}</div>}
 
         {/* Card-delete conflict overlay (inline modal) */}
         {editor.cardDeleteConflict && (
@@ -425,16 +404,15 @@ export function TimelineView({ campaignPath, onPaletteVarsChange }: TimelineView
         />
       )}
 
-      {/* Footer buttons — injected via portal when not in editor mode */}
+      {/* Footer buttons — center slot, hidden while event editor is open */}
       {!editor.editorMode && (
-        <FooterPortal>
+        <FooterPortal slot="center">
           <FooterButton onClick={handleJumpToNow} title="Jump to in-game now">
             Now
           </FooterButton>
           <FooterButton
             variant="primary"
             onClick={() => editor.openCreate()}
-            onMouseDown={(e) => e.stopPropagation()}
             title="Create a new event"
           >
             + Event

--- a/desktop/src/renderer/views/timeline/view-state-persistence.ts
+++ b/desktop/src/renderer/views/timeline/view-state-persistence.ts
@@ -1,0 +1,34 @@
+import type { ViewState } from '../../timeline/math/zoom';
+
+function persistenceKey(campaignPath: string): string {
+  return `timeline-view:${campaignPath}`;
+}
+
+export function loadSavedViewState(campaignPath: string): ViewState | null {
+  try {
+    const raw = localStorage.getItem(persistenceKey(campaignPath));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'centerSeconds' in parsed &&
+      'secondsPerPixel' in parsed &&
+      typeof (parsed as ViewState).centerSeconds === 'number' &&
+      typeof (parsed as ViewState).secondsPerPixel === 'number'
+    ) {
+      return parsed as ViewState;
+    }
+  } catch {
+    // ignore malformed data
+  }
+  return null;
+}
+
+export function saveViewState(campaignPath: string, view: ViewState): void {
+  try {
+    localStorage.setItem(persistenceKey(campaignPath), JSON.stringify(view));
+  } catch {
+    // ignore storage errors
+  }
+}


### PR DESCRIPTION
## Summary

- **Right-click now-marker** opens `AdvanceTimePopover`: quick delta buttons (+1h / +6h / +1 day / +1 week), relative text input (`+5h`, `+2d`, `+1w`, `+30m`), ISO date/time input, Esc and outside-click to dismiss. Saves via `timelinePort.putState`; marker moves immediately. Errors surface in the existing timeline error toast.
- **Timeline initial position** defaults to in-game now (falls back to `campaign_start`, then 0). Zoom level and pan position are persisted to `localStorage` per campaign path (extracted to `view-state-persistence.ts` with an `isInitialized` ref guard to prevent startup clobber).
- **Footer redesigned as a 3-slot grid** (`left` / `center` / `right`). `FooterPortal` gains a `slot` prop (default `'right'` for backward compat). `FooterButton` component added with `default` / `primary` / `active` variants. Timeline contributes "Now" (jump to in-game now) and "+ Event" (primary) in the center slot, hidden while the event editor is open. Old floating `timeline-new-event-btn` removed. Notes, EventEditorModal, and Relationships updated to named slots.
- **Palette loading lifted to App** via new `useCampaignPalette` hook so CSS vars persist across view switches (fixes footer colour loss when switching away from Timeline and back).

All 526 tests pass; lint clean; build clean. Zero changes outside `desktop/`.

## Test plan

- [x] Right-click the now-marker → popover opens anchored to the marker labels
- [x] Quick delta buttons advance time correctly; expanded date label updates live
- [x] Relative input (`+5h`, `+2d 30m`, `+1w`) parses and previews; invalid input disables Save
- [x] ISO input (`4726-05-04T09:30`) parses; out-of-range input shows error styling
- [x] Save calls `putState`; now-marker moves to new position; popover closes
- [x] Esc closes popover; clicking outside closes popover; Save/Cancel close popover
- [ ] Advance-time failure (mock `putState` error) shows error toast; popover stays open
- [x] Reload campaign → view position and zoom restored from localStorage
- [x] Switch campaigns → view position resets to that campaign's saved or default position
- [x] Footer shows "Now" + "+ Event" buttons in center while timeline is active
- [x] "+ Event" opens event editor; footer buttons disappear while editor is open, reappear on close
- [x] "Now" button scrolls timeline to in-game now
- [x] Notes, Relationships views still render their footer controls correctly
- [x] Footer background is panel-coloured (matches CSS var), not black

https://claude.ai/code/session_01LxuGFXhESiNascLKQuBzue

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxuGFXhESiNascLKQuBzue)_