### PR TITLE
feat: campaign loading screen UI component (#153)

### DIFF
--- a/src/renderer/views/campaigns/__tests__/campaign-loading-screen.test.tsx
+++ b/src/renderer/views/campaigns/__tests__/campaign-loading-screen.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+import { CampaignLoadingScreen } from '../campaign-loading-screen';
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setup() {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+}
+
+function teardown() {
+  act(() => root.unmount());
+  container.remove();
+}
+
+describe('CampaignLoadingScreen', () => {
+  afterEach(teardown);
+
+  it('renders the title', () => {
+    setup();
+    act(() => root.render(<CampaignLoadingScreen percentage={50} taskName="Loading events" />));
+    expect(container.querySelector('h2')?.textContent).toBe('Loading Your Universe');
+  });
+
+  it('renders the task name', () => {
+    setup();
+    act(() => root.render(<CampaignLoadingScreen percentage={30} taskName="Parsing notes" />));
+    expect(container.textContent).toContain('Parsing notes');
+  });
+
+  it('sets progress bar width to the given percentage', () => {
+    setup();
+    act(() => root.render(<CampaignLoadingScreen percentage={75} taskName="Loading" />));
+    const fill = container.querySelector('.campaign-loading-bar-fill') as HTMLElement;
+    expect(fill.style.width).toBe('75%');
+  });
+
+  it('clamps percentage below 0 to 0', () => {
+    setup();
+    act(() => root.render(<CampaignLoadingScreen percentage={-10} taskName="Loading" />));
+    const fill = container.querySelector('.campaign-loading-bar-fill') as HTMLElement;
+    expect(fill.style.width).toBe('0%');
+  });
+
+  it('clamps percentage above 100 to 100', () => {
+    setup();
+    act(() => root.render(<CampaignLoadingScreen percentage={120} taskName="Loading" />));
+    const fill = container.querySelector('.campaign-loading-bar-fill') as HTMLElement;
+    expect(fill.style.width).toBe('100%');
+  });
+
+  it('exposes progressbar role with aria attributes', () => {
+    setup();
+    act(() => root.render(<CampaignLoadingScreen percentage={40} taskName="Loading" />));
+    const bar = container.querySelector('[role="progressbar"]');
+    expect(bar).not.toBeNull();
+    expect(bar?.getAttribute('aria-valuenow')).toBe('40');
+    expect(bar?.getAttribute('aria-valuemin')).toBe('0');
+    expect(bar?.getAttribute('aria-valuemax')).toBe('100');
+  });
+
+  it('has no close button', () => {
+    setup();
+    act(() => root.render(<CampaignLoadingScreen percentage={50} taskName="Loading" />));
+    expect(container.querySelector('button')).toBeNull();
+  });
+});

--- a/src/renderer/views/campaigns/campaign-loading-screen.css
+++ b/src/renderer/views/campaigns/campaign-loading-screen.css
@@ -1,0 +1,44 @@
+.campaign-loading-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.campaign-loading-panel {
+  border-radius: 12px;
+  padding: 40px 48px;
+  width: 400px;
+  max-width: calc(100vw - 48px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.8);
+}
+
+.campaign-loading-title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.campaign-loading-bar-track {
+  height: 8px;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.campaign-loading-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.campaign-loading-task {
+  font-size: 13px;
+  text-align: center;
+}

--- a/src/renderer/views/campaigns/campaign-loading-screen.tsx
+++ b/src/renderer/views/campaigns/campaign-loading-screen.tsx
@@ -1,0 +1,41 @@
+import { ThemeProvider } from '../../theme';
+import './campaign-loading-screen.css';
+
+interface CampaignLoadingScreenProps {
+  percentage: number;
+  taskName: string;
+}
+
+export function CampaignLoadingScreen({ percentage, taskName }: CampaignLoadingScreenProps) {
+  const bs = ThemeProvider.get().bootstrap;
+  const clampedPct = Math.min(100, Math.max(0, percentage));
+
+  return (
+    <div className="campaign-loading-overlay">
+      <div
+        className="campaign-loading-panel"
+        style={{ backgroundColor: bs.cardBg, border: `1px solid ${bs.cardBorder}` }}
+      >
+        <h2 className="campaign-loading-title" style={{ color: bs.primary }}>
+          Loading Your Universe
+        </h2>
+        <div
+          className="campaign-loading-bar-track"
+          style={{ backgroundColor: bs.bg, border: `1px solid ${bs.cardBorder}` }}
+          role="progressbar"
+          aria-valuenow={clampedPct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <div
+            className="campaign-loading-bar-fill"
+            style={{ width: `${clampedPct}%`, backgroundColor: bs.primary }}
+          />
+        </div>
+        <div className="campaign-loading-task" style={{ color: bs.textMuted }}>
+          {taskName}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📝 Description

**Issue(s):** #153

Adds the `CampaignLoadingScreen` component — a fixed overlay shown during campaign load with an animated progress bar, title, and current task name. Pure UI component; no close button; dismissed programmatically by the caller.

---

## 🔍 Details

* **`campaign-loading-screen.tsx`:** New React component with `percentage` and `taskName` props. Renders a fixed overlay (matching the `rgba(0,0,0,0.65)` modal pattern), a centered panel, an accessible `role="progressbar"` bar whose fill width transitions with CSS, and muted task name text. All colors sourced from `ThemeProvider.get().bootstrap` to match the pre-campaign-theme bootstrap palette.
* **`campaign-loading-screen.css`:** Structural layout (overlay, panel, bar track/fill, CSS `transition: width 0.3s ease`) with no hardcoded colour values.
* **`__tests__/campaign-loading-screen.test.tsx`:** 7 vitest tests covering title, task name, bar width, clamping below 0, clamping above 100, ARIA attributes, and absence of a close button.

---

## 🧪 Manual Test Cases

### 🚀 New Behavior
- [ ] Overlay covers the full viewport with a dark semi-transparent backdrop
- [ ] Panel is horizontally and vertically centered
- [ ] "Loading Your Universe" title appears in the indigo primary color
- [ ] Progress bar fills to the given percentage with a smooth CSS transition when the percentage prop changes
- [ ] Task name renders below the bar in muted text
- [ ] No close button or dismiss affordance is visible

### 🛡️ Regression Checks
- [ ] Existing campaign manager renders and functions normally
- [ ] All existing tests still pass (`npm test`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYDAcRXyoTguNm58v6phQ6)_