### PR TITLE
Add entity tag parse/validate/format utilities (#158)

### DIFF
--- a/src/shared/__tests__/entity-tags.test.ts
+++ b/src/shared/__tests__/entity-tags.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  isEntityTag,
-  parseEntityTag,
-  formatEntityTag,
-  isValidCustomTag,
-} from '../entity-tags';
+import { isEntityTag, parseEntityTag, formatEntityTag, isValidCustomTag } from '../entity-tags';
 
 describe('isEntityTag', () => {
   it('returns true for valid entity tags', () => {

--- a/src/shared/__tests__/entity-tags.test.ts
+++ b/src/shared/__tests__/entity-tags.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isEntityTag,
+  parseEntityTag,
+  formatEntityTag,
+  isValidCustomTag,
+} from '../entity-tags';
+
+describe('isEntityTag', () => {
+  it('returns true for valid entity tags', () => {
+    expect(isEntityTag('id:ab12')).toBe(true);
+    expect(isEntityTag('id:0000')).toBe(true);
+    expect(isEntityTag('id:zzzz')).toBe(true);
+    expect(isEntityTag('id:a1b2')).toBe(true);
+  });
+
+  it('returns false when prefix is wrong', () => {
+    expect(isEntityTag('ID:ab12')).toBe(false);
+    expect(isEntityTag('Id:ab12')).toBe(false);
+    expect(isEntityTag('ab12')).toBe(false);
+    expect(isEntityTag(':ab12')).toBe(false);
+  });
+
+  it('returns false when ID length is not exactly 4', () => {
+    expect(isEntityTag('id:abc')).toBe(false);
+    expect(isEntityTag('id:abcde')).toBe(false);
+    expect(isEntityTag('id:')).toBe(false);
+  });
+
+  it('returns false when ID contains invalid characters', () => {
+    expect(isEntityTag('id:AB12')).toBe(false);
+    expect(isEntityTag('id:ab-2')).toBe(false);
+    expect(isEntityTag('id:ab 2')).toBe(false);
+    expect(isEntityTag('id:ab_2')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isEntityTag('')).toBe(false);
+  });
+});
+
+describe('parseEntityTag', () => {
+  it('returns the 4-character ID from a valid entity tag', () => {
+    expect(parseEntityTag('id:ab12')).toBe('ab12');
+    expect(parseEntityTag('id:0000')).toBe('0000');
+    expect(parseEntityTag('id:zzzz')).toBe('zzzz');
+  });
+
+  it('returns null for invalid entity tags', () => {
+    expect(parseEntityTag('ab12')).toBeNull();
+    expect(parseEntityTag('id:abc')).toBeNull();
+    expect(parseEntityTag('id:ABCD')).toBeNull();
+    expect(parseEntityTag('')).toBeNull();
+  });
+});
+
+describe('formatEntityTag', () => {
+  it('prefixes the ID with id:', () => {
+    expect(formatEntityTag('ab12')).toBe('id:ab12');
+    expect(formatEntityTag('0000')).toBe('id:0000');
+  });
+});
+
+describe('isValidCustomTag', () => {
+  it('returns true for normal custom tags', () => {
+    expect(isValidCustomTag('combat')).toBe(true);
+    expect(isValidCustomTag('session-1')).toBe(true);
+    expect(isValidCustomTag('npc')).toBe(true);
+  });
+
+  it('returns false for tags that match entity tag format', () => {
+    expect(isValidCustomTag('id:ab12')).toBe(false);
+    expect(isValidCustomTag('id:0000')).toBe(false);
+  });
+
+  it('returns true for near-misses that do not match entity tag format', () => {
+    expect(isValidCustomTag('id:abc')).toBe(true);
+    expect(isValidCustomTag('id:ABCD')).toBe(true);
+    expect(isValidCustomTag('id:')).toBe(true);
+  });
+});

--- a/src/shared/entity-tags.ts
+++ b/src/shared/entity-tags.ts
@@ -1,0 +1,17 @@
+const ENTITY_TAG_RE = /^id:[a-z0-9]{4}$/;
+
+export function isEntityTag(tag: string): boolean {
+  return ENTITY_TAG_RE.test(tag);
+}
+
+export function parseEntityTag(tag: string): string | null {
+  return ENTITY_TAG_RE.test(tag) ? tag.slice(3) : null;
+}
+
+export function formatEntityTag(id: string): string {
+  return `id:${id}`;
+}
+
+export function isValidCustomTag(tag: string): boolean {
+  return !isEntityTag(tag);
+}


### PR DESCRIPTION
## 📝 Description

**Issue(s):** #158

Adds pure utility functions for the `id:XXXX` entity tag format used by the auto-tagging system, plus a guard that prevents custom tags from colliding with that format.

---

## 🔍 Details

* **`src/shared/entity-tags.ts`:** New module with `isEntityTag`, `parseEntityTag`, `formatEntityTag`, and `isValidCustomTag`. All functions are pure (no IO, no React) and operate on the `id:[a-z0-9]{4}` format defined by `ids.ts`.
* **`src/shared/__tests__/entity-tags.test.ts`:** Unit tests covering valid tags, invalid prefix/length/character edge cases, null returns from `parseEntityTag`, and the guard behaviour of `isValidCustomTag`.

---

## 🧪 Manual Test Cases

### 🚀 New Behavior
- [ ] `isEntityTag('id:ab12')` returns `true`; `isEntityTag('id:AB12')` returns `false`
- [ ] `parseEntityTag('id:ab12')` returns `'ab12'`; `parseEntityTag('npc')` returns `null`
- [ ] `formatEntityTag('ab12')` returns `'id:ab12'`
- [ ] `isValidCustomTag('combat')` returns `true`; `isValidCustomTag('id:ab12')` returns `false`

### 🛡️ Regression Checks
- [ ] Full test suite (`npm test`) still passes — 1037 tests across 65 files

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ut25PzgzRPbbdFH7SGWbt)_