### PR TITLE
Add label override fields to EntityIndexEntry

### DIFF
--- a/src/main/entity-index.ts
+++ b/src/main/entity-index.ts
@@ -10,6 +10,8 @@ export interface EntityIndexEntry {
   path: string; // Campaign-relative path (using forward slashes)
   title: string;
   type: 'note' | 'event' | 'asset';
+  tagLabelOverride?: string;
+  linkLabelOverride?: string;
 }
 
 export function buildEntityIndex(campaignPath: string): EntityIndexEntry[] {
@@ -48,7 +50,17 @@ export function indexSingleEntity(fullPath: string, campaignPath: string): Entit
         fs.writeFileSync(fullPath, stringifyNote(body, frontmatter), 'utf-8');
       }
       const type: 'note' | 'event' = isNote ? 'note' : 'event';
-      return { id: frontmatter.id, path: rel, title: frontmatter.title, type };
+      const entry: EntityIndexEntry = {
+        id: frontmatter.id,
+        path: rel,
+        title: frontmatter.title,
+        type,
+      };
+      if (typeof frontmatter.tagLabelOverride === 'string')
+        entry.tagLabelOverride = frontmatter.tagLabelOverride;
+      if (typeof frontmatter.linkLabelOverride === 'string')
+        entry.linkLabelOverride = frontmatter.linkLabelOverride;
+      return entry;
     } catch {
       return null;
     }
@@ -86,7 +98,17 @@ function scanDir(
         if (needsWrite) {
           fs.writeFileSync(fullPath, stringifyNote(body, frontmatter), 'utf-8');
         }
-        index.push({ id: frontmatter.id, path: prefix + relPath, title: frontmatter.title, type });
+        const indexEntry: EntityIndexEntry = {
+          id: frontmatter.id,
+          path: prefix + relPath,
+          title: frontmatter.title,
+          type,
+        };
+        if (typeof frontmatter.tagLabelOverride === 'string')
+          indexEntry.tagLabelOverride = frontmatter.tagLabelOverride;
+        if (typeof frontmatter.linkLabelOverride === 'string')
+          indexEntry.linkLabelOverride = frontmatter.linkLabelOverride;
+        index.push(indexEntry);
       } else if (type === 'note' && ASSET_EXTENSIONS.has(ext)) {
         const title = path.basename(entry.name, ext);
         index.push({ id: '', path: prefix + relPath, title, type: 'asset' });

--- a/src/shared/__tests__/entity-labels.test.ts
+++ b/src/shared/__tests__/entity-labels.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { effectiveTagLabel, effectiveLinkLabel } from '../entity-labels';
+import type { EntityIndexEntry } from '../../types/global';
+
+function makeEntry(overrides: Partial<EntityIndexEntry> = {}): EntityIndexEntry {
+  return { id: 'abc1', path: 'notes/foo.md', title: 'Default Title', type: 'note', ...overrides };
+}
+
+describe('effectiveTagLabel', () => {
+  it('returns title when no tagLabelOverride', () => {
+    expect(effectiveTagLabel(makeEntry())).toBe('Default Title');
+  });
+
+  it('returns tagLabelOverride when present', () => {
+    expect(effectiveTagLabel(makeEntry({ tagLabelOverride: 'Custom Tag' }))).toBe('Custom Tag');
+  });
+
+  it('returns title when tagLabelOverride is undefined', () => {
+    expect(effectiveTagLabel(makeEntry({ tagLabelOverride: undefined }))).toBe('Default Title');
+  });
+
+  it('ignores linkLabelOverride', () => {
+    expect(effectiveTagLabel(makeEntry({ linkLabelOverride: 'Link Label' }))).toBe('Default Title');
+  });
+});
+
+describe('effectiveLinkLabel', () => {
+  it('returns title when no linkLabelOverride', () => {
+    expect(effectiveLinkLabel(makeEntry())).toBe('Default Title');
+  });
+
+  it('returns linkLabelOverride when present', () => {
+    expect(effectiveLinkLabel(makeEntry({ linkLabelOverride: 'Custom Link' }))).toBe('Custom Link');
+  });
+
+  it('returns title when linkLabelOverride is undefined', () => {
+    expect(effectiveLinkLabel(makeEntry({ linkLabelOverride: undefined }))).toBe('Default Title');
+  });
+
+  it('ignores tagLabelOverride', () => {
+    expect(effectiveLinkLabel(makeEntry({ tagLabelOverride: 'Tag Label' }))).toBe('Default Title');
+  });
+});

--- a/src/shared/entity-labels.ts
+++ b/src/shared/entity-labels.ts
@@ -1,0 +1,9 @@
+import type { EntityIndexEntry } from '../types/global';
+
+export function effectiveTagLabel(entry: EntityIndexEntry): string {
+  return entry.tagLabelOverride ?? entry.title;
+}
+
+export function effectiveLinkLabel(entry: EntityIndexEntry): string {
+  return entry.linkLabelOverride ?? entry.title;
+}

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -23,6 +23,8 @@ export interface EntityIndexEntry {
   path: string;
   title: string;
   type: 'note' | 'event' | 'asset';
+  tagLabelOverride?: string;
+  linkLabelOverride?: string;
 }
 
 export type EntityIndexDelta =


### PR DESCRIPTION
## 📝 Description

**Issue(s):** #149

Extends `EntityIndexEntry` with optional `tagLabelOverride` and `linkLabelOverride` fields sourced from file frontmatter, and adds pure helper functions to resolve the effective label for tag and link display contexts.

---

## 🔍 Details

* **`src/types/global.d.ts`:** Added optional `tagLabelOverride?: string` and `linkLabelOverride?: string` fields to the shared `EntityIndexEntry` interface.
* **`src/main/entity-index.ts`:** Same fields added to the main-process `EntityIndexEntry` interface. `scanDir` and `indexSingleEntity` now read these from file frontmatter when present (guarded with `typeof === 'string'` since frontmatter values are `unknown`). Renamed shadowing `entry` variable in `scanDir` to `indexEntry` for clarity.
* **`src/shared/entity-labels.ts` (new):** Pure helper functions `effectiveTagLabel` and `effectiveLinkLabel` — return the respective override if present, otherwise fall back to `title`.
* **`src/shared/__tests__/entity-labels.test.ts` (new):** 8 unit tests covering override-present, override-absent, explicit-undefined, and cross-field isolation for both helpers.

---

## 🧪 Manual Test Cases

There is no manual testing possible for this PR. The index is internal and not exposed in any UI, and there is no UI for setting frontmatter override fields. All behaviour is covered by unit tests.

End-to-end verification is deferred to the ticket that first consumes these fields in the UI.