### PR TITLE
Three UX improvements: default view, event card scroll, new event focus

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -17,7 +17,7 @@ import type { LinkIndexEntry } from '../types/global';
 import '../../src/index.css';
 
 export default function App() {
-  const [currentView, setCurrentView] = useState<ViewType>('notes');
+  const [currentView, setCurrentView] = useState<ViewType>('timeline');
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [pendingJumpFilename, setPendingJumpFilename] = useState<string | null>(null);
   const [pendingOpenNotePath, setPendingOpenNotePath] = useState<string | null>(null);

--- a/src/renderer/timeline/event-editor/EventEditorModal.tsx
+++ b/src/renderer/timeline/event-editor/EventEditorModal.tsx
@@ -88,6 +88,7 @@ export function EventEditorModal({
   const savedTimerRef = useRef<number | null>(null);
 
   const viewRef = useRef<EditorView | null>(null);
+  const titleInputRef = useRef<HTMLInputElement>(null);
   const autoSaveTimerRef = useRef<number | null>(null);
 
   // Clear pending timers if the modal unmounts mid-flight
@@ -96,6 +97,14 @@ export function EventEditorModal({
       if (savedTimerRef.current !== null) window.clearTimeout(savedTimerRef.current);
       if (autoSaveTimerRef.current !== null) window.clearTimeout(autoSaveTimerRef.current);
     };
+  }, []);
+
+  // Focus the title on new event creation. This runs after children's effects
+  // (including MarkdownEditor's mode-toggle effect that calls view.focus()),
+  // so it reliably wins the focus race.
+  useEffect(() => {
+    if (mode.kind === 'create') titleInputRef.current?.focus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Capture mount-time values in a ref so the effect can have an empty deps array.
@@ -409,6 +418,7 @@ export function EventEditorModal({
                 <label className="event-editor-field">
                   <span className="event-editor-field-label">Title</span>
                   <input
+                    ref={titleInputRef}
                     type="text"
                     className="event-editor-input"
                     value={buffer.title}

--- a/src/renderer/timeline/interactions/useZoom.ts
+++ b/src/renderer/timeline/interactions/useZoom.ts
@@ -26,6 +26,8 @@ export function useZoom(
     if (!container) return;
 
     function onWheel(e: WheelEvent) {
+      // If the wheel fires over an expanded event card, let the browser scroll it.
+      if ((e.target as Element | null)?.closest('.event-card-expanded')) return;
       e.preventDefault();
       // clientX - rect.left gives position relative to container left edge,
       // which is what zoomAbout expects. offsetX is target-relative and breaks


### PR DESCRIPTION
## Summary

- **Default view**: Opening a campaign now lands on the Timeline view instead of Notes
- **Event card scrolling**: Wheel events over an expanded event card now scroll the card content rather than zooming the timeline
- **New event focus**: Opening the event creation editor focuses the Title field; editing an existing event still focuses the body editor

## Changes

- `src/renderer/app.tsx` — change initial `currentView` state from `'notes'` to `'timeline'`
- `src/renderer/timeline/interactions/useZoom.ts` — skip zoom if the wheel target is inside `.event-card-expanded`; the browser then handles the default scroll on the card
- `src/renderer/timeline/event-editor/EventEditorModal.tsx` — add `titleInputRef` and a mount-time `useEffect` that focuses the title input when `mode.kind === 'create'`. The effect is defined in the parent component so it runs after the MarkdownEditor's mode-toggle effect (which calls `view.focus()`), ensuring the title wins the focus race.

## Test plan

- [x] Open a campaign — verify the Timeline view is shown by default
- [x] Open an event card, expand it so content overflows, scroll over the card — verify the card scrolls rather than the timeline zooming
- [x] Create a new event — verify the Title field is focused on open
- [x] Edit an existing event — verify the body editor is focused on open

https://claude.ai/code/session_01G5EtjSKfNEG3PWi4DC5ymq

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5EtjSKfNEG3PWi4DC5ymq)_