### PR TITLE
#163 Add Edit Tag Label and Edit Link Label to note sidebar context menu

### DIFF
--- a/src/renderer/notes/components/note-context-menu.tsx
+++ b/src/renderer/notes/components/note-context-menu.tsx
@@ -13,6 +13,8 @@ interface Props {
   onNewFolder(folder: string, subdir?: string): void;
   onRename(folder: string, path: string): void;
   onDelete(folder: string, path: string | undefined, kind: ContextMenuTarget['kind']): void;
+  onEditTagLabel?(folder: string, path: string): void;
+  onEditLinkLabel?(folder: string, path: string): void;
 }
 
 export function NoteContextMenu({
@@ -22,6 +24,8 @@ export function NoteContextMenu({
   onNewFolder,
   onRename,
   onDelete,
+  onEditTagLabel,
+  onEditLinkLabel,
 }: Props) {
   const { menuRef, pos } = useContextMenuBehavior(target.x, target.y, onClose);
 
@@ -76,6 +80,29 @@ export function NoteContextMenu({
       >
         {target.kind === 'topfolder' ? 'Delete Folder' : 'Delete'}
       </button>
+      {target.kind === 'file' && (
+        <>
+          <div className="context-menu-sep" />
+          <button
+            className="context-menu-item"
+            onClick={() => {
+              onEditTagLabel?.(target.folder, target.path);
+              onClose();
+            }}
+          >
+            Edit Tag Label
+          </button>
+          <button
+            className="context-menu-item"
+            onClick={() => {
+              onEditLinkLabel?.(target.folder, target.path);
+              onClose();
+            }}
+          >
+            Edit Link Label
+          </button>
+        </>
+      )}
     </div>
   );
 }

--- a/src/renderer/notes/domain/__tests__/link-resolution.test.ts
+++ b/src/renderer/notes/domain/__tests__/link-resolution.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveLinkById, resolveMarkdownHref } from '../link-resolution';
+import { resolveLinkById, resolveMarkdownHref, findEntityIdByNotePath } from '../link-resolution';
 import type { EntityIndexEntry } from '../../../../types/global';
 
 const idx: EntityIndexEntry[] = [
@@ -26,6 +26,20 @@ describe('resolveLinkById', () => {
       folder: 'Lore',
       path: 'bob.md',
     });
+  });
+});
+
+describe('findEntityIdByNotePath', () => {
+  it('returns the id when folder and path match', () => {
+    expect(findEntityIdByNotePath(idx, 'Lore', 'bob.md')).toBe('a1');
+  });
+
+  it('returns null when path does not match', () => {
+    expect(findEntityIdByNotePath(idx, 'Lore', 'nonexistent.md')).toBeNull();
+  });
+
+  it('returns null when folder does not match', () => {
+    expect(findEntityIdByNotePath(idx, 'WrongFolder', 'bob.md')).toBeNull();
   });
 });
 

--- a/src/renderer/notes/domain/link-resolution.ts
+++ b/src/renderer/notes/domain/link-resolution.ts
@@ -19,6 +19,14 @@ export function resolveLinkById(
   return { kind: 'note', folder: parts[1], path: parts.slice(2).join('/') };
 }
 
+export function findEntityIdByNotePath(
+  entityIndex: readonly EntityIndexEntry[],
+  folder: string,
+  path: string,
+): string | null {
+  return entityIndex.find((e) => e.path === `notes/${folder}/${path}`)?.id ?? null;
+}
+
 export function resolveMarkdownHref(
   entityIndex: readonly EntityIndexEntry[],
   rawUrl: string,

--- a/src/renderer/notes/hooks/useNotesController.ts
+++ b/src/renderer/notes/hooks/useNotesController.ts
@@ -3,7 +3,11 @@ import { notesData } from '../data';
 import { slugify } from '../domain/slugify';
 import { parseNotePath } from '../domain/open-note-by-path';
 import { suggestLinks as suggestLinksDomain } from '../../shared/suggest-links';
-import { resolveLinkById, resolveMarkdownHref } from '../domain/link-resolution';
+import {
+  resolveLinkById,
+  resolveMarkdownHref,
+  findEntityIdByNotePath,
+} from '../domain/link-resolution';
 import { scanFolderContents } from '../scan-folder';
 import {
   removeFileFromFolderFiles,
@@ -71,6 +75,10 @@ export function useNotesController({
   );
   const [newFolderMode, setNewFolderMode] = useState(false);
   const [contextMenu, setContextMenu] = useState<ContextMenuTarget | null>(null);
+  const [labelEditorTarget, setLabelEditorTarget] = useState<{
+    entityId: string;
+    target: 'tagLabel' | 'linkLabel';
+  } | null>(null);
   const [renamingKey, setRenamingKey] = useState<string | null>(null);
   const [dragTarget, setDragTarget] = useState<string | null>(null);
 
@@ -532,6 +540,15 @@ export function useNotesController({
     );
   }
 
+  function handleOpenLabelEditor(folder: string, path: string, target: 'tagLabel' | 'linkLabel') {
+    const entityId = findEntityIdByNotePath(entityIndex, folder, path);
+    if (!entityId) {
+      pushToast('Could not find entity for this note', true);
+      return;
+    }
+    setLabelEditorTarget({ entityId, target });
+  }
+
   function openMarkdownLink(rawUrl: string) {
     const match = resolveMarkdownHref(entityIndex, rawUrl);
     if (!match) {
@@ -591,6 +608,7 @@ export function useNotesController({
     creatingDirIn,
     newFolderMode,
     contextMenu,
+    labelEditorTarget,
     renamingKey,
     dragTarget,
     // UI state
@@ -611,6 +629,7 @@ export function useNotesController({
     setCreatingDirIn,
     setNewFolderMode,
     setContextMenu,
+    setLabelEditorTarget,
     setRenamingKey,
     setDragTarget,
     setOpenFolderPaths,
@@ -638,6 +657,7 @@ export function useNotesController({
     handleRenameFolder,
     handleMove,
     handleOpenLink,
+    handleOpenLabelEditor,
     openMarkdownLink,
     suggestLinks,
     handleQuickAddCreate,

--- a/src/renderer/notes/notes.tsx
+++ b/src/renderer/notes/notes.tsx
@@ -11,6 +11,7 @@ import {
 import { buildEntityLabelMap } from '../../shared/entity-labels';
 import { QuickAdd } from './components/quick-add.tsx';
 import { NoteContextMenu } from './components/note-context-menu.tsx';
+import { LabelOverrideEditor } from '../shared/components/label-override-editor';
 import { EditorTabs } from './components/editor-tabs.tsx';
 import { BreadcrumbNav } from './components/breadcrumb-nav.tsx';
 import { FolderSidebar } from './components/folder-sidebar.tsx';
@@ -323,6 +324,16 @@ export function NotesApp({
             if (kind === 'topfolder') ctrl.handleDeleteFolder(folder);
             else ctrl.handleDeleteFile(folder, path!);
           }}
+          onEditTagLabel={(folder, path) => ctrl.handleOpenLabelEditor(folder, path, 'tagLabel')}
+          onEditLinkLabel={(folder, path) => ctrl.handleOpenLabelEditor(folder, path, 'linkLabel')}
+        />
+      )}
+
+      {ctrl.labelEditorTarget && (
+        <LabelOverrideEditor
+          entityId={ctrl.labelEditorTarget.entityId}
+          target={ctrl.labelEditorTarget.target}
+          onClose={() => ctrl.setLabelEditorTarget(null)}
         />
       )}
     </>

--- a/src/renderer/shared/components/label-override-editor.tsx
+++ b/src/renderer/shared/components/label-override-editor.tsx
@@ -82,6 +82,9 @@ export function LabelOverrideEditor({ entityId, target, onClose }: Props) {
             className="label-editor-input"
             value={value}
             onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !saving) void handleSave();
+            }}
             placeholder={defaultLabel}
             autoFocus
           />


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds "Edit Tag Label" and "Edit Link Label" items to the note sidebar context menu, separated from file management actions by a divider
- Menu items only appear for note files (not folders or assets)
- Clicking either item opens the shared `LabelOverrideEditor` modal (built in #165)
- Entity lookup from file path (`notes/{folder}/{path}`) is a pure domain function in `link-resolution.ts`, covered by new unit tests

## Test plan

- [ ] Right-click a note file in the sidebar — "Edit Tag Label" and "Edit Link Label" appear below a separator after "Delete"
- [ ] Right-click a folder — label options do not appear
- [ ] Right-click a top-level folder — label options do not appear
- [ ] Clicking "Edit Tag Label" opens the label override editor with title "Edit Tag Label"
- [ ] Clicking "Edit Link Label" opens the label override editor with title "Edit Link Label"
- [ ] Right-clicking a note whose path is not in the entity index shows an error toast instead of crashing
- [ ] Unit tests pass: `npm test -- link-resolution`

https://claude.ai/code/session_0176Sje2Huwpsp9YoXtesEHf
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0176Sje2Huwpsp9YoXtesEHf)_