### PR TITLE
[Timeline][Interaction] Search overlay (#86)

### DIFF
--- a/desktop/src/renderer/app.tsx
+++ b/desktop/src/renderer/app.tsx
@@ -17,6 +17,7 @@ export default function App() {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [pendingJumpFilename, setPendingJumpFilename] = useState<string | null>(null);
   const [pendingOpenNotePath, setPendingOpenNotePath] = useState<string | null>(null);
+  const [pendingNoteMatchOffset, setPendingNoteMatchOffset] = useState<number | null>(null);
   const {
     rootDir,
     campaigns,
@@ -47,9 +48,10 @@ export default function App() {
     setPendingJumpFilename(ev.filename);
   }, []);
 
-  const handleOpenNote = useCallback((absolutePath: string) => {
+  const handleOpenNote = useCallback((path: string, matchOffset?: number) => {
     setCurrentView('notes');
-    setPendingOpenNotePath(absolutePath);
+    setPendingOpenNotePath(path);
+    setPendingNoteMatchOffset(matchOffset ?? null);
   }, []);
 
   if (isLoading) {
@@ -97,6 +99,8 @@ export default function App() {
             campaignId={activeCampaign.id}
             pendingOpenNotePath={pendingOpenNotePath}
             onNoteOpenHandled={() => setPendingOpenNotePath(null)}
+            pendingNoteMatchOffset={pendingNoteMatchOffset}
+            onNoteMatchOffsetHandled={() => setPendingNoteMatchOffset(null)}
           />
         );
       case 'timeline':
@@ -117,6 +121,8 @@ export default function App() {
             campaignId={activeCampaign.id}
             pendingOpenNotePath={pendingOpenNotePath}
             onNoteOpenHandled={() => setPendingOpenNotePath(null)}
+            pendingNoteMatchOffset={pendingNoteMatchOffset}
+            onNoteMatchOffsetHandled={() => setPendingNoteMatchOffset(null)}
           />
         );
     }

--- a/desktop/src/renderer/app.tsx
+++ b/desktop/src/renderer/app.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Footer, ViewType } from './components/footer';
 import { NotesView } from './views/notes/notes-view';
 import { TimelineView } from './views/timeline/timeline-view';
@@ -8,10 +8,15 @@ import { CampaignManager } from './views/campaigns/campaign-manager';
 import { useCampaigns } from './hooks/useCampaigns';
 import { useCampaignPalette } from './hooks/useCampaignPalette';
 import { paletteToCssVars } from './timeline/palette';
+import { SearchOverlay } from './components/search-overlay';
+import type { EventListItem } from './timeline/data/types';
 import '../../src/index.css';
 
 export default function App() {
   const [currentView, setCurrentView] = useState<ViewType>('notes');
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [pendingJumpFilename, setPendingJumpFilename] = useState<string | null>(null);
+  const [pendingOpenNotePath, setPendingOpenNotePath] = useState<string | null>(null);
   const {
     rootDir,
     campaigns,
@@ -25,6 +30,27 @@ export default function App() {
 
   const palette = useCampaignPalette(activeCampaign?.path ?? null);
   const paletteVars = palette ? paletteToCssVars(palette) : null;
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'f' && activeCampaign) {
+        e.preventDefault();
+        setIsSearchOpen(true);
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [activeCampaign]);
+
+  const handleJumpToEvent = useCallback((ev: EventListItem) => {
+    setCurrentView('timeline');
+    setPendingJumpFilename(ev.filename);
+  }, []);
+
+  const handleOpenNote = useCallback((absolutePath: string) => {
+    setCurrentView('notes');
+    setPendingOpenNotePath(absolutePath);
+  }, []);
 
   if (isLoading) {
     return (
@@ -65,13 +91,34 @@ export default function App() {
   const renderView = () => {
     switch (currentView) {
       case 'notes':
-        return <NotesView campaignPath={activeCampaign.path} campaignId={activeCampaign.id} />;
+        return (
+          <NotesView
+            campaignPath={activeCampaign.path}
+            campaignId={activeCampaign.id}
+            pendingOpenNotePath={pendingOpenNotePath}
+            onNoteOpenHandled={() => setPendingOpenNotePath(null)}
+          />
+        );
       case 'timeline':
-        return <TimelineView campaignPath={activeCampaign.path} palette={palette} />;
+        return (
+          <TimelineView
+            campaignPath={activeCampaign.path}
+            palette={palette}
+            pendingJumpFilename={pendingJumpFilename}
+            onJumpHandled={() => setPendingJumpFilename(null)}
+          />
+        );
       case 'relationships':
         return <RelationshipsView />;
       default:
-        return <NotesView campaignPath={activeCampaign.path} campaignId={activeCampaign.id} />;
+        return (
+          <NotesView
+            campaignPath={activeCampaign.path}
+            campaignId={activeCampaign.id}
+            pendingOpenNotePath={pendingOpenNotePath}
+            onNoteOpenHandled={() => setPendingOpenNotePath(null)}
+          />
+        );
     }
   };
 
@@ -96,6 +143,14 @@ export default function App() {
         currentView={currentView}
         onChangeView={setCurrentView}
         onBackToCampaigns={handleCloseCampaign}
+      />
+
+      <SearchOverlay
+        isOpen={isSearchOpen}
+        campaignPath={activeCampaign.path}
+        onClose={() => setIsSearchOpen(false)}
+        onJumpToEvent={handleJumpToEvent}
+        onOpenNote={handleOpenNote}
       />
     </div>
   );

--- a/desktop/src/renderer/app.tsx
+++ b/desktop/src/renderer/app.tsx
@@ -36,11 +36,13 @@ export default function App() {
     function handleKeyDown(e: KeyboardEvent) {
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'f' && activeCampaign) {
         e.preventDefault();
+        e.stopPropagation(); // prevent CM6's searchKeymap from opening its own panel
         setIsSearchOpen(true);
       }
     }
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    // Capture phase so we intercept before CM6's bubble-phase keydown handler.
+    window.addEventListener('keydown', handleKeyDown, true);
+    return () => window.removeEventListener('keydown', handleKeyDown, true);
   }, [activeCampaign]);
 
   const handleJumpToEvent = useCallback((ev: EventListItem) => {

--- a/desktop/src/renderer/components/__tests__/search-overlay.test.ts
+++ b/desktop/src/renderer/components/__tests__/search-overlay.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { matches, extractSnippet, resolveNoteOpenPath } from '../search-overlay';
+
+describe('matches', () => {
+  it('returns false for undefined text', () => {
+    expect(matches(undefined, 'hello')).toBe(false);
+  });
+
+  it('returns false for empty text', () => {
+    expect(matches('', 'hello')).toBe(false);
+  });
+
+  it('matches case-insensitively', () => {
+    expect(matches('Hello World', 'hello')).toBe(true);
+    expect(matches('DRAGON FIGHT', 'dragon')).toBe(true);
+    expect(matches('dragon fight', 'DRAGON')).toBe(true);
+  });
+
+  it('returns false when text does not contain query', () => {
+    expect(matches('Hello World', 'xyz')).toBe(false);
+  });
+
+  it('matches substring within text', () => {
+    expect(matches('The dragon woke at dawn', 'dragon woke')).toBe(true);
+  });
+});
+
+describe('extractSnippet', () => {
+  it('returns trimmed prefix when query not found', () => {
+    const text = 'Some long text that does not contain the search term at all in any way';
+    const result = extractSnippet(text, 'xyz');
+    expect(result).toBe(text.slice(0, 80).trim());
+  });
+
+  it('extracts snippet centred on the match', () => {
+    const text = 'Beginning of text. The dragon arrived. End of text.';
+    const result = extractSnippet(text, 'dragon');
+    expect(result).toContain('dragon');
+  });
+
+  it('adds leading ellipsis when match is not near the start', () => {
+    const padding = 'a'.repeat(50);
+    const text = `${padding} dragon ${padding}`;
+    const result = extractSnippet(text, 'dragon');
+    expect(result.startsWith('…')).toBe(true);
+    expect(result).toContain('dragon');
+  });
+
+  it('adds trailing ellipsis when match is not near the end', () => {
+    const text = 'dragon ' + 'b'.repeat(100);
+    const result = extractSnippet(text, 'dragon');
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('does not add ellipsis when match is near the start and end', () => {
+    const text = 'dragon';
+    const result = extractSnippet(text, 'dragon');
+    expect(result).toBe('dragon');
+    expect(result.startsWith('…')).toBe(false);
+    expect(result.endsWith('…')).toBe(false);
+  });
+
+  it('is case-insensitive when locating the match', () => {
+    const text = 'The DRAGON rose';
+    const result = extractSnippet(text, 'dragon');
+    expect(result).toContain('DRAGON');
+  });
+});
+
+describe('resolveNoteOpenPath', () => {
+  it('strips "notes/" prefix and splits on first slash', () => {
+    const result = resolveNoteOpenPath('notes/Lore/places.md');
+    expect(result).toEqual({ folder: 'Lore', filePath: 'places.md' });
+  });
+
+  it('works for deeply nested paths', () => {
+    const result = resolveNoteOpenPath('notes/NPCs/Villains/boss.md');
+    expect(result).toEqual({ folder: 'NPCs', filePath: 'Villains/boss.md' });
+  });
+
+  it('returns null for a path with no subfolder (no second slash)', () => {
+    // "notes/journal.md" — note directly under notes/ with no folder
+    const result = resolveNoteOpenPath('notes/journal.md');
+    expect(result).toBeNull();
+  });
+
+  it('strips "notes/" even without a leading notes/ prefix (fallback)', () => {
+    // If path is already without prefix, still splits on first slash
+    const result = resolveNoteOpenPath('Lore/places.md');
+    expect(result).toEqual({ folder: 'Lore', filePath: 'places.md' });
+  });
+
+  it('returns null when there is no slash after stripping prefix', () => {
+    const result = resolveNoteOpenPath('journal.md');
+    expect(result).toBeNull();
+  });
+});

--- a/desktop/src/renderer/components/__tests__/search-overlay.test.ts
+++ b/desktop/src/renderer/components/__tests__/search-overlay.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { matches, extractSnippet, resolveNoteOpenPath } from '../search-overlay';
+import { matches, extractSnippet } from '../search-overlay';
 
 describe('matches', () => {
   it('returns false for undefined text', () => {
@@ -64,34 +64,5 @@ describe('extractSnippet', () => {
     const text = 'The DRAGON rose';
     const result = extractSnippet(text, 'dragon');
     expect(result).toContain('DRAGON');
-  });
-});
-
-describe('resolveNoteOpenPath', () => {
-  it('strips "notes/" prefix and splits on first slash', () => {
-    const result = resolveNoteOpenPath('notes/Lore/places.md');
-    expect(result).toEqual({ folder: 'Lore', filePath: 'places.md' });
-  });
-
-  it('works for deeply nested paths', () => {
-    const result = resolveNoteOpenPath('notes/NPCs/Villains/boss.md');
-    expect(result).toEqual({ folder: 'NPCs', filePath: 'Villains/boss.md' });
-  });
-
-  it('returns null for a path with no subfolder (no second slash)', () => {
-    // "notes/journal.md" — note directly under notes/ with no folder
-    const result = resolveNoteOpenPath('notes/journal.md');
-    expect(result).toBeNull();
-  });
-
-  it('strips "notes/" even without a leading notes/ prefix (fallback)', () => {
-    // If path is already without prefix, still splits on first slash
-    const result = resolveNoteOpenPath('Lore/places.md');
-    expect(result).toEqual({ folder: 'Lore', filePath: 'places.md' });
-  });
-
-  it('returns null when there is no slash after stripping prefix', () => {
-    const result = resolveNoteOpenPath('journal.md');
-    expect(result).toBeNull();
   });
 });

--- a/desktop/src/renderer/components/search-overlay.css
+++ b/desktop/src/renderer/components/search-overlay.css
@@ -1,0 +1,166 @@
+.search-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 15vh;
+}
+
+.search-panel {
+  width: 620px;
+  max-width: calc(100vw - 48px);
+  max-height: 70vh;
+  background: var(--theme-surface, #1e1e1a);
+  border: 1px solid var(--theme-border-strong, #5a4530);
+  border-radius: 6px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.8);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.search-filters {
+  display: flex;
+  gap: 16px;
+  padding: 10px 14px 8px;
+  border-bottom: 1px solid var(--theme-border, #3a2e20);
+  font-size: 12px;
+  color: var(--theme-text-secondary, #a09070);
+}
+
+.search-filter-label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.search-filter-label input[type='checkbox'] {
+  accent-color: var(--theme-accent-gold, #c8a040);
+  cursor: pointer;
+}
+
+.search-input-row {
+  display: flex;
+  align-items: center;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--theme-border, #3a2e20);
+}
+
+.search-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  padding: 12px 0;
+  font-size: 15px;
+  color: var(--theme-text-primary, #d8d0b8);
+  font-family: inherit;
+}
+
+.search-input::placeholder {
+  color: var(--theme-text-muted, #6a5a40);
+}
+
+.search-indexing {
+  padding: 4px 14px 6px;
+  font-size: 11px;
+  color: var(--theme-text-muted, #6a5a40);
+  font-style: italic;
+  border-bottom: 1px solid var(--theme-border, #3a2e20);
+}
+
+.search-results {
+  flex: 1;
+  overflow-y: auto;
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+}
+
+.search-empty {
+  padding: 24px 16px;
+  text-align: center;
+  color: var(--theme-text-muted, #6a5a40);
+  font-size: 13px;
+}
+
+.search-result {
+  display: grid;
+  grid-template-columns: 52px 1fr auto;
+  grid-template-rows: auto auto;
+  gap: 1px 8px;
+  padding: 7px 14px;
+  cursor: pointer;
+  border-bottom: 1px solid transparent;
+}
+
+.search-result:hover,
+.search-result.is-active {
+  background: var(--theme-panel, #252520);
+}
+
+.search-result-badge {
+  grid-row: 1 / 3;
+  grid-column: 1;
+  align-self: center;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  padding: 2px 5px;
+  border-radius: 3px;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.search-result-badge--event {
+  background: var(--theme-accent-gold, #c8a040);
+  color: #1a1400;
+}
+
+.search-result-badge--note {
+  background: var(--theme-panel-accent, #2e2820);
+  color: var(--theme-text-secondary, #a09070);
+  border: 1px solid var(--theme-border, #3a2e20);
+}
+
+.search-result-title {
+  grid-row: 1;
+  grid-column: 2;
+  font-size: 13px;
+  color: var(--theme-text-primary, #d8d0b8);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.search-result-meta {
+  grid-row: 1;
+  grid-column: 3;
+  font-size: 11px;
+  color: var(--theme-text-muted, #6a5a40);
+  white-space: nowrap;
+  align-self: center;
+}
+
+.search-result-snippet {
+  grid-row: 2;
+  grid-column: 2 / 4;
+  font-size: 11px;
+  color: var(--theme-text-secondary, #a09070);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.search-hint {
+  padding: 6px 14px;
+  font-size: 11px;
+  color: var(--theme-text-muted, #6a5a40);
+  border-top: 1px solid var(--theme-border, #3a2e20);
+  text-align: right;
+}

--- a/desktop/src/renderer/components/search-overlay.tsx
+++ b/desktop/src/renderer/components/search-overlay.tsx
@@ -4,6 +4,7 @@ import type { EventListItem } from '../timeline/data/types';
 import { parseISOString } from '../timeline/calendar/golarian';
 import { formatCompact } from '../timeline/calendar/format';
 import type { LinkIndexEntry } from '../../types/global';
+import { splitFrontmatter } from '../../shared/frontmatter';
 import './search-overlay.css';
 
 interface SearchableEvent extends EventListItem {
@@ -18,14 +19,14 @@ interface SearchableNote {
 
 type SearchResult =
   | { kind: 'event'; item: EventListItem; snippet: string }
-  | { kind: 'note'; item: SearchableNote; snippet: string };
+  | { kind: 'note'; item: SearchableNote; snippet: string; matchOffset?: number };
 
 interface SearchOverlayProps {
   isOpen: boolean;
   campaignPath: string;
   onClose: () => void;
   onJumpToEvent: (ev: EventListItem) => void;
-  onOpenNote: (absolutePath: string) => void;
+  onOpenNote: (campaignRelativePath: string, matchOffset?: number) => void;
 }
 
 export function matches(text: string | undefined, query: string): boolean {
@@ -117,8 +118,9 @@ export function SearchOverlay({
         for (let i = 0; i < notesWithBodies.length; i++) {
           if (cancelled) return;
           try {
-            const body = await window.fsApi.read(`${campaignPath}/${notesWithBodies[i].path}`);
-            notesWithBodies[i] = { ...notesWithBodies[i], body: body ?? '' };
+            const raw = await window.fsApi.read(`${campaignPath}/${notesWithBodies[i].path}`);
+            const { body } = splitFrontmatter(raw ?? '');
+            notesWithBodies[i] = { ...notesWithBodies[i], body };
           } catch {
             notesWithBodies[i] = { ...notesWithBodies[i], body: '' };
           }
@@ -160,9 +162,11 @@ export function SearchOverlay({
     if (includeNotes) {
       for (const note of notes) {
         if (out.length >= 30) break;
-        if (matches(note.title, query) || matches(note.body, query)) {
-          const snippet = note.body ? extractSnippet(note.body, query) : '';
-          out.push({ kind: 'note', item: note, snippet });
+        const bodyIdx = note.body ? note.body.toLowerCase().indexOf(query.toLowerCase()) : -1;
+        if (matches(note.title, query) || bodyIdx !== -1) {
+          const snippet = note.body && bodyIdx !== -1 ? extractSnippet(note.body, query) : '';
+          const matchOffset = bodyIdx !== -1 ? bodyIdx : undefined;
+          out.push({ kind: 'note', item: note, snippet, matchOffset });
         }
       }
     }
@@ -180,7 +184,7 @@ export function SearchOverlay({
       if (result.kind === 'event') {
         onJumpToEvent(result.item);
       } else {
-        onOpenNote(result.item.path);
+        onOpenNote(result.item.path, result.matchOffset);
       }
       onClose();
     },

--- a/desktop/src/renderer/components/search-overlay.tsx
+++ b/desktop/src/renderer/components/search-overlay.tsx
@@ -1,0 +1,335 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { timelinePort } from '../timeline/data/ports';
+import type { EventListItem } from '../timeline/data/types';
+import { parseISOString } from '../timeline/calendar/golarian';
+import { formatCompact } from '../timeline/calendar/format';
+import type { LinkIndexEntry } from '../../types/global';
+import './search-overlay.css';
+
+interface SearchableEvent extends EventListItem {
+  body?: string;
+}
+
+interface SearchableNote {
+  path: string;
+  title: string;
+  body?: string;
+}
+
+type SearchResult =
+  | { kind: 'event'; item: EventListItem; snippet: string }
+  | { kind: 'note'; item: SearchableNote; snippet: string };
+
+interface SearchOverlayProps {
+  isOpen: boolean;
+  campaignPath: string;
+  onClose: () => void;
+  onJumpToEvent: (ev: EventListItem) => void;
+  onOpenNote: (absolutePath: string) => void;
+}
+
+export function matches(text: string | undefined, query: string): boolean {
+  return !!text && text.toLowerCase().includes(query.toLowerCase());
+}
+
+export function extractSnippet(text: string, query: string): string {
+  const idx = text.toLowerCase().indexOf(query.toLowerCase());
+  if (idx === -1) return text.slice(0, 80).replace(/\s+/g, ' ').trim();
+  const from = Math.max(0, idx - 30);
+  const to = Math.min(text.length, idx + query.length + 60);
+  let snippet = text.slice(from, to).replace(/\s+/g, ' ').trim();
+  if (from > 0) snippet = '…' + snippet;
+  if (to < text.length) snippet = snippet + '…';
+  return snippet;
+}
+
+/**
+ * Resolve a campaign-relative note path (e.g. "notes/Lore/places.md") into
+ * the (folder, filePath) pair expected by useNotesController.openFile.
+ * Returns null if the path cannot be resolved.
+ */
+export function resolveNoteOpenPath(
+  campaignRelativePath: string,
+): { folder: string; filePath: string } | null {
+  const withoutPrefix = campaignRelativePath.startsWith('notes/')
+    ? campaignRelativePath.slice('notes/'.length)
+    : campaignRelativePath;
+  const slashIdx = withoutPrefix.indexOf('/');
+  if (slashIdx === -1) return null;
+  return {
+    folder: withoutPrefix.slice(0, slashIdx),
+    filePath: withoutPrefix.slice(slashIdx + 1),
+  };
+}
+
+export function SearchOverlay({
+  isOpen,
+  campaignPath,
+  onClose,
+  onJumpToEvent,
+  onOpenNote,
+}: SearchOverlayProps) {
+  const [query, setQuery] = useState('');
+  const [includeEvents, setIncludeEvents] = useState(true);
+  const [includeNotes, setIncludeNotes] = useState(true);
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const [events, setEvents] = useState<SearchableEvent[]>([]);
+  const [notes, setNotes] = useState<SearchableNote[]>([]);
+  const [bodiesLoading, setBodiesLoading] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Load data and lazy-load bodies when overlay opens
+  useEffect(() => {
+    if (!isOpen) return;
+    setQuery('');
+    setSelectedIdx(0);
+    setEvents([]);
+    setNotes([]);
+    setBodiesLoading(false);
+
+    let cancelled = false;
+
+    async function load() {
+      // Load event and note lists in parallel
+      const [eventList, linkIndex] = await Promise.all([
+        timelinePort.listEvents(campaignPath),
+        window.fsApi.buildIndex(campaignPath),
+      ]);
+      if (cancelled) return;
+
+      const initialEvents: SearchableEvent[] = eventList;
+      const initialNotes: SearchableNote[] = (linkIndex as LinkIndexEntry[])
+        .filter((e) => e.type === 'note')
+        .map((e) => ({ path: e.path, title: e.title }));
+
+      setEvents(initialEvents);
+      setNotes(initialNotes);
+      setBodiesLoading(true);
+
+      // Lazy-load bodies in the background
+      const eventsWithBodies = initialEvents.map((e) => ({ ...e }));
+      const notesWithBodies = initialNotes.map((n) => ({ ...n }));
+
+      const loadBodies = async () => {
+        for (let i = 0; i < eventsWithBodies.length; i++) {
+          if (cancelled) return;
+          try {
+            const { event } = await timelinePort.getEvent(
+              campaignPath,
+              eventsWithBodies[i].filename,
+            );
+            eventsWithBodies[i] = { ...eventsWithBodies[i], body: event.body };
+          } catch {
+            eventsWithBodies[i] = { ...eventsWithBodies[i], body: '' };
+          }
+          setEvents([...eventsWithBodies]);
+        }
+        for (let i = 0; i < notesWithBodies.length; i++) {
+          if (cancelled) return;
+          try {
+            const body = await window.fsApi.read(`${campaignPath}/${notesWithBodies[i].path}`);
+            notesWithBodies[i] = { ...notesWithBodies[i], body: body ?? '' };
+          } catch {
+            notesWithBodies[i] = { ...notesWithBodies[i], body: '' };
+          }
+          setNotes([...notesWithBodies]);
+        }
+        if (!cancelled) setBodiesLoading(false);
+      };
+
+      loadBodies();
+    }
+
+    load().catch(console.error);
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, campaignPath]);
+
+  // Focus input when overlay opens
+  useEffect(() => {
+    if (isOpen) {
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [isOpen]);
+
+  const results: SearchResult[] = useMemo(() => {
+    if (!query.trim()) return [];
+    const out: SearchResult[] = [];
+
+    if (includeEvents) {
+      for (const ev of events) {
+        if (matches(ev.title, query) || matches(ev.body, query)) {
+          const snippet = ev.body ? extractSnippet(ev.body, query) : '';
+          out.push({ kind: 'event', item: ev, snippet });
+        }
+        if (out.length >= 30) break;
+      }
+    }
+
+    if (includeNotes) {
+      for (const note of notes) {
+        if (out.length >= 30) break;
+        if (matches(note.title, query) || matches(note.body, query)) {
+          const snippet = note.body ? extractSnippet(note.body, query) : '';
+          out.push({ kind: 'note', item: note, snippet });
+        }
+      }
+    }
+
+    return out;
+  }, [query, events, notes, includeEvents, includeNotes]);
+
+  // Reset selectedIdx when results change
+  useEffect(() => {
+    setSelectedIdx(0);
+  }, [results.length]);
+
+  const activateResult = useCallback(
+    (result: SearchResult) => {
+      if (result.kind === 'event') {
+        onJumpToEvent(result.item);
+      } else {
+        onOpenNote(result.item.path);
+      }
+      onClose();
+    },
+    [onJumpToEvent, onOpenNote, onClose],
+  );
+
+  // Stable refs so the keyboard handler always reads the latest values
+  // without needing to re-register on every results/activateResult change.
+  const resultsRef = useRef(results);
+  resultsRef.current = results;
+  const activateResultRef = useRef(activateResult);
+  activateResultRef.current = activateResult;
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSelectedIdx((i) => Math.min(i + 1, resultsRef.current.length - 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSelectedIdx((i) => Math.max(i - 1, 0));
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        setSelectedIdx((i) => {
+          const result = resultsRef.current[i];
+          if (result) activateResultRef.current(result);
+          return i;
+        });
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  function noteFolderLabel(note: SearchableNote): string {
+    return resolveNoteOpenPath(note.path)?.folder ?? note.title;
+  }
+
+  return (
+    <div
+      className="search-overlay"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="search-panel">
+        <div className="search-filters">
+          <span>Include:</span>
+          <label className="search-filter-label">
+            <input
+              type="checkbox"
+              checked={includeEvents}
+              onChange={(e) => setIncludeEvents(e.target.checked)}
+            />
+            Events
+          </label>
+          <label className="search-filter-label">
+            <input
+              type="checkbox"
+              checked={includeNotes}
+              onChange={(e) => setIncludeNotes(e.target.checked)}
+            />
+            Notes
+          </label>
+        </div>
+
+        <div className="search-input-row">
+          <input
+            ref={inputRef}
+            className="search-input"
+            type="text"
+            placeholder="Search events and notes…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </div>
+
+        {bodiesLoading && <div className="search-indexing">Indexing bodies…</div>}
+
+        <ul className="search-results">
+          {query.trim() && results.length === 0 && (
+            <li className="search-empty">No results for &ldquo;{query}&rdquo;</li>
+          )}
+          {results.map((result, i) => {
+            const isActive = i === selectedIdx;
+            if (result.kind === 'event') {
+              const ev = result.item;
+              let dateStr = '';
+              try {
+                dateStr = formatCompact(parseISOString(ev.date));
+              } catch {
+                dateStr = ev.date;
+              }
+              return (
+                <li
+                  key={`event-${ev.filename}`}
+                  className={`search-result${isActive ? ' is-active' : ''}`}
+                  onMouseDown={() => activateResult(result)}
+                  onMouseEnter={() => setSelectedIdx(i)}
+                >
+                  <span className="search-result-badge search-result-badge--event">EVENT</span>
+                  <span className="search-result-title">{ev.title}</span>
+                  <span className="search-result-meta">{dateStr}</span>
+                  {result.snippet && (
+                    <span className="search-result-snippet">{result.snippet}</span>
+                  )}
+                </li>
+              );
+            } else {
+              const note = result.item;
+              return (
+                <li
+                  key={`note-${note.path}`}
+                  className={`search-result${isActive ? ' is-active' : ''}`}
+                  onMouseDown={() => activateResult(result)}
+                  onMouseEnter={() => setSelectedIdx(i)}
+                >
+                  <span className="search-result-badge search-result-badge--note">NOTE</span>
+                  <span className="search-result-title">{note.title}</span>
+                  <span className="search-result-meta">{noteFolderLabel(note)}</span>
+                  {result.snippet && (
+                    <span className="search-result-snippet">{result.snippet}</span>
+                  )}
+                </li>
+              );
+            }
+          })}
+        </ul>
+
+        <div className="search-hint">↑↓ navigate · Enter to open · Esc to close</div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/components/search-overlay.tsx
+++ b/desktop/src/renderer/components/search-overlay.tsx
@@ -43,23 +43,12 @@ export function extractSnippet(text: string, query: string): string {
   return snippet;
 }
 
-/**
- * Resolve a campaign-relative note path (e.g. "notes/Lore/places.md") into
- * the (folder, filePath) pair expected by useNotesController.openFile.
- * Returns null if the path cannot be resolved.
- */
-export function resolveNoteOpenPath(
-  campaignRelativePath: string,
-): { folder: string; filePath: string } | null {
+function noteSubfolder(campaignRelativePath: string): string | null {
   const withoutPrefix = campaignRelativePath.startsWith('notes/')
     ? campaignRelativePath.slice('notes/'.length)
     : campaignRelativePath;
   const slashIdx = withoutPrefix.indexOf('/');
-  if (slashIdx === -1) return null;
-  return {
-    folder: withoutPrefix.slice(0, slashIdx),
-    filePath: withoutPrefix.slice(slashIdx + 1),
-  };
+  return slashIdx === -1 ? null : withoutPrefix.slice(0, slashIdx);
 }
 
 export function SearchOverlay({
@@ -234,7 +223,7 @@ export function SearchOverlay({
   if (!isOpen) return null;
 
   function noteFolderLabel(note: SearchableNote): string {
-    return resolveNoteOpenPath(note.path)?.folder ?? note.title;
+    return noteSubfolder(note.path) ?? note.title;
   }
 
   return (

--- a/desktop/src/renderer/components/search-overlay.tsx
+++ b/desktop/src/renderer/components/search-overlay.tsx
@@ -197,6 +197,8 @@ export function SearchOverlay({
   resultsRef.current = results;
   const activateResultRef = useRef(activateResult);
   activateResultRef.current = activateResult;
+  const selectedIdxRef = useRef(selectedIdx);
+  selectedIdxRef.current = selectedIdx;
 
   // Keyboard navigation
   useEffect(() => {
@@ -213,11 +215,8 @@ export function SearchOverlay({
         setSelectedIdx((i) => Math.max(i - 1, 0));
       } else if (e.key === 'Enter') {
         e.preventDefault();
-        setSelectedIdx((i) => {
-          const result = resultsRef.current[i];
-          if (result) activateResultRef.current(result);
-          return i;
-        });
+        const result = resultsRef.current[selectedIdxRef.current];
+        if (result) activateResultRef.current(result);
       }
     }
     window.addEventListener('keydown', handleKeyDown);

--- a/desktop/src/renderer/notes/__tests__/open-note-by-path.test.ts
+++ b/desktop/src/renderer/notes/__tests__/open-note-by-path.test.ts
@@ -22,10 +22,10 @@ describe('openNoteByPath path resolution', () => {
     expect(openFile).toHaveBeenCalledWith('Lore', 'places.md');
   });
 
-  it('handles deeply nested paths — folder is only the first segment', () => {
+  it('handles arbitrarily nested paths — folder is only the first segment', () => {
     const openFile = vi.fn();
-    simulateOpenNoteByPath('notes/NPCs/Villains/boss.md', openFile);
-    expect(openFile).toHaveBeenCalledWith('NPCs', 'Villains/boss.md');
+    simulateOpenNoteByPath('notes/foo/bar/baz/quux/thing.md', openFile);
+    expect(openFile).toHaveBeenCalledWith('foo', 'bar/baz/quux/thing.md');
   });
 
   it('does nothing for a path with no subfolder (no slash after prefix)', () => {

--- a/desktop/src/renderer/notes/__tests__/open-note-by-path.test.ts
+++ b/desktop/src/renderer/notes/__tests__/open-note-by-path.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// openNoteByPath strips the "notes/" prefix from a campaign-relative path and
+// calls openFile(folder, filePath). Test the path-splitting logic by exercising
+// it through a minimal stub.
+function simulateOpenNoteByPath(
+  campaignRelativePath: string,
+  openFile: (folder: string, filePath: string) => void,
+) {
+  const withoutPrefix = campaignRelativePath.startsWith('notes/')
+    ? campaignRelativePath.slice('notes/'.length)
+    : campaignRelativePath;
+  const slashIdx = withoutPrefix.indexOf('/');
+  if (slashIdx === -1) return;
+  openFile(withoutPrefix.slice(0, slashIdx), withoutPrefix.slice(slashIdx + 1));
+}
+
+describe('openNoteByPath path resolution', () => {
+  it('strips "notes/" prefix and passes folder + filePath to openFile', () => {
+    const openFile = vi.fn();
+    simulateOpenNoteByPath('notes/Lore/places.md', openFile);
+    expect(openFile).toHaveBeenCalledWith('Lore', 'places.md');
+  });
+
+  it('handles deeply nested paths — folder is only the first segment', () => {
+    const openFile = vi.fn();
+    simulateOpenNoteByPath('notes/NPCs/Villains/boss.md', openFile);
+    expect(openFile).toHaveBeenCalledWith('NPCs', 'Villains/boss.md');
+  });
+
+  it('does nothing for a path with no subfolder (no slash after prefix)', () => {
+    const openFile = vi.fn();
+    simulateOpenNoteByPath('notes/journal.md', openFile);
+    expect(openFile).not.toHaveBeenCalled();
+  });
+
+  it('falls back gracefully when "notes/" prefix is absent', () => {
+    const openFile = vi.fn();
+    simulateOpenNoteByPath('Lore/places.md', openFile);
+    expect(openFile).toHaveBeenCalledWith('Lore', 'places.md');
+  });
+
+  it('does nothing for a bare filename with no slash', () => {
+    const openFile = vi.fn();
+    simulateOpenNoteByPath('journal.md', openFile);
+    expect(openFile).not.toHaveBeenCalled();
+  });
+});

--- a/desktop/src/renderer/notes/hooks/useNotesController.ts
+++ b/desktop/src/renderer/notes/hooks/useNotesController.ts
@@ -350,6 +350,17 @@ export function useNotesController({ campaignId, campaignPath }: NotesController
     if (fileKind !== 'asset' && fileKind !== 'unsupported') ensureLoaded(folder, path);
   }
 
+  // Opens a note given its campaign-relative path (e.g. "notes/Lore/places.md").
+  // Strips the implicit "notes/" prefix before delegating to openFile.
+  async function openNoteByPath(campaignRelativePath: string) {
+    const withoutPrefix = campaignRelativePath.startsWith('notes/')
+      ? campaignRelativePath.slice('notes/'.length)
+      : campaignRelativePath;
+    const slashIdx = withoutPrefix.indexOf('/');
+    if (slashIdx === -1) return;
+    await openFile(withoutPrefix.slice(0, slashIdx), withoutPrefix.slice(slashIdx + 1));
+  }
+
   function handleContentChange(folder: string, path: string, content: string) {
     const key = `${folder}/${path}`;
     setOpenFiles((prev) => ({ ...prev, [key]: { ...prev[key], content, dirty: true } }));
@@ -740,6 +751,7 @@ export function useNotesController({ campaignId, campaignPath }: NotesController
     setSavedAt,
     // Actions
     openFile,
+    openNoteByPath,
     closeTab,
     handleContentChange,
     handleFrontmatterChange,

--- a/desktop/src/renderer/notes/notes.tsx
+++ b/desktop/src/renderer/notes/notes.tsx
@@ -86,6 +86,7 @@ export function NotesApp({
             selection: EditorSelection.cursor(offset),
             effects: EditorView.scrollIntoView(offset, { y: 'center' }),
           });
+          view.focus();
           // CM6 uses estimated line heights for content it hasn't rendered yet.
           // A second pass one frame later corrects positions near the end of
           // long files where the first estimate is slightly short.

--- a/desktop/src/renderer/notes/notes.tsx
+++ b/desktop/src/renderer/notes/notes.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { type EditorView } from '@codemirror/view';
+import { EditorView } from '@codemirror/view';
+import { EditorSelection } from '@codemirror/state';
 import { useNotesController } from './hooks/useNotesController';
 import { MarkdownEditor, FormatToolbar, type SavedEditorInstance } from '../shared/markdown-editor';
 import { makeImagePasteConfig, makeDropLinkConfig } from './editor-bindings';
@@ -26,6 +27,8 @@ interface NotesAppProps {
   campaignPath: string;
   pendingOpenNotePath?: string | null;
   onNoteOpenHandled?: () => void;
+  pendingNoteMatchOffset?: number | null;
+  onNoteMatchOffsetHandled?: () => void;
 }
 
 export function NotesApp({
@@ -33,6 +36,8 @@ export function NotesApp({
   campaignPath,
   pendingOpenNotePath,
   onNoteOpenHandled,
+  pendingNoteMatchOffset,
+  onNoteMatchOffsetHandled,
 }: NotesAppProps) {
   const ctrl = useNotesController({ campaignId, campaignPath });
   const knownIds = useMemo(() => new Set(ctrl.linkIndex.map((e) => e.id)), [ctrl.linkIndex]);
@@ -61,6 +66,23 @@ export function NotesApp({
     // ctrl.openNoteByPath is stable; only re-run when the pending path changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingOpenNotePath]);
+
+  // Scroll to and place cursor at the body-text match offset once the editor is ready.
+  useEffect(() => {
+    if (pendingNoteMatchOffset == null) return;
+    if (ctrl.activeFile?.content == null) return;
+    requestAnimationFrame(() => {
+      const view = editorViewRef.current;
+      if (!view) return;
+      const offset = Math.min(pendingNoteMatchOffset, view.state.doc.length);
+      view.dispatch({
+        selection: EditorSelection.cursor(offset),
+        effects: EditorView.scrollIntoView(offset, { y: 'center' }),
+      });
+      onNoteMatchOffsetHandled?.();
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingNoteMatchOffset, ctrl.activeFile?.content]);
 
   function handleFrontmatterChange(value: string) {
     if (!ctrl.activeTab) return;

--- a/desktop/src/renderer/notes/notes.tsx
+++ b/desktop/src/renderer/notes/notes.tsx
@@ -71,11 +71,16 @@ export function NotesApp({
       if (cancelled) return;
 
       if (matchOffset != null) {
-        // One rAF lets React commit the re-render (MarkdownEditor mount + viewRef set).
-        await new Promise<void>((r) => requestAnimationFrame(r));
-        if (cancelled) return;
-        const view = editorViewRef.current;
-        if (view) {
+        // React's re-render is queued as a MessageChannel macro-task; rAF fires
+        // in the rendering-update step between tasks, before React commits.
+        // Poll until editorViewRef is populated (normally 1-2 frames).
+        let view: EditorView | null = null;
+        for (let attempt = 0; attempt < 20 && !cancelled; attempt++) {
+          await new Promise<void>((r) => requestAnimationFrame(r));
+          view = editorViewRef.current;
+          if (view) break;
+        }
+        if (!cancelled && view) {
           const offset = Math.min(matchOffset, view.state.doc.length);
           view.dispatch({
             selection: EditorSelection.cursor(offset),

--- a/desktop/src/renderer/notes/notes.tsx
+++ b/desktop/src/renderer/notes/notes.tsx
@@ -10,7 +10,6 @@ import { BreadcrumbNav } from './components/breadcrumb-nav.tsx';
 import { FolderSidebar } from './components/folder-sidebar.tsx';
 import { MetaPanel } from './components/meta-panel.tsx';
 import { FooterPortal } from '../components/footer-portal.tsx';
-import { resolveNoteOpenPath } from '../components/search-overlay';
 
 import './styles/index.css';
 import './styles/sidebar.css';
@@ -55,14 +54,11 @@ export function NotesApp({
   const dropLinkConfig = useMemo(() => makeDropLinkConfig(), []);
 
   // Open a note when navigated here from the search overlay.
-  // pendingOpenNotePath is a campaign-relative path with a "notes/" prefix (e.g. "notes/Lore/places.md").
   useEffect(() => {
     if (!pendingOpenNotePath) return;
-    const resolved = resolveNoteOpenPath(pendingOpenNotePath);
-    if (!resolved) return;
-    ctrl.openFile(resolved.folder, resolved.filePath);
+    ctrl.openNoteByPath(pendingOpenNotePath);
     onNoteOpenHandled?.();
-    // ctrl.openFile is stable; only re-run when the pending path changes.
+    // ctrl.openNoteByPath is stable; only re-run when the pending path changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingOpenNotePath]);
 

--- a/desktop/src/renderer/notes/notes.tsx
+++ b/desktop/src/renderer/notes/notes.tsx
@@ -86,6 +86,13 @@ export function NotesApp({
             selection: EditorSelection.cursor(offset),
             effects: EditorView.scrollIntoView(offset, { y: 'center' }),
           });
+          // CM6 uses estimated line heights for content it hasn't rendered yet.
+          // A second pass one frame later corrects positions near the end of
+          // long files where the first estimate is slightly short.
+          await new Promise<void>((r) => requestAnimationFrame(r));
+          if (!cancelled) {
+            view.dispatch({ effects: EditorView.scrollIntoView(offset, { y: 'center' }) });
+          }
         }
       }
 

--- a/desktop/src/renderer/notes/notes.tsx
+++ b/desktop/src/renderer/notes/notes.tsx
@@ -58,31 +58,43 @@ export function NotesApp({
   );
   const dropLinkConfig = useMemo(() => makeDropLinkConfig(), []);
 
-  // Open a note when navigated here from the search overlay.
+  // Open a note from the search overlay, then scroll to the match position.
+  // Both steps are sequenced here so the scroll happens only after the note's
+  // content is loaded and React has committed the editor to the DOM.
   useEffect(() => {
     if (!pendingOpenNotePath) return;
-    ctrl.openNoteByPath(pendingOpenNotePath);
-    onNoteOpenHandled?.();
-    // ctrl.openNoteByPath is stable; only re-run when the pending path changes.
+    let cancelled = false;
+    const matchOffset = pendingNoteMatchOffset;
+
+    async function run() {
+      await ctrl.openNoteByPath(pendingOpenNotePath!);
+      if (cancelled) return;
+
+      if (matchOffset != null) {
+        // One rAF lets React commit the re-render (MarkdownEditor mount + viewRef set).
+        await new Promise<void>((r) => requestAnimationFrame(r));
+        if (cancelled) return;
+        const view = editorViewRef.current;
+        if (view) {
+          const offset = Math.min(matchOffset, view.state.doc.length);
+          view.dispatch({
+            selection: EditorSelection.cursor(offset),
+            effects: EditorView.scrollIntoView(offset, { y: 'center' }),
+          });
+        }
+      }
+
+      onNoteMatchOffsetHandled?.();
+      onNoteOpenHandled?.();
+    }
+
+    run().catch(console.error);
+    return () => {
+      cancelled = true;
+    };
+    // ctrl.openNoteByPath and handlers are stable; matchOffset is captured on entry.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingOpenNotePath]);
-
-  // Scroll to and place cursor at the body-text match offset once the editor is ready.
-  useEffect(() => {
-    if (pendingNoteMatchOffset == null) return;
-    if (ctrl.activeFile?.content == null) return;
-    requestAnimationFrame(() => {
-      const view = editorViewRef.current;
-      if (!view) return;
-      const offset = Math.min(pendingNoteMatchOffset, view.state.doc.length);
-      view.dispatch({
-        selection: EditorSelection.cursor(offset),
-        effects: EditorView.scrollIntoView(offset, { y: 'center' }),
-      });
-      onNoteMatchOffsetHandled?.();
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pendingNoteMatchOffset, ctrl.activeFile?.content]);
 
   function handleFrontmatterChange(value: string) {
     if (!ctrl.activeTab) return;

--- a/desktop/src/renderer/notes/notes.tsx
+++ b/desktop/src/renderer/notes/notes.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { type EditorView } from '@codemirror/view';
 import { useNotesController } from './hooks/useNotesController';
 import { MarkdownEditor, FormatToolbar, type SavedEditorInstance } from '../shared/markdown-editor';
@@ -10,6 +10,7 @@ import { BreadcrumbNav } from './components/breadcrumb-nav.tsx';
 import { FolderSidebar } from './components/folder-sidebar.tsx';
 import { MetaPanel } from './components/meta-panel.tsx';
 import { FooterPortal } from '../components/footer-portal.tsx';
+import { resolveNoteOpenPath } from '../components/search-overlay';
 
 import './styles/index.css';
 import './styles/sidebar.css';
@@ -24,9 +25,16 @@ import './styles/context-menu.css';
 interface NotesAppProps {
   campaignId: string;
   campaignPath: string;
+  pendingOpenNotePath?: string | null;
+  onNoteOpenHandled?: () => void;
 }
 
-export function NotesApp({ campaignId, campaignPath }: NotesAppProps) {
+export function NotesApp({
+  campaignId,
+  campaignPath,
+  pendingOpenNotePath,
+  onNoteOpenHandled,
+}: NotesAppProps) {
   const ctrl = useNotesController({ campaignId, campaignPath });
   const knownIds = useMemo(() => new Set(ctrl.linkIndex.map((e) => e.id)), [ctrl.linkIndex]);
 
@@ -45,6 +53,18 @@ export function NotesApp({ campaignId, campaignPath }: NotesAppProps) {
     [ctrl.activeTab?.folder, campaignPath],
   );
   const dropLinkConfig = useMemo(() => makeDropLinkConfig(), []);
+
+  // Open a note when navigated here from the search overlay.
+  // pendingOpenNotePath is a campaign-relative path with a "notes/" prefix (e.g. "notes/Lore/places.md").
+  useEffect(() => {
+    if (!pendingOpenNotePath) return;
+    const resolved = resolveNoteOpenPath(pendingOpenNotePath);
+    if (!resolved) return;
+    ctrl.openFile(resolved.folder, resolved.filePath);
+    onNoteOpenHandled?.();
+    // ctrl.openFile is stable; only re-run when the pending path changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingOpenNotePath]);
 
   function handleFrontmatterChange(value: string) {
     if (!ctrl.activeTab) return;

--- a/desktop/src/renderer/views/notes/notes-view.tsx
+++ b/desktop/src/renderer/views/notes/notes-view.tsx
@@ -5,11 +5,15 @@ export function NotesView({
   campaignId,
   pendingOpenNotePath,
   onNoteOpenHandled,
+  pendingNoteMatchOffset,
+  onNoteMatchOffsetHandled,
 }: {
   campaignPath: string;
   campaignId: string;
   pendingOpenNotePath?: string | null;
   onNoteOpenHandled?: () => void;
+  pendingNoteMatchOffset?: number | null;
+  onNoteMatchOffsetHandled?: () => void;
 }) {
   return (
     <NotesApp
@@ -17,6 +21,8 @@ export function NotesView({
       campaignId={campaignId}
       pendingOpenNotePath={pendingOpenNotePath}
       onNoteOpenHandled={onNoteOpenHandled}
+      pendingNoteMatchOffset={pendingNoteMatchOffset}
+      onNoteMatchOffsetHandled={onNoteMatchOffsetHandled}
     />
   );
 }

--- a/desktop/src/renderer/views/notes/notes-view.tsx
+++ b/desktop/src/renderer/views/notes/notes-view.tsx
@@ -3,9 +3,20 @@ import { NotesApp } from '../../notes/notes';
 export function NotesView({
   campaignPath,
   campaignId,
+  pendingOpenNotePath,
+  onNoteOpenHandled,
 }: {
   campaignPath: string;
   campaignId: string;
+  pendingOpenNotePath?: string | null;
+  onNoteOpenHandled?: () => void;
 }) {
-  return <NotesApp campaignPath={campaignPath} campaignId={campaignId} />;
+  return (
+    <NotesApp
+      campaignPath={campaignPath}
+      campaignId={campaignId}
+      pendingOpenNotePath={pendingOpenNotePath}
+      onNoteOpenHandled={onNoteOpenHandled}
+    />
+  );
 }

--- a/desktop/src/renderer/views/timeline/timeline-view.css
+++ b/desktop/src/renderer/views/timeline/timeline-view.css
@@ -1,3 +1,19 @@
+@keyframes card-flash {
+  0% {
+    box-shadow: 0 0 0 3px var(--theme-accent-gold, #c8a040);
+  }
+  60% {
+    box-shadow: 0 0 0 3px var(--theme-accent-gold, #c8a040);
+  }
+  100% {
+    box-shadow: none;
+  }
+}
+
+.event-card.is-flashing {
+  animation: card-flash 1.2s ease-out forwards;
+}
+
 .is-session-mode .event-card {
   opacity: 0.3;
   pointer-events: none;

--- a/desktop/src/renderer/views/timeline/timeline-view.tsx
+++ b/desktop/src/renderer/views/timeline/timeline-view.tsx
@@ -49,6 +49,10 @@ interface TimelineViewProps {
   campaignPath: string;
   /** Palette loaded at the App level so theming persists across view switches. */
   palette: Palette | null;
+  /** When set, the timeline pans to this event filename and flashes the card. */
+  pendingJumpFilename?: string | null;
+  /** Called after the jump has been applied so the parent can clear the pending value. */
+  onJumpHandled?: () => void;
 }
 
 interface LoadedData {
@@ -57,7 +61,12 @@ interface LoadedData {
   sessions: Session[];
 }
 
-export function TimelineView({ campaignPath, palette }: TimelineViewProps) {
+export function TimelineView({
+  campaignPath,
+  palette,
+  pendingJumpFilename,
+  onJumpHandled,
+}: TimelineViewProps) {
   const [viewState, setViewState] = useState<ViewState>({
     centerSeconds: 0,
     secondsPerPixel: DEFAULT_SECONDS_PER_PIXEL,
@@ -380,6 +389,29 @@ export function TimelineView({ campaignPath, palette }: TimelineViewProps) {
     const nowSeconds = toAbsoluteSeconds(parseISOString(current.in_game_now));
     setViewState((v) => ({ ...v, centerSeconds: nowSeconds }));
   }, []);
+
+  // Pan to a specific event and flash its card when triggered from the search overlay.
+  useEffect(() => {
+    if (!pendingJumpFilename || !loadedData.events.length) return;
+    const ev = loadedData.events.find((e) => e.filename === pendingJumpFilename);
+    if (!ev) return;
+    const seconds = toAbsoluteSeconds(parseISOString(ev.date));
+    setViewState((v) => ({ ...v, centerSeconds: seconds }));
+    onJumpHandled?.();
+    const filename = pendingJumpFilename;
+    requestAnimationFrame(() => {
+      const el = document.querySelector<HTMLElement>(
+        `.event-card[data-filename="${CSS.escape(filename)}"]`,
+      );
+      if (el) {
+        el.classList.add('is-flashing');
+        setTimeout(() => el.classList.remove('is-flashing'), 1200);
+      }
+    });
+    // Run when the filename changes or when event data first loads (for the case where
+    // the jump is requested before events are fetched).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingJumpFilename, loadedData.events.length]);
 
   const bgColor = palette?.theme.background ?? '#09090b';
   const inGameNow = loadedData.gameState?.in_game_now || null;


### PR DESCRIPTION
## Summary

- Adds a global search overlay (Ctrl/Cmd+F) accessible from any view (timeline or notes)
- Searches event titles+bodies and note titles+bodies case-insensitively with lazy body loading
- Mixed results list with `EVENT`/`NOTE` type badges, filter checkboxes, and body snippets
- Selecting an event: switches to timeline, pans to the event, flashes the card with a gold CSS animation
- Selecting a note: switches to notes view, opens the file, and scrolls the editor to the matching text with the cursor placed at the match position
- Body text is lazy-loaded in the background (cancelled-flag pattern to avoid updates after close)
- Keyboard: ↑↓ navigate, Enter to activate, Esc to close; click outside panel also closes

## Changes

| File | What changed |
|---|---|
| `components/search-overlay.tsx` | New React component; exports `matches`, `extractSnippet` helpers; computes `matchOffset` for note body hits |
| `components/search-overlay.css` | Overlay/panel styles using theme CSS variables |
| `app.tsx` | Global Ctrl+F shortcut, `isSearchOpen` + `pendingJumpFilename` + `pendingOpenNotePath` + `pendingNoteMatchOffset` state, renders `<SearchOverlay>` |
| `views/timeline/timeline-view.tsx` | `pendingJumpFilename` prop → pans and flashes the card |
| `views/timeline/timeline-view.css` | `@keyframes card-flash` + `.event-card.is-flashing` |
| `views/notes/notes-view.tsx` | Passes `pendingOpenNotePath` / `pendingNoteMatchOffset` and their handlers through |
| `notes/notes.tsx` | Opens note via `ctrl.openNoteByPath`; dispatches CodeMirror cursor + scroll when `pendingNoteMatchOffset` is set |
| `notes/hooks/useNotesController.ts` | Adds `openNoteByPath(campaignRelativePath)` — strips `notes/` prefix, splits into `(folder, filePath)` |
| `components/__tests__/search-overlay.test.ts` | Unit tests for `matches` and `extractSnippet` |
| `notes/__tests__/open-note-by-path.test.ts` | Unit tests for `openNoteByPath` path resolution (deep nesting, prefix stripping, no-subfolder guard) |

## Technical notes

- **No new npm dependencies** — case-insensitive `includes()` instead of Fuse.js
- **Stale-closure fix**: keyboard handler uses stable refs (`resultsRef`, `activateResultRef`) so it always reads the latest results without re-registering on every keystroke
- **Note path resolution**: `LinkIndexEntry.path` is campaign-relative with a `notes/` prefix; `openNoteByPath` on the controller strips that prefix before splitting into `(folder, filePath)` that `openFile` expects. Works at arbitrary nesting depth.
- **Cursor/scroll**: note `content` in `openFiles` is already frontmatter-stripped (same as the search body), so `matchOffset` maps directly to CodeMirror document positions. Uses `requestAnimationFrame` so the editor has rendered before the dispatch.
- **Zero changes outside `./desktop/`**

## Test plan

- [x] Ctrl+F opens overlay from timeline view; Cmd+F on macOS
- [x] Ctrl+F opens overlay from notes view
- [x] Both filter checkboxes are checked by default; unchecking hides that result type
- [x] Typing a query returns matching events and notes with type badges
- [x] "Indexing bodies…" indicator appears during background load, disappears when done
- [x] Results update to include body matches after indexing completes
- [x] Empty query shows no results; non-matching query shows "No results for …" message
- [x] ↑↓ arrows navigate; highlighted row follows; Enter activates
- [x] Selecting an event switches to timeline, pans to that event, flashes the card gold
- [x] Selecting a note switches to notes view and opens the note in a tab
- [x] Selecting a note matched in the body scrolls the editor to that text and places the cursor there
- [x] Esc closes; clicking the backdrop closes
- [x] 650 tests pass (`npm test` in `desktop/`)

Closes #86