### PR TITLE
Rename LinkIndex to EntityIndex (#148)

### DIFF
--- a/src/main/entity-index.ts
+++ b/src/main/entity-index.ts
@@ -5,15 +5,15 @@ import { ASSET_EXTENSIONS } from '../shared/fileKinds.js';
 
 export { ASSET_EXTENSIONS };
 
-export interface LinkIndexEntry {
+export interface EntityIndexEntry {
   id: string;
   path: string; // Campaign-relative path (using forward slashes)
   title: string;
   type: 'note' | 'event' | 'asset';
 }
 
-export function buildLinkIndex(campaignPath: string): LinkIndexEntry[] {
-  const index: LinkIndexEntry[] = [];
+export function buildEntityIndex(campaignPath: string): EntityIndexEntry[] {
+  const index: EntityIndexEntry[] = [];
   const notesDir = path.join(campaignPath, 'notes');
   const timelineDir = path.join(campaignPath, 'timeline');
 
@@ -32,7 +32,7 @@ export function buildLinkIndex(campaignPath: string): LinkIndexEntry[] {
  * Writes back frontmatter if id/title were auto-generated.
  * Returns null if the file is not a tracked markdown file.
  */
-export function indexSingleFile(fullPath: string, campaignPath: string): LinkIndexEntry | null {
+export function indexSingleEntity(fullPath: string, campaignPath: string): EntityIndexEntry | null {
   const ext = path.extname(fullPath).toLowerCase();
   const rel = path.relative(campaignPath, fullPath).replace(/\\/g, '/');
   const isNote = rel.startsWith('notes/');
@@ -66,7 +66,7 @@ function scanDir(
   currentDir: string,
   type: 'note' | 'event',
   baseDir: string,
-  index: LinkIndexEntry[],
+  index: EntityIndexEntry[],
 ) {
   const entries = fs.readdirSync(currentDir, { withFileTypes: true });
 

--- a/src/main/fileWatcher.ts
+++ b/src/main/fileWatcher.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { BrowserWindow } from 'electron';
 import * as chokidar from 'chokidar';
-import { indexSingleFile, ASSET_EXTENSIONS } from './linkIndex.js';
+import { indexSingleEntity, ASSET_EXTENSIONS } from './entity-index.js';
 
 export class FileWatcher {
   private watcher: chokidar.FSWatcher | null = null;
@@ -39,7 +39,7 @@ export class FileWatcher {
         const ext = path.extname(filePath).toLowerCase();
         const tracked = ext === '.md' || ASSET_EXTENSIONS.has(ext);
         if (tracked && (rel.startsWith('notes/') || rel.startsWith('timeline/'))) {
-          mainWindow.webContents.send('notes:indexDelta', { op: 'remove', path: rel });
+          mainWindow.webContents.send('entity:indexDelta', { op: 'remove', path: rel });
         }
       });
 
@@ -49,9 +49,9 @@ export class FileWatcher {
   private pushIndexDelta(filePath: string, op: 'add' | 'update', mainWindow: BrowserWindow) {
     const ext = path.extname(filePath).toLowerCase();
     if (ext !== '.md' && !ASSET_EXTENSIONS.has(ext)) return;
-    const entry = indexSingleFile(filePath, this.campaignPath);
+    const entry = indexSingleEntity(filePath, this.campaignPath);
     if (!entry) return;
-    mainWindow.webContents.send('notes:indexDelta', { op, entry });
+    mainWindow.webContents.send('entity:indexDelta', { op, entry });
   }
 
   public stop() {

--- a/src/main/ipcHandlers.ts
+++ b/src/main/ipcHandlers.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 import matter from 'gray-matter';
 import pkg from 'electron-updater';
 import { generateShortId } from '../shared/ids.js';
-import { buildLinkIndex } from './linkIndex.js';
+import { buildEntityIndex } from './entity-index.js';
 import { registerTimelineIpcHandlers } from './timelineIpcHandlers.js';
 
 const { autoUpdater } = pkg;
@@ -254,11 +254,11 @@ ${description}
     }
   });
 
-  ipcMain.handle('notes:buildIndex', async (event, campaignPath: string) => {
+  ipcMain.handle('entity:buildIndex', async (event, campaignPath: string) => {
     try {
-      return buildLinkIndex(campaignPath);
+      return buildEntityIndex(campaignPath);
     } catch (error) {
-      console.error('Failed to build link index:', error);
+      console.error('Failed to build entity index:', error);
       return [];
     }
   });

--- a/src/preload/index.cts
+++ b/src/preload/index.cts
@@ -24,7 +24,7 @@ contextBridge.exposeInMainWorld('fsApi', {
   rename: (oldPath: string, newPath: string) => ipcRenderer.invoke('fs:rename', oldPath, newPath),
 
   // Notes
-  buildIndex: (campaignPath: string) => ipcRenderer.invoke('notes:buildIndex', campaignPath),
+  buildIndex: (campaignPath: string) => ipcRenderer.invoke('entity:buildIndex', campaignPath),
   ensureDirs: (notesDir: string) => ipcRenderer.invoke('notes:ensureDirs', notesDir),
 
   // Watcher
@@ -34,10 +34,10 @@ contextBridge.exposeInMainWorld('fsApi', {
     return () => ipcRenderer.removeListener('fs:changed', listener);
   },
 
-  onIndexDelta: (callback: (delta: unknown) => void) => {
+  onEntityDelta: (callback: (delta: unknown) => void) => {
     const listener = (_event: unknown, delta: unknown) => callback(delta);
-    ipcRenderer.on('notes:indexDelta', listener);
-    return () => ipcRenderer.removeListener('notes:indexDelta', listener);
+    ipcRenderer.on('entity:indexDelta', listener);
+    return () => ipcRenderer.removeListener('entity:indexDelta', listener);
   },
 
   // Timeline

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -12,7 +12,7 @@ import { notesData } from './notes/data';
 import { timelinePort } from './timeline/data/ports';
 import { initPeek, teardownPeek } from './peek/stack';
 import type { EventListItem } from './timeline/data/types';
-import type { LinkIndexEntry } from '../types/global';
+import type { EntityIndexEntry } from '../types/global';
 import '../../src/index.css';
 
 export default function App() {
@@ -32,22 +32,22 @@ export default function App() {
     handleCloseCampaign,
   } = useCampaigns();
 
-  const linkIndexRef = useRef<LinkIndexEntry[]>([]);
+  const entityIndexRef = useRef<EntityIndexEntry[]>([]);
 
   useEffect(() => {
     if (!activeCampaign) return;
     const campaignPath = activeCampaign.path;
-    linkIndexRef.current = [];
+    entityIndexRef.current = [];
     let active = true;
     notesData
-      .getLinkIndex(campaignPath)
+      .getEntityIndex(campaignPath)
       .then((index) => {
-        if (active) linkIndexRef.current = index;
+        if (active) entityIndexRef.current = index;
       })
       .catch(() => {});
     return () => {
       active = false;
-      linkIndexRef.current = [];
+      entityIndexRef.current = [];
     };
   }, [activeCampaign?.path]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -63,7 +63,7 @@ export default function App() {
         const { event } = await timelinePort.getEvent(campaignPath, filename);
         return `# ${event.title}\n\n${event.body}`;
       },
-      getLinkIndex: () => linkIndexRef.current,
+      getEntityIndex: () => entityIndexRef.current,
       onOpenById: handleOpenById,
     });
     return () => teardownPeek();
@@ -96,7 +96,7 @@ export default function App() {
 
   const handleOpenById = useCallback(
     (id: string) => {
-      const entry = linkIndexRef.current.find((e) => e.id === id);
+      const entry = entityIndexRef.current.find((e) => e.id === id);
       if (!entry) return;
       if (entry.type === 'event') {
         handleJumpToEvent(entry.path.split('/').pop()!);

--- a/src/renderer/components/search-overlay.tsx
+++ b/src/renderer/components/search-overlay.tsx
@@ -3,7 +3,7 @@ import { timelinePort } from '../timeline/data/ports';
 import type { EventListItem } from '../timeline/data/types';
 import { parseISOString } from '../timeline/calendar/golarian';
 import { formatCompact } from '../timeline/calendar/format';
-import type { LinkIndexEntry } from '../../types/global';
+import type { EntityIndexEntry } from '../../types/global';
 import { splitFrontmatter } from '../../shared/frontmatter';
 import './search-overlay.css';
 
@@ -82,14 +82,14 @@ export function SearchOverlay({
 
     async function load() {
       // Load event and note lists in parallel
-      const [eventList, linkIndex] = await Promise.all([
+      const [eventList, entityIndex] = await Promise.all([
         timelinePort.listEvents(campaignPath),
         window.fsApi.buildIndex(campaignPath),
       ]);
       if (cancelled) return;
 
       const initialEvents: SearchableEvent[] = eventList;
-      const initialNotes: SearchableNote[] = (linkIndex as LinkIndexEntry[])
+      const initialNotes: SearchableNote[] = (entityIndex as EntityIndexEntry[])
         .filter((e) => e.type === 'note')
         .map((e) => ({ path: e.path, title: e.title }));
 

--- a/src/renderer/notes/__tests__/scan-folder.test.ts
+++ b/src/renderer/notes/__tests__/scan-folder.test.ts
@@ -6,7 +6,7 @@ vi.mock('../data', () => ({
 
 import { notesData } from '../data';
 import { scanFolderContents } from '../scan-folder';
-import type { LinkIndexEntry } from '../../../types/global';
+import type { EntityIndexEntry } from '../../../types/global';
 
 const listFolder = notesData.listFolder as ReturnType<typeof vi.fn>;
 
@@ -30,7 +30,7 @@ describe('scanFolderContents', () => {
   });
 
   it('produces a note entry for a file matched in the index', async () => {
-    const index: LinkIndexEntry[] = [
+    const index: EntityIndexEntry[] = [
       { id: 'n1', path: 'notes/Lore/bob.md', title: 'Bob', type: 'note' },
     ];
     listFolder.mockResolvedValue([{ name: 'bob.md', isDirectory: false }]);
@@ -39,7 +39,7 @@ describe('scanFolderContents', () => {
   });
 
   it('produces an asset entry for an asset in the index', async () => {
-    const index: LinkIndexEntry[] = [
+    const index: EntityIndexEntry[] = [
       { id: 's1', path: 'notes/Lore/map.png', title: 'World Map', type: 'asset' },
     ];
     listFolder.mockResolvedValue([{ name: 'map.png', isDirectory: false }]);
@@ -64,7 +64,7 @@ describe('scanFolderContents', () => {
   });
 
   it('recurses into a non-empty child directory and uses nested relative paths', async () => {
-    const index: LinkIndexEntry[] = [
+    const index: EntityIndexEntry[] = [
       { id: 'n2', path: 'notes/Lore/sub/child.md', title: 'Child', type: 'note' },
     ];
     listFolder.mockImplementation(async (p: string) => {
@@ -77,7 +77,7 @@ describe('scanFolderContents', () => {
   });
 
   it('does not produce a dir entry for a child directory that has contents', async () => {
-    const index: LinkIndexEntry[] = [
+    const index: EntityIndexEntry[] = [
       { id: 'n3', path: 'notes/Lore/sub/child.md', title: 'Child', type: 'note' },
     ];
     listFolder.mockImplementation(async (p: string) => {
@@ -91,7 +91,7 @@ describe('scanFolderContents', () => {
   });
 
   it('returns partial results when listFolder throws for a subdirectory', async () => {
-    const index: LinkIndexEntry[] = [
+    const index: EntityIndexEntry[] = [
       { id: 'n4', path: 'notes/Lore/good.md', title: 'Good', type: 'note' },
     ];
     // First call: root dir listing. Second call: bad subdir throws.
@@ -106,7 +106,7 @@ describe('scanFolderContents', () => {
   });
 
   it('handles folder and file names that contain spaces', async () => {
-    const index: LinkIndexEntry[] = [
+    const index: EntityIndexEntry[] = [
       {
         id: 'sp1',
         path: 'notes/Lore/Player Characters/bob the brave.md',

--- a/src/renderer/notes/data.ts
+++ b/src/renderer/notes/data.ts
@@ -1,4 +1,4 @@
-import { LinkIndexEntry } from '../../types/global';
+import { EntityIndexEntry } from '../../types/global';
 
 export const notesData = {
   async readNote(path: string): Promise<string | null> {
@@ -17,7 +17,7 @@ export const notesData = {
     return window.fsApi.rename(oldPath, newPath);
   },
 
-  async getLinkIndex(campaignPath: string): Promise<LinkIndexEntry[]> {
+  async getEntityIndex(campaignPath: string): Promise<EntityIndexEntry[]> {
     return window.fsApi.buildIndex(campaignPath);
   },
 

--- a/src/renderer/notes/domain/__tests__/link-resolution.test.ts
+++ b/src/renderer/notes/domain/__tests__/link-resolution.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { resolveLinkById, resolveMarkdownHref } from '../link-resolution';
-import type { LinkIndexEntry } from '../../../../types/global';
+import type { EntityIndexEntry } from '../../../../types/global';
 
-const idx: LinkIndexEntry[] = [
+const idx: EntityIndexEntry[] = [
   { id: 'a1', path: 'notes/Lore/bob.md', title: 'Bob the Brave', type: 'note' },
   { id: 'a2', path: 'notes/Lore/places.md', title: 'Places', type: 'note' },
   { id: 'e1', path: 'timeline/sess-01.md', title: 'Session 1', type: 'event' },

--- a/src/renderer/notes/domain/link-resolution.ts
+++ b/src/renderer/notes/domain/link-resolution.ts
@@ -1,12 +1,12 @@
-import type { LinkIndexEntry } from '../../../types/global';
+import type { EntityIndexEntry } from '../../../types/global';
 
 export type ResolvedLink =
   | { kind: 'not-found' }
   | { kind: 'event'; filename: string }
   | { kind: 'note'; folder: string; path: string };
 
-export function resolveLinkById(linkIndex: readonly LinkIndexEntry[], id: string): ResolvedLink {
-  const entry = linkIndex.find((e) => e.id === id);
+export function resolveLinkById(entityIndex: readonly EntityIndexEntry[], id: string): ResolvedLink {
+  const entry = entityIndex.find((e) => e.id === id);
   if (!entry) return { kind: 'not-found' };
   if (entry.type === 'event') {
     const filename = entry.path.split('/').slice(1).join('/');
@@ -17,9 +17,9 @@ export function resolveLinkById(linkIndex: readonly LinkIndexEntry[], id: string
 }
 
 export function resolveMarkdownHref(
-  linkIndex: readonly LinkIndexEntry[],
+  entityIndex: readonly EntityIndexEntry[],
   rawUrl: string,
-): LinkIndexEntry | null {
+): EntityIndexEntry | null {
   const target = rawUrl.replace(/^\.?\//, '');
-  return linkIndex.find((e) => e.path === target || e.path.endsWith('/' + target)) ?? null;
+  return entityIndex.find((e) => e.path === target || e.path.endsWith('/' + target)) ?? null;
 }

--- a/src/renderer/notes/domain/link-resolution.ts
+++ b/src/renderer/notes/domain/link-resolution.ts
@@ -5,7 +5,10 @@ export type ResolvedLink =
   | { kind: 'event'; filename: string }
   | { kind: 'note'; folder: string; path: string };
 
-export function resolveLinkById(entityIndex: readonly EntityIndexEntry[], id: string): ResolvedLink {
+export function resolveLinkById(
+  entityIndex: readonly EntityIndexEntry[],
+  id: string,
+): ResolvedLink {
   const entry = entityIndex.find((e) => e.id === id);
   if (!entry) return { kind: 'not-found' };
   if (entry.type === 'event') {

--- a/src/renderer/notes/hooks/useNotesController.ts
+++ b/src/renderer/notes/hooks/useNotesController.ts
@@ -28,7 +28,7 @@ import {
   type Toast,
   type ConfirmState,
 } from '../types';
-import type { LinkIndexEntry } from '../../../types/global';
+import type { EntityIndexEntry } from '../../../types/global';
 import type { ContextMenuTarget } from '../components/note-context-menu';
 
 interface NotesControllerOptions {
@@ -46,7 +46,7 @@ export function useNotesController({
   const [folders, setFolders] = useState<string[]>([]);
   const [folderFiles, setFolderFiles] = useState<Record<string, NoteEntry[] | null>>({});
   const [openFiles, setOpenFiles] = useState<Record<string, FileState>>({});
-  const [linkIndex, setLinkIndex] = useState<LinkIndexEntry[]>([]);
+  const [entityIndex, setEntityIndex] = useState<EntityIndexEntry[]>([]);
 
   // ---- Tabs ----
   const [tabsState, dispatch] = useReducer(tabsReducer, campaignId, (id): TabsState => {
@@ -135,7 +135,7 @@ export function useNotesController({
   }, [activeTab]);
 
   const scanFolderContentsForCampaign = useCallback(
-    (folder: string, index: LinkIndexEntry[]) => scanFolderContents(campaignPath, folder, index),
+    (folder: string, index: EntityIndexEntry[]) => scanFolderContents(campaignPath, folder, index),
     [campaignPath],
   );
 
@@ -149,8 +149,8 @@ export function useNotesController({
         const folderNames = entries.filter((e) => e.isDirectory).map((e) => e.name);
         setFolders(folderNames);
 
-        const index = await notesData.getLinkIndex(campaignPath);
-        setLinkIndex(index);
+        const index = await notesData.getEntityIndex(campaignPath);
+        setEntityIndex(index);
 
         // Scan each folder from the filesystem so empty dirs and unrecognised
         // files appear in the sidebar alongside notes and assets.
@@ -173,10 +173,10 @@ export function useNotesController({
 
   // ---- A3: Live index delta listener ----
   useEffect(() => {
-    const unsub = window.fsApi.onIndexDelta((delta) => {
+    const unsub = window.fsApi.onEntityDelta((delta) => {
       if (delta.op === 'add' || delta.op === 'update') {
         const { entry } = delta;
-        setLinkIndex((prev) => {
+        setEntityIndex((prev) => {
           const filtered = prev.filter((e) => e.id !== entry.id && e.path !== entry.path);
           return [...filtered, entry];
         });
@@ -202,7 +202,7 @@ export function useNotesController({
         }
       } else if (delta.op === 'remove') {
         const relPath = delta.path;
-        setLinkIndex((prev) => prev.filter((e) => e.path !== relPath));
+        setEntityIndex((prev) => prev.filter((e) => e.path !== relPath));
         const parts = relPath.split('/');
         if (parts.length >= 3 && parts[0] === 'notes') {
           const folder = parts[1];
@@ -253,7 +253,7 @@ export function useNotesController({
     if (folderFiles[folder] !== undefined) return;
     setFolderFiles((prev) => ({ ...prev, [folder]: null }));
     try {
-      const entries = await scanFolderContentsForCampaign(folder, linkIndex);
+      const entries = await scanFolderContentsForCampaign(folder, entityIndex);
       setFolderFiles((prev) => ({ ...prev, [folder]: entries }));
     } catch (err) {
       pushToast(`Failed to load ${folder}: ${String(err)}`, true);
@@ -345,7 +345,7 @@ export function useNotesController({
       if (!slug) return;
       const filename = `${slug}.md`;
       setQuickAddOpen(false);
-      // Write frontmatter from the start so the link-index watcher finds needsWrite:false
+      // Write frontmatter from the start so the entity-index watcher finds needsWrite:false
       // and does not rewrite the file, which would create a race with our autosave.
       const id = generateShortId();
       const frontmatter = `id: ${id}\ntitle: ${title}`;
@@ -382,7 +382,7 @@ export function useNotesController({
     const base = slug.endsWith('.md') ? slug : `${slug}.md`;
     const filePath = ctx.subdir ? `${ctx.subdir}/${base}` : base;
     try {
-      // Write frontmatter from the start so the link-index watcher finds needsWrite:false
+      // Write frontmatter from the start so the entity-index watcher finds needsWrite:false
       // and does not rewrite the file, which would race with ensureLoaded's disk read.
       const id = generateShortId();
       const frontmatter = `id: ${id}\ntitle: ${trimmed}`;
@@ -517,7 +517,7 @@ export function useNotesController({
   }
 
   function handleOpenLink(id: string) {
-    const resolved = resolveLinkById(linkIndex, id);
+    const resolved = resolveLinkById(entityIndex, id);
     if (resolved.kind === 'not-found') {
       pushToast(`Note not found: ${id}`, true);
       return;
@@ -536,7 +536,7 @@ export function useNotesController({
   }
 
   function openMarkdownLink(rawUrl: string) {
-    const match = resolveMarkdownHref(linkIndex, rawUrl);
+    const match = resolveMarkdownHref(entityIndex, rawUrl);
     if (!match) {
       pushToast(`Could not resolve link: ${rawUrl}`, true);
       return;
@@ -545,7 +545,7 @@ export function useNotesController({
   }
 
   function suggestLinks(query: string) {
-    return suggestLinksDomain(linkIndex, query);
+    return suggestLinksDomain(entityIndex, query);
   }
 
   async function handleRenameFolder(oldFolderName: string, newName: string) {
@@ -583,7 +583,7 @@ export function useNotesController({
     folders,
     folderFiles,
     openFiles,
-    linkIndex,
+    entityIndex,
     // Tabs
     tabs,
     activeTab,

--- a/src/renderer/notes/notes.tsx
+++ b/src/renderer/notes/notes.tsx
@@ -46,7 +46,7 @@ export function NotesApp({
   onOpenEvent,
 }: NotesAppProps) {
   const ctrl = useNotesController({ campaignId, campaignPath, onOpenEvent });
-  const knownIds = useMemo(() => new Set(ctrl.linkIndex.map((e) => e.id)), [ctrl.linkIndex]);
+  const knownIds = useMemo(() => new Set(ctrl.entityIndex.map((e) => e.id)), [ctrl.entityIndex]);
 
   const editorStateCache = useRef(new Map<string, SavedEditorInstance>());
   const editorViewRef = useRef<EditorView | null>(null);

--- a/src/renderer/notes/scan-folder.ts
+++ b/src/renderer/notes/scan-folder.ts
@@ -1,11 +1,11 @@
 import { notesData } from './data';
-import type { LinkIndexEntry } from '../../types/global';
+import type { EntityIndexEntry } from '../../types/global';
 import type { NoteEntry } from './types';
 
 export async function scanFolderContents(
   campaignPath: string,
   folder: string,
-  index: readonly LinkIndexEntry[],
+  index: readonly EntityIndexEntry[],
 ): Promise<NoteEntry[]> {
   const results: NoteEntry[] = [];
 

--- a/src/renderer/peek/__tests__/peek-hover-integration.test.tsx
+++ b/src/renderer/peek/__tests__/peek-hover-integration.test.tsx
@@ -138,7 +138,7 @@ describe('peek hover integration — end-to-end via initPeek', () => {
   it('triggers showPeek after OPEN_DELAY_MS when initPeek is wired to the editor', () => {
     initPeek({
       fetcher: vi.fn(),
-      getLinkIndex: () => [{ id: 'abc1', path: 'notes/foo.md', title: 'Foo', type: 'note' }],
+      getEntityIndex: () => [{ id: 'abc1', path: 'notes/foo.md', title: 'Foo', type: 'note' }],
     });
 
     setup();

--- a/src/renderer/peek/__tests__/resolve.test.ts
+++ b/src/renderer/peek/__tests__/resolve.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { resolvePeekTarget } from '../resolve';
-import type { LinkIndexEntry } from '../../../types/global';
+import type { EntityIndexEntry } from '../../../types/global';
 
-const linkIndex: LinkIndexEntry[] = [
+const entityIndex: EntityIndexEntry[] = [
   { id: 'bob', path: 'notes/npcs/bob.md', title: 'Bob', type: 'note' },
   { id: 'battle', path: 'timeline/battle.md', title: 'Battle', type: 'event' },
   { id: 'map', path: 'notes/assets/map.png', title: 'Map', type: 'asset' },
@@ -50,23 +50,23 @@ describe('resolvePeekTarget — plain href', () => {
 
 describe('resolvePeekTarget — wiki-link id', () => {
   it('resolves note id', () => {
-    expect(resolvePeekTarget('bob', 'notes', linkIndex)).toEqual({
+    expect(resolvePeekTarget('bob', 'notes', entityIndex)).toEqual({
       path: 'notes/npcs/bob.md',
     });
   });
 
   it('resolves event id', () => {
-    expect(resolvePeekTarget('battle', 'notes', linkIndex)).toEqual({
+    expect(resolvePeekTarget('battle', 'notes', entityIndex)).toEqual({
       path: 'timeline/battle.md',
     });
   });
 
   it('returns null for unknown id', () => {
-    expect(resolvePeekTarget('nonexistent', 'notes', linkIndex)).toBeNull();
+    expect(resolvePeekTarget('nonexistent', 'notes', entityIndex)).toBeNull();
   });
 
   it('returns null for asset id', () => {
-    expect(resolvePeekTarget('map', 'notes', linkIndex)).toBeNull();
+    expect(resolvePeekTarget('map', 'notes', entityIndex)).toBeNull();
   });
 
   it('returns null when index is empty', () => {
@@ -74,7 +74,7 @@ describe('resolvePeekTarget — wiki-link id', () => {
   });
 
   it('baseDir does not affect wiki-id resolution', () => {
-    expect(resolvePeekTarget('bob', 'timeline', linkIndex)).toEqual({
+    expect(resolvePeekTarget('bob', 'timeline', entityIndex)).toEqual({
       path: 'notes/npcs/bob.md',
     });
   });

--- a/src/renderer/peek/__tests__/stack.test.ts
+++ b/src/renderer/peek/__tests__/stack.test.ts
@@ -83,7 +83,7 @@ beforeEach(() => {
   capturedCalls = [];
   vi.useFakeTimers();
   mockResolvePeekTarget.mockReturnValue({ path: 'notes/foo.md' });
-  initPeek({ fetcher: vi.fn(), getLinkIndex: () => [] });
+  initPeek({ fetcher: vi.fn(), getEntityIndex: () => [] });
 });
 
 afterEach(() => {

--- a/src/renderer/peek/resolve.ts
+++ b/src/renderer/peek/resolve.ts
@@ -1,4 +1,4 @@
-import type { LinkIndexEntry } from '../../types/global';
+import type { EntityIndexEntry } from '../../types/global';
 
 export interface PeekTarget {
   path: string;
@@ -7,14 +7,14 @@ export interface PeekTarget {
 /**
  * Resolve a link (plain href or wiki-link id) to a peekable target.
  *
- * @param href      Raw href or wiki-link id
- * @param baseDir   Campaign-relative directory of the source file (e.g. "notes/npcs")
- * @param linkIndex Current link index entries (for wiki-link id lookup)
+ * @param href        Raw href or wiki-link id
+ * @param baseDir     Campaign-relative directory of the source file (e.g. "notes/npcs")
+ * @param entityIndex Current entity index entries (for wiki-link id lookup)
  */
 export function resolvePeekTarget(
   href: string,
   baseDir: string,
-  linkIndex: readonly LinkIndexEntry[],
+  entityIndex: readonly EntityIndexEntry[],
 ): PeekTarget | null {
   if (!href) return null;
 
@@ -25,7 +25,7 @@ export function resolvePeekTarget(
     !href.includes('://') &&
     !href.endsWith('.md')
   ) {
-    const entry = linkIndex.find((e) => e.id === href);
+    const entry = entityIndex.find((e) => e.id === href);
     if (!entry) return null;
     if (entry.type === 'asset') return null;
     return { path: entry.path };

--- a/src/renderer/peek/stack.ts
+++ b/src/renderer/peek/stack.ts
@@ -1,4 +1,4 @@
-import type { LinkIndexEntry } from '../../types/global';
+import type { EntityIndexEntry } from '../../types/global';
 import { showPeek, type PeekHandle } from './show';
 import { resolvePeekTarget } from './resolve';
 
@@ -19,7 +19,7 @@ let stackConfig: PeekStackConfig | null = null;
 
 export interface PeekStackConfig {
   fetcher: (path: string, signal: AbortSignal) => Promise<string>;
-  getLinkIndex: () => readonly LinkIndexEntry[];
+  getEntityIndex: () => readonly EntityIndexEntry[];
   onOpenById?: (id: string) => void;
 }
 
@@ -45,7 +45,7 @@ function isLive(el: Element | null): boolean {
   const cmLink = el.closest<HTMLElement>('.cm-note-link');
   if (cmLink) {
     const noteId = cmLink.dataset.noteId;
-    return !!noteId && resolvePeekTarget(noteId, '', stackConfig?.getLinkIndex() ?? []) !== null;
+    return !!noteId && resolvePeekTarget(noteId, '', stackConfig?.getEntityIndex() ?? []) !== null;
   }
 
   // Plain <a href> links in rendered HTML (e.g. markdown preview surfaces with data-base-dir)
@@ -54,7 +54,7 @@ function isLive(el: Element | null): boolean {
   const baseDir = a.closest('[data-base-dir]')?.getAttribute('data-base-dir') ?? '';
   if (!baseDir) return false;
   return (
-    resolvePeekTarget(a.getAttribute('href') ?? '', baseDir, stackConfig?.getLinkIndex() ?? []) !==
+    resolvePeekTarget(a.getAttribute('href') ?? '', baseDir, stackConfig?.getEntityIndex() ?? []) !==
     null
   );
 }
@@ -124,7 +124,7 @@ function handleOver(e: MouseEvent) {
   if (cmLink) {
     const noteId = cmLink.dataset.noteId;
     if (!noteId) return;
-    const peekTarget = resolvePeekTarget(noteId, '', stackConfig?.getLinkIndex() ?? []);
+    const peekTarget = resolvePeekTarget(noteId, '', stackConfig?.getEntityIndex() ?? []);
     if (!peekTarget) return;
     cancelClose();
     cancelOpen();
@@ -140,7 +140,7 @@ function handleOver(e: MouseEvent) {
   const peekTarget = resolvePeekTarget(
     a.getAttribute('href') ?? '',
     baseDir,
-    stackConfig?.getLinkIndex() ?? [],
+    stackConfig?.getEntityIndex() ?? [],
   );
   if (!peekTarget) return;
   cancelClose();
@@ -182,7 +182,7 @@ export function teardownPeek(): void {
 
 export function openFromWikiLink(id: string, el: HTMLElement): void {
   if (!stackConfig) return;
-  const peekTarget = resolvePeekTarget(id, '', stackConfig.getLinkIndex());
+  const peekTarget = resolvePeekTarget(id, '', stackConfig.getEntityIndex());
   if (!peekTarget) return;
   cancelClose();
   cancelOpen();

--- a/src/renderer/peek/stack.ts
+++ b/src/renderer/peek/stack.ts
@@ -54,8 +54,11 @@ function isLive(el: Element | null): boolean {
   const baseDir = a.closest('[data-base-dir]')?.getAttribute('data-base-dir') ?? '';
   if (!baseDir) return false;
   return (
-    resolvePeekTarget(a.getAttribute('href') ?? '', baseDir, stackConfig?.getEntityIndex() ?? []) !==
-    null
+    resolvePeekTarget(
+      a.getAttribute('href') ?? '',
+      baseDir,
+      stackConfig?.getEntityIndex() ?? [],
+    ) !== null
   );
 }
 

--- a/src/renderer/shared/__tests__/suggest-links.test.ts
+++ b/src/renderer/shared/__tests__/suggest-links.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { suggestLinks } from '../suggest-links';
-import type { LinkIndexEntry } from '../../../types/global';
+import type { EntityIndexEntry } from '../../../types/global';
 
-const idx: LinkIndexEntry[] = [
+const idx: EntityIndexEntry[] = [
   { id: 'a1', path: 'notes/Lore/bob.md', title: 'Bob the Brave', type: 'note' },
   { id: 'a2', path: 'notes/Lore/places.md', title: 'Places', type: 'note' },
   { id: 'e1', path: 'timeline/sess-01.md', title: 'Session 1', type: 'event' },

--- a/src/renderer/shared/suggest-links.ts
+++ b/src/renderer/shared/suggest-links.ts
@@ -1,12 +1,12 @@
-import type { LinkIndexEntry } from '../../types/global';
+import type { EntityIndexEntry } from '../../types/global';
 import type { WikiLinkSuggestion } from './markdown-editor';
 
 export function suggestLinks(
-  linkIndex: readonly LinkIndexEntry[],
+  entityIndex: readonly EntityIndexEntry[],
   query: string,
 ): WikiLinkSuggestion[] {
   const q = query.toLowerCase();
-  return linkIndex
+  return entityIndex
     .filter((e) => e.title.toLowerCase().includes(q) || e.id.toLowerCase().includes(q))
     .map((e) =>
       e.type === 'asset'

--- a/src/renderer/timeline/event-editor/EventEditorModal.tsx
+++ b/src/renderer/timeline/event-editor/EventEditorModal.tsx
@@ -53,23 +53,23 @@ export function EventEditorModal({
   const [saveState, setSaveState] = useState<SaveState>('clean');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [conflictPending, setConflictPending] = useState<ConflictPending | null>(null);
-  const [linkIndex, setLinkIndex] = useState<Awaited<ReturnType<typeof notesData.getLinkIndex>>>(
+  const [entityIndex, setEntityIndex] = useState<Awaited<ReturnType<typeof notesData.getEntityIndex>>>(
     [],
   );
 
   useEffect(() => {
     notesData
-      .getLinkIndex(campaignPath)
-      .then(setLinkIndex)
+      .getEntityIndex(campaignPath)
+      .then(setEntityIndex)
       .catch(() => {});
   }, [campaignPath]);
 
   const suggestLinksForIndex = useCallback(
-    (query: string) => suggestLinks(linkIndex, query),
-    [linkIndex],
+    (query: string) => suggestLinks(entityIndex, query),
+    [entityIndex],
   );
 
-  const knownIds = useMemo(() => new Set(linkIndex.map((e) => e.id)), [linkIndex]);
+  const knownIds = useMemo(() => new Set(entityIndex.map((e) => e.id)), [entityIndex]);
 
   // Refs for stable access inside async callbacks without needing deps
   const lastModifiedRef = useRef<string | null>(null);

--- a/src/renderer/timeline/event-editor/EventEditorModal.tsx
+++ b/src/renderer/timeline/event-editor/EventEditorModal.tsx
@@ -53,9 +53,9 @@ export function EventEditorModal({
   const [saveState, setSaveState] = useState<SaveState>('clean');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [conflictPending, setConflictPending] = useState<ConflictPending | null>(null);
-  const [entityIndex, setEntityIndex] = useState<Awaited<ReturnType<typeof notesData.getEntityIndex>>>(
-    [],
-  );
+  const [entityIndex, setEntityIndex] = useState<
+    Awaited<ReturnType<typeof notesData.getEntityIndex>>
+  >([]);
 
   useEffect(() => {
     notesData

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -18,15 +18,15 @@ export interface Campaign {
   path: string;
 }
 
-export interface LinkIndexEntry {
+export interface EntityIndexEntry {
   id: string;
   path: string;
   title: string;
   type: 'note' | 'event' | 'asset';
 }
 
-export type IndexDeltaEvent =
-  | { op: 'add' | 'update'; entry: LinkIndexEntry }
+export type EntityIndexDelta =
+  | { op: 'add' | 'update'; entry: EntityIndexEntry }
   | { op: 'remove'; path: string };
 
 declare global {
@@ -55,12 +55,12 @@ declare global {
       rename: (oldPath: string, newPath: string) => Promise<boolean>;
 
       // Notes
-      buildIndex: (campaignPath: string) => Promise<LinkIndexEntry[]>;
+      buildIndex: (campaignPath: string) => Promise<EntityIndexEntry[]>;
       ensureDirs: (notesDir: string) => Promise<boolean>;
 
       // Watcher
       onFileChange: (callback: (data: { event: string; path: string }) => void) => () => void;
-      onIndexDelta: (callback: (delta: IndexDeltaEvent) => void) => () => void;
+      onEntityDelta: (callback: (delta: EntityIndexDelta) => void) => () => void;
 
       // Dialog
       selectDirectory: () => Promise<string | null>;


### PR DESCRIPTION
## 📝 Description

**Issue(s):** #148

Mechanical rename of the "link index" concept to "entity index" across the codebase, preparing the foundation for entity memory (label management, overrides, entity tags). No functional changes.

---

## 🔍 Details

* **`src/main/linkIndex.ts` → `src/main/entity-index.ts`:** Renamed file; `LinkIndexEntry` → `EntityIndexEntry`, `buildLinkIndex` → `buildEntityIndex`, `indexSingleFile` → `indexSingleEntity`.
* **`src/types/global.d.ts`:** `LinkIndexEntry` → `EntityIndexEntry`, `IndexDeltaEvent` → `EntityIndexDelta`, `onIndexDelta` → `onEntityDelta` in the `WindowApi` type.
* **`src/main/ipcHandlers.ts`:** Updated import and IPC channel name `notes:buildIndex` → `entity:buildIndex`.
* **`src/main/fileWatcher.ts`:** Updated import and IPC channel name `notes:indexDelta` → `entity:indexDelta`.
* **`src/preload/index.cts`:** `onIndexDelta` → `onEntityDelta`; IPC channel strings updated to match.
* **Renderer files** (`app.tsx`, `search-overlay.tsx`, `notes.tsx`, `data.ts`, `scan-folder.ts`, `useNotesController.ts`, `EventEditorModal.tsx`, `suggest-links.ts`, `link-resolution.ts`, `resolve.ts`, `stack.ts`): All `linkIndex` variables, `LinkIndexEntry` type references, and `getLinkIndex` / `getEntityIndex` method names updated.
* **Test files** (6 files): All type annotations and variable names updated to match.

---

## 🧪 Manual Test Cases

### 🚀 New Behavior
- [x] Open a campaign; notes and events appear in the editor's wiki-link autocomplete (entity index builds correctly via `entity:buildIndex`)
- [x] Edit or create a note/event; the index updates live (delta events arrive via `entity:indexDelta`)

### 🛡️ Regression Checks
- [x] Peek (hover preview) on wiki-links still resolves and opens correctly
- [x] Search overlay (Ctrl+F) returns notes and events as before
- [x] Event editor modal wiki-link suggestions still work

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pf9pa2CzUjf341ZGok1ANc)_