### PR TITLE
chore: align desktop package version with v0.1.0-alpha.1 release tag

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tabletop-timeline",
   "private": true,
-  "version": "1.0.0",
+  "version": "0.1.0-alpha.1",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bumps `desktop/package.json` version from `1.0.0` to `0.1.0-alpha.1`
- electron-builder reads the version from `package.json`, not the git tag — this mismatch caused the pipeline to publish a stray `v1.0.0` draft release instead of attaching the `.exe` to the intended `v0.1.0-alpha.1` release

## Test plan
- [ ] Merge this PR into `main`
- [ ] Delete the stray `v1.0.0` draft release on GitHub
- [ ] Re-run the pipeline against the `v0.1.0-alpha.1` tag (or re-push it) — the installer should now be named `TableTop-Timeline-Setup-0.1.0-alpha.1.exe` and attached to the correct release

https://claude.ai/code/session_018iDfLcsDPLAzHwowYDCU5Y

---
_Generated by [Claude Code](https://claude.ai/code/session_018iDfLcsDPLAzHwowYDCU5Y)_