### PR TITLE
IPC handler for label override updates (#150)

### DIFF
--- a/src/main/campaign-state.ts
+++ b/src/main/campaign-state.ts
@@ -1,0 +1,9 @@
+let _campaignPath: string | null = null;
+
+export function getCampaignPath(): string | null {
+  return _campaignPath;
+}
+
+export function setCampaignPath(p: string | null): void {
+  _campaignPath = p;
+}

--- a/src/main/entity-index-handlers.ts
+++ b/src/main/entity-index-handlers.ts
@@ -1,8 +1,8 @@
-import { ipcMain, BrowserWindow } from 'electron';
+import { ipcMain } from 'electron';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { getCampaignPath } from './campaign-state.js';
-import { buildEntityIndex, findEntityById, indexSingleEntity } from './entity-index.js';
+import { buildEntityIndex, findEntityById } from './entity-index.js';
 import { parseNote, stringifyNote } from '../shared/frontmatter.js';
 
 export function registerEntityIndexHandlers() {
@@ -19,12 +19,7 @@ export function registerEntityIndexHandlers() {
 
   ipcMain.handle(
     'entity:updateLabelOverride',
-    async (
-      _event,
-      id: string,
-      target: 'tagLabel' | 'linkLabel',
-      value: string | null,
-    ) => {
+    async (_event, id: string, target: 'tagLabel' | 'linkLabel', value: string | null) => {
       const campaignPath = getCampaignPath();
       if (!campaignPath) return false;
 
@@ -44,12 +39,7 @@ export function registerEntityIndexHandlers() {
         }
 
         fs.writeFileSync(fullPath, stringifyNote(body, frontmatter), 'utf-8');
-
-        const updatedEntry = indexSingleEntity(fullPath, campaignPath);
-        if (updatedEntry) {
-          const win = BrowserWindow.getAllWindows()[0];
-          win?.webContents.send('entity:indexDelta', { op: 'update', entry: updatedEntry });
-        }
+        // File watcher picks up the write and emits entity:indexDelta, same as all other writes.
 
         return true;
       } catch (error) {

--- a/src/main/entity-index-handlers.ts
+++ b/src/main/entity-index-handlers.ts
@@ -1,0 +1,61 @@
+import { ipcMain, BrowserWindow } from 'electron';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { getCampaignPath } from './campaign-state.js';
+import { buildEntityIndex, findEntityById, indexSingleEntity } from './entity-index.js';
+import { parseNote, stringifyNote } from '../shared/frontmatter.js';
+
+export function registerEntityIndexHandlers() {
+  ipcMain.handle('entity:getAll', async () => {
+    const campaignPath = getCampaignPath();
+    if (!campaignPath) return [];
+    try {
+      return buildEntityIndex(campaignPath);
+    } catch (error) {
+      console.error('Failed to get entity index:', error);
+      return [];
+    }
+  });
+
+  ipcMain.handle(
+    'entity:updateLabelOverride',
+    async (
+      _event,
+      id: string,
+      target: 'tagLabel' | 'linkLabel',
+      value: string | null,
+    ) => {
+      const campaignPath = getCampaignPath();
+      if (!campaignPath) return false;
+
+      try {
+        const fullPath = findEntityById(id, campaignPath);
+        if (!fullPath) return false;
+
+        const content = fs.readFileSync(fullPath, 'utf-8');
+        const fallbackTitle = path.basename(fullPath, '.md');
+        const { frontmatter, body } = parseNote(content, fallbackTitle);
+
+        const key = target === 'tagLabel' ? 'tagLabelOverride' : 'linkLabelOverride';
+        if (value === null) {
+          delete frontmatter[key];
+        } else {
+          frontmatter[key] = value;
+        }
+
+        fs.writeFileSync(fullPath, stringifyNote(body, frontmatter), 'utf-8');
+
+        const updatedEntry = indexSingleEntity(fullPath, campaignPath);
+        if (updatedEntry) {
+          const win = BrowserWindow.getAllWindows()[0];
+          win?.webContents.send('entity:indexDelta', { op: 'update', entry: updatedEntry });
+        }
+
+        return true;
+      } catch (error) {
+        console.error('Failed to update label override:', error);
+        return false;
+      }
+    },
+  );
+}

--- a/src/main/entity-index.ts
+++ b/src/main/entity-index.ts
@@ -14,6 +14,36 @@ export interface EntityIndexEntry {
   linkLabelOverride?: string;
 }
 
+export function findEntityById(id: string, campaignPath: string): string | null {
+  for (const subdir of ['notes', 'timeline']) {
+    const result = findMdById(id, path.join(campaignPath, subdir));
+    if (result) return result;
+  }
+  return null;
+}
+
+function findMdById(id: string, dir: string): string | null {
+  if (!fs.existsSync(dir)) return null;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const result = findMdById(id, fullPath);
+      if (result) return result;
+    } else if (entry.isFile() && path.extname(entry.name).toLowerCase() === '.md') {
+      try {
+        const content = fs.readFileSync(fullPath, 'utf-8');
+        const fallbackTitle = path.basename(fullPath, '.md');
+        const { frontmatter } = parseNote(content, fallbackTitle);
+        if (frontmatter.id === id) return fullPath;
+      } catch {
+        // skip unreadable files
+      }
+    }
+  }
+  return null;
+}
+
 export function buildEntityIndex(campaignPath: string): EntityIndexEntry[] {
   const index: EntityIndexEntry[] = [];
   const notesDir = path.join(campaignPath, 'notes');

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,6 +6,7 @@ const { autoUpdater } = pkg;
 import { windowManager } from './windowManager.js';
 import { registerIpcHandlers } from './ipcHandlers.js';
 import { FileWatcher } from './fileWatcher.js';
+import { getCampaignPath, setCampaignPath } from './campaign-state.js';
 
 protocol.registerSchemesAsPrivileged([
   {
@@ -20,20 +21,18 @@ protocol.registerSchemesAsPrivileged([
   },
 ]);
 
-let currentCampaignPath: string | null = null;
-
 const fileWatcher = new FileWatcher();
 registerIpcHandlers();
 
 app.whenReady().then(() => {
   // URL shape: notes-asset://current/notes/<folder>/assets/<file>
   protocol.handle('notes-asset', (request) => {
-    if (!currentCampaignPath) {
+    if (!getCampaignPath()) {
       return new Response('No campaign open', { status: 404 });
     }
     const url = new URL(request.url);
     const relPath = decodeURIComponent(url.pathname.slice(1)); // strip leading /
-    const campaignBase = path.resolve(currentCampaignPath);
+    const campaignBase = path.resolve(getCampaignPath()!);
     const resolved = path.resolve(campaignBase, relPath);
     if (!resolved.startsWith(campaignBase + path.sep)) {
       return new Response('Forbidden', { status: 403 });
@@ -44,13 +43,13 @@ app.whenReady().then(() => {
   const mainWindow = windowManager.createMainWindow();
 
   ipcMain.handle('campaign:open', async (event, campaignPath: string) => {
-    currentCampaignPath = path.resolve(campaignPath);
+    setCampaignPath(path.resolve(campaignPath));
     await fileWatcher.start(campaignPath, mainWindow);
     return true;
   });
 
   ipcMain.handle('campaign:close', async () => {
-    currentCampaignPath = null;
+    setCampaignPath(null);
     fileWatcher.stop();
     return true;
   });

--- a/src/main/ipcHandlers.ts
+++ b/src/main/ipcHandlers.ts
@@ -6,6 +6,7 @@ import pkg from 'electron-updater';
 import { generateShortId } from '../shared/ids.js';
 import { buildEntityIndex } from './entity-index.js';
 import { registerTimelineIpcHandlers } from './timelineIpcHandlers.js';
+import { registerEntityIndexHandlers } from './entity-index-handlers.js';
 
 const { autoUpdater } = pkg;
 
@@ -280,6 +281,7 @@ ${description}
   });
 
   registerTimelineIpcHandlers();
+  registerEntityIndexHandlers();
 
   ipcMain.handle('app:getVersion', () => app.getVersion());
   ipcMain.handle('app:installUpdate', async () => {

--- a/src/preload/index.cts
+++ b/src/preload/index.cts
@@ -26,6 +26,9 @@ contextBridge.exposeInMainWorld('fsApi', {
   // Notes
   buildIndex: (campaignPath: string) => ipcRenderer.invoke('entity:buildIndex', campaignPath),
   ensureDirs: (notesDir: string) => ipcRenderer.invoke('notes:ensureDirs', notesDir),
+  getEntityIndex: () => ipcRenderer.invoke('entity:getAll'),
+  updateEntityLabelOverride: (id: string, target: 'tagLabel' | 'linkLabel', value: string | null) =>
+    ipcRenderer.invoke('entity:updateLabelOverride', id, target, value),
 
   // Watcher
   onFileChange: (callback: (data: { event: string; path: string }) => void) => {

--- a/src/renderer/shared/entity-index.ts
+++ b/src/renderer/shared/entity-index.ts
@@ -1,0 +1,15 @@
+import type { EntityIndexEntry } from '../../types/global';
+
+export const entityIndex = {
+  getAll(): Promise<EntityIndexEntry[]> {
+    return window.fsApi.getEntityIndex();
+  },
+
+  updateLabelOverride(
+    id: string,
+    target: 'tagLabel' | 'linkLabel',
+    value: string | null,
+  ): Promise<boolean> {
+    return window.fsApi.updateEntityLabelOverride(id, target, value);
+  },
+};

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -59,6 +59,12 @@ declare global {
       // Notes
       buildIndex: (campaignPath: string) => Promise<EntityIndexEntry[]>;
       ensureDirs: (notesDir: string) => Promise<boolean>;
+      getEntityIndex: () => Promise<EntityIndexEntry[]>;
+      updateEntityLabelOverride: (
+        id: string,
+        target: 'tagLabel' | 'linkLabel',
+        value: string | null,
+      ) => Promise<boolean>;
 
       // Watcher
       onFileChange: (callback: (data: { event: string; path: string }) => void) => () => void;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `entity:updateLabelOverride(id, target, value)` IPC handler — finds entity file by ID, sets or removes `tagLabelOverride` / `linkLabelOverride` in frontmatter, writes to disk; the file watcher emits the `entity:indexDelta` update to the renderer (consistent with all other file-writing handlers)
- Adds `entity:getAll()` IPC handler — returns the full entity index for the current campaign without the renderer needing to pass the path
- Extracts `currentCampaignPath` from `index.ts` into a shared `campaign-state.ts` singleton so both `index.ts` and the new handlers can read/write it without circular imports
- Adds `findEntityById` to `entity-index.ts` — an efficient targeted scan that stops at first match, without the write-back side effects of `buildEntityIndex`
- Exposes both new handlers via the preload bridge (`window.fsApi.updateEntityLabelOverride`, `window.fsApi.getEntityIndex`) with matching type declarations in `global.d.ts`
- Adds `src/renderer/shared/entity-index.ts` as the renderer-side IO port wrapping the IPC calls

## Test plan

- [ ] Open a campaign, verify `entity:getAll` returns the full entity index in devtools
- [ ] Call `updateEntityLabelOverride(id, 'tagLabel', 'Custom Label')` — confirm frontmatter gains `tagLabelOverride: Custom Label` and the file watcher emits an `entity:indexDelta` update
- [ ] Call `updateEntityLabelOverride(id, 'tagLabel', null)` — confirm `tagLabelOverride` is removed from frontmatter and another delta is emitted
- [ ] Repeat for `linkLabel` / `linkLabelOverride`
- [ ] Call with an unknown ID — confirm handler returns `false` without writing any file

Closes #150

https://claude.ai/code/session_01QssvmRKay4Gr2RJeMiGdDa
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QssvmRKay4Gr2RJeMiGdDa)_