### PR TITLE
fix: set electron-builder releaseType to prerelease

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -34,7 +34,8 @@
       {
         "provider": "github",
         "owner": "lpendrake",
-        "repo": "last-gasp"
+        "repo": "last-gasp",
+        "releaseType": "prerelease"
       }
     ],
     "directories": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tabletop-timeline",
   "private": true,
-  "version": "1.0.0",
+  "version": "0.1.0-alpha.1",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Adds `"releaseType": "prerelease"` to the electron-builder publish config in `desktop/package.json`

## Problem
electron-builder defaults to `releaseType: "draft"` — it looks for a draft release to upload assets to. Since releases are created manually via the GitHub UI as pre-releases (not drafts), the upload was silently skipped with:
```
reason=existing type not compatible with publishing type existingType=pre-release publishingType=draft
```

## Fix
Setting `releaseType: "prerelease"` tells electron-builder to upload to an existing pre-release for the tag.

## Note for future stable releases
When shipping a non-pre-release (e.g. `v1.0.0`), change this to `"releaseType": "release"` — or omit it and use the draft workflow instead.

## Test plan
- [ ] Merge this PR
- [ ] Re-push the `v0.1.0-alpha.1` tag against the latest main commit
- [ ] Pipeline should upload `TableTop-Timeline-Setup-0.1.0-alpha.1.exe` to the existing pre-release

https://claude.ai/code/session_018iDfLcsDPLAzHwowYDCU5Y

---
_Generated by [Claude Code](https://claude.ai/code/session_018iDfLcsDPLAzHwowYDCU5Y)_