### PR TITLE
feat: change wiki link completions to insert [[id]] format

### DIFF
--- a/src/renderer/shared/markdown-editor/extensions/__tests__/wiki-links.test.ts
+++ b/src/renderer/shared/markdown-editor/extensions/__tests__/wiki-links.test.ts
@@ -8,7 +8,9 @@ import {
   findWikiLinksInLine,
   wikiLinks,
   buildDecorations,
+  buildWikiLinkInsert,
   type WikiLinksConfig,
+  type WikiLinkSuggestion,
 } from '../wiki-links';
 
 describe('parseTrigger', () => {
@@ -185,6 +187,42 @@ describe('onHover / onHoverEnd callbacks', () => {
     expect(() => {
       link!.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     }).not.toThrow();
+  });
+});
+
+describe('buildWikiLinkInsert', () => {
+  const note: WikiLinkSuggestion = { id: 'abc1', label: 'Alice' };
+
+  it('inserts [[id]] format (not [[label|id]])', () => {
+    const { insert } = buildWikiLinkInsert(note, 2, 10, 15, 'xx');
+    expect(insert).toBe('[[abc1]]');
+  });
+
+  it('replaceFrom accounts for the [[ prefix', () => {
+    const { replaceFrom } = buildWikiLinkInsert(note, 2, 10, 15, 'xx');
+    expect(replaceFrom).toBe(8);
+  });
+
+  it('does not absorb trailing ]] when not present', () => {
+    const { replaceTo } = buildWikiLinkInsert(note, 2, 10, 15, 'xx');
+    expect(replaceTo).toBe(15);
+  });
+
+  it('absorbs trailing ]] when already present', () => {
+    const { replaceTo } = buildWikiLinkInsert(note, 2, 10, 15, ']]');
+    expect(replaceTo).toBe(17);
+  });
+
+  it('inserts image markdown for asset suggestions', () => {
+    const img: WikiLinkSuggestion = { id: 'img1', label: 'photo', assetPath: 'images/photo.png' };
+    const { insert, replaceTo } = buildWikiLinkInsert(img, 1, 5, 10, ']]');
+    expect(insert).toBe('![photo](notes-asset://current/images/photo.png)');
+    expect(replaceTo).toBe(10);
+  });
+
+  it('uses @ prefix length of 1 correctly', () => {
+    const { replaceFrom } = buildWikiLinkInsert(note, 1, 8, 12, 'xx');
+    expect(replaceFrom).toBe(7);
   });
 });
 

--- a/src/renderer/shared/markdown-editor/extensions/wiki-links.ts
+++ b/src/renderer/shared/markdown-editor/extensions/wiki-links.ts
@@ -169,6 +169,34 @@ function wikiLinkEditKeymap(config: WikiLinksConfig): Extension {
   );
 }
 
+export interface WikiLinkApplyResult {
+  insert: string;
+  replaceFrom: number;
+  replaceTo: number;
+}
+
+export function buildWikiLinkInsert(
+  s: WikiLinkSuggestion,
+  prefixLen: number,
+  from: number,
+  to: number,
+  nextTwo: string,
+): WikiLinkApplyResult {
+  const replaceFrom = from - prefixLen;
+  if (s.assetPath) {
+    return {
+      insert: `![${s.label}](notes-asset://current/${s.assetPath})`,
+      replaceFrom,
+      replaceTo: to,
+    };
+  }
+  return {
+    insert: `[[${s.id}]]`,
+    replaceFrom,
+    replaceTo: nextTwo === ']]' ? to + 2 : to,
+  };
+}
+
 function wikiLinkCompletions(config: WikiLinksConfig): Extension {
   if (!config.suggest) return [];
 
@@ -191,16 +219,14 @@ function wikiLinkCompletions(config: WikiLinksConfig): Extension {
             label: s.label,
             detail: s.detail,
             apply: (view: EditorView, _completion: Completion, from: number, to: number) => {
-              const replaceFrom = from - prefixLen;
-              let insert: string;
-              let replaceTo: number;
-              if (s.assetPath) {
-                insert = `![${s.label}](notes-asset://current/${s.assetPath})`;
-                replaceTo = to;
-              } else {
-                insert = `[[${s.label}|${s.id}]]`;
-                replaceTo = view.state.doc.sliceString(to, to + 2) === ']]' ? to + 2 : to;
-              }
+              const nextTwo = view.state.doc.sliceString(to, to + 2);
+              const { insert, replaceFrom, replaceTo } = buildWikiLinkInsert(
+                s,
+                prefixLen,
+                from,
+                to,
+                nextTwo,
+              );
               view.dispatch({
                 changes: { from: replaceFrom, to: replaceTo, insert },
                 selection: { anchor: replaceFrom + insert.length },


### PR DESCRIPTION
## Summary

- Changes the completion apply callback in `wiki-links.ts` to insert `[[id]]` instead of `[[label|id]]`, so display labels resolve dynamically from the entity index
- Extracts the insertion logic into exported `buildWikiLinkInsert` (pure function, no IO) to enable direct unit testing without mounting a full editor
- Adds 6 unit tests covering: new `[[id]]` format, prefix-length offset calculation (`[[` and `@`), trailing `]]` absorption, and the asset-path image branch

## Test plan

- [ ] All 1019 existing tests pass (`npm test`)
- [ ] `buildWikiLinkInsert` tests verify `[[id]]` insertion format
- [ ] `buildWikiLinkInsert` tests verify asset path branch still inserts `[label](notes-asset://...)`
- [ ] `buildWikiLinkInsert` tests verify trailing `]]` is absorbed when already present, and not absorbed when absent
- [x] Existing `[[label|id]]` links continue to parse and render correctly (parser handles both formats)

Closes #155

https://claude.ai/code/session_01YU9LzuxbfDjftaMX9BfCWC

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU9LzuxbfDjftaMX9BfCWC)_