### PR TITLE
Add CampaignLoader framework for campaign load progress (#152)

### DIFF
--- a/src/main/__tests__/campaign-loader.test.ts
+++ b/src/main/__tests__/campaign-loader.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CampaignLoader } from '../campaign-loader.js';
+import type { NamedTask } from '../campaign-loader.js';
+
+function makeWebContents() {
+  return { send: vi.fn() };
+}
+
+describe('CampaignLoader', () => {
+  it('sends loadComplete after all tasks finish', async () => {
+    const wc = makeWebContents();
+    const loader = new CampaignLoader([{ name: 'task-a', task: async () => {} }]);
+
+    await loader.run(wc as never);
+
+    expect(wc.send).toHaveBeenCalledWith('campaign:loadComplete');
+  });
+
+  it('sends loadProgress with correct percentage for a single task', async () => {
+    const wc = makeWebContents();
+    const task: NamedTask = {
+      name: 'index',
+      task: async (onProgress) => {
+        onProgress(1, 4);
+        onProgress(4, 4);
+      },
+    };
+
+    await loader(wc, [task]);
+
+    const progressCalls = wc.send.mock.calls.filter(([ch]) => ch === 'campaign:loadProgress');
+    expect(progressCalls[0]).toEqual([
+      'campaign:loadProgress',
+      { percentage: 25, taskName: 'index' },
+    ]);
+    expect(progressCalls[1]).toEqual([
+      'campaign:loadProgress',
+      { percentage: 100, taskName: 'index' },
+    ]);
+  });
+
+  it('aggregates progress across multiple tasks', async () => {
+    const wc = makeWebContents();
+
+    const taskA: NamedTask = {
+      name: 'a',
+      task: async (onProgress) => {
+        onProgress(2, 4);
+      },
+    };
+    const taskB: NamedTask = {
+      name: 'b',
+      task: async () => {},
+    };
+
+    await loader(wc, [taskA, taskB]);
+
+    // After task A: 2/4 = 50%. Task B resolved without progress (0/0 doesn't add).
+    const progressCalls = wc.send.mock.calls.filter(([ch]) => ch === 'campaign:loadProgress');
+    expect(progressCalls[0]).toEqual(['campaign:loadProgress', { percentage: 50, taskName: 'a' }]);
+  });
+
+  it('correctly aggregates when both tasks report progress', async () => {
+    const wc = makeWebContents();
+    const snapshots: Array<{ percentage: number; taskName: string }> = [];
+    wc.send.mockImplementation((channel: string, data: unknown) => {
+      if (channel === 'campaign:loadProgress') {
+        snapshots.push(data as { percentage: number; taskName: string });
+      }
+    });
+
+    const taskA: NamedTask = {
+      name: 'a',
+      task: async (onProgress) => {
+        onProgress(1, 2);
+        onProgress(2, 2);
+      },
+    };
+    const taskB: NamedTask = {
+      name: 'b',
+      task: async (onProgress) => {
+        onProgress(1, 2);
+        onProgress(2, 2);
+      },
+    };
+
+    await new CampaignLoader([taskA, taskB]).run(wc as never);
+
+    // After taskA runs: 1/2=50%, 2/2=100%
+    // After taskB starts: taskA still 2/2; taskB 1/2 → 3/4=75%, then 4/4=100%
+    expect(snapshots.map((s) => s.percentage)).toEqual([50, 100, 75, 100]);
+  });
+
+  it('sends percentage 0 when total is 0', async () => {
+    const wc = makeWebContents();
+    const task: NamedTask = {
+      name: 'empty',
+      task: async (onProgress) => {
+        onProgress(0, 0);
+      },
+    };
+
+    await new CampaignLoader([task]).run(wc as never);
+
+    const progressCalls = wc.send.mock.calls.filter(([ch]) => ch === 'campaign:loadProgress');
+    expect(progressCalls[0][1].percentage).toBe(0);
+  });
+
+  it('runs tasks sequentially, not concurrently', async () => {
+    const wc = makeWebContents();
+    const order: string[] = [];
+
+    const tasks: NamedTask[] = ['first', 'second', 'third'].map((name) => ({
+      name,
+      task: async () => {
+        order.push(`start:${name}`);
+        await Promise.resolve();
+        order.push(`end:${name}`);
+      },
+    }));
+
+    await new CampaignLoader(tasks).run(wc as never);
+
+    expect(order).toEqual([
+      'start:first',
+      'end:first',
+      'start:second',
+      'end:second',
+      'start:third',
+      'end:third',
+    ]);
+  });
+});
+
+function loader(wc: ReturnType<typeof makeWebContents>, tasks: NamedTask[]): Promise<void> {
+  return new CampaignLoader(tasks).run(wc as never);
+}

--- a/src/main/campaign-loader.ts
+++ b/src/main/campaign-loader.ts
@@ -1,0 +1,33 @@
+import type { WebContents } from 'electron';
+
+export type LoadingTask = (onProgress: (completed: number, total: number) => void) => Promise<void>;
+
+export interface NamedTask {
+  name: string;
+  task: LoadingTask;
+}
+
+export class CampaignLoader {
+  constructor(private readonly tasks: NamedTask[]) {}
+
+  async run(webContents: WebContents): Promise<void> {
+    const progress = this.tasks.map(() => ({ completed: 0, total: 0 }));
+
+    const sendProgress = (taskName: string) => {
+      const totalCompleted = progress.reduce((sum, p) => sum + p.completed, 0);
+      const totalCount = progress.reduce((sum, p) => sum + p.total, 0);
+      const percentage = totalCount > 0 ? Math.round((totalCompleted / totalCount) * 100) : 0;
+      webContents.send('campaign:loadProgress', { percentage, taskName });
+    };
+
+    for (let i = 0; i < this.tasks.length; i++) {
+      const { name, task } = this.tasks[i];
+      await task((completed, total) => {
+        progress[i] = { completed, total };
+        sendProgress(name);
+      });
+    }
+
+    webContents.send('campaign:loadComplete');
+  }
+}

--- a/src/preload/index.cts
+++ b/src/preload/index.cts
@@ -97,4 +97,18 @@ contextBridge.exposeInMainWorld('fsApi', {
     ipcRenderer.on('app:updateDownloaded', listener);
     return () => ipcRenderer.removeListener('app:updateDownloaded', listener);
   },
+
+  // Campaign Loading
+  onLoadProgress: (callback: (data: { percentage: number; taskName: string }) => void) => {
+    const listener = (_event: unknown, data: { percentage: number; taskName: string }) =>
+      callback(data);
+    ipcRenderer.on('campaign:loadProgress', listener);
+    return () => ipcRenderer.removeListener('campaign:loadProgress', listener);
+  },
+
+  onLoadComplete: (callback: () => void) => {
+    const listener = () => callback();
+    ipcRenderer.on('campaign:loadComplete', listener);
+    return () => ipcRenderer.removeListener('campaign:loadComplete', listener);
+  },
 });

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -107,6 +107,12 @@ declare global {
         callback: (info: { version: string; releaseNotes: string }) => void,
       ) => () => void;
       onUpdateDownloaded: (callback: () => void) => () => void;
+
+      // Campaign Loading
+      onLoadProgress: (
+        callback: (data: { percentage: number; taskName: string }) => void,
+      ) => () => void;
+      onLoadComplete: (callback: () => void) => () => void;
     };
   }
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Introduces `LoadingTask` type and `CampaignLoader` class in `src/main/campaign-loader.ts`
- `CampaignLoader` accepts an array of named tasks, runs them sequentially, and aggregates progress as `sum(completed) / sum(total)` across all tasks
- Emits `campaign:loadProgress { percentage, taskName }` on each sub-task tick and `campaign:loadComplete` when all tasks finish
- Adds `onLoadProgress` / `onLoadComplete` preload listeners (with cleanup return) to `src/preload/index.cts`
- Adds corresponding type declarations to `src/types/global.d.ts`

## Test plan

- [ ] `npm test -- campaign-loader` — 6 tests covering single-task progress, multi-task aggregation, 0-total edge case, sequential ordering, and loadComplete
- [ ] `npm run lint` — clean
- [ ] `npm test` — all 1059 tests pass

Closes #152

https://claude.ai/code/session_01PJFf2zX32mXkjQ7aox4egR
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJFf2zX32mXkjQ7aox4egR)_