### PR TITLE
#161 Warn users when they manually type id:XXXX reserved entity tag format

### DIFF
--- a/src/renderer/timeline/event-editor/EventEditorModal.css
+++ b/src/renderer/timeline/event-editor/EventEditorModal.css
@@ -92,6 +92,13 @@
   flex-shrink: 0;
 }
 
+/* ===== Inline field warning ===== */
+
+.event-editor-field-warning {
+  font-size: 11px;
+  color: var(--theme-danger);
+}
+
 /* ===== Loading state ===== */
 
 .event-editor-loading {

--- a/src/renderer/timeline/event-editor/EventEditorModal.css
+++ b/src/renderer/timeline/event-editor/EventEditorModal.css
@@ -178,6 +178,22 @@
   white-space: nowrap;
 }
 
+.event-editor-tag-chip-remove {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+  margin-left: 3px;
+  padding: 0 1px;
+  opacity: 0.5;
+}
+
+.event-editor-tag-chip-remove:hover {
+  opacity: 1;
+}
+
 /* ===== Color row ===== */
 
 .event-editor-color-row {

--- a/src/renderer/timeline/event-editor/EventEditorModal.tsx
+++ b/src/renderer/timeline/event-editor/EventEditorModal.tsx
@@ -14,6 +14,7 @@ import {
   deriveFilename,
   getColorPresetValue,
   buildTagChips,
+  hasReservedTagPrefix,
   type EditorBuffer,
   type EditorMode,
 } from './domain';
@@ -503,6 +504,11 @@ export function EventEditorModal({
                     placeholder="plot:beast, location:fort"
                     autoComplete="off"
                   />
+                  {hasReservedTagPrefix(buffer.tagsText) && (
+                    <span className="event-editor-field-warning">
+                      Tags starting with &apos;id:&apos; are reserved for system-generated tags
+                    </span>
+                  )}
                   <TagChipPreview
                     tagsText={buffer.tagsText}
                     body={buffer.body}

--- a/src/renderer/timeline/event-editor/EventEditorModal.tsx
+++ b/src/renderer/timeline/event-editor/EventEditorModal.tsx
@@ -545,7 +545,6 @@ export function EventEditorModal({
                     onKeyDown={handleTagInputKeyDown}
                     placeholder="plot:beast, location:fort"
                     autoComplete="off"
-                    disabled={isBusy}
                   />
                   {hasReservedTagPrefix(tagInput) && (
                     <span className="event-editor-field-warning">

--- a/src/renderer/timeline/event-editor/EventEditorModal.tsx
+++ b/src/renderer/timeline/event-editor/EventEditorModal.tsx
@@ -297,9 +297,19 @@ export function EventEditorModal({
       if (!trimmed) return;
       const newText = addTagsToText(bufferRef.current.tagsText, trimmed);
       setTagInput('');
-      if (newText !== bufferRef.current.tagsText) updateBuffer({ tagsText: newText });
+      if (newText === bufferRef.current.tagsText) return;
+      // Update ref synchronously so doSave reads the new tags immediately.
+      bufferRef.current = { ...bufferRef.current, tagsText: newText };
+      setBuffer(bufferRef.current);
+      setSaveState((s) => (s === 'saving' ? s : 'dirty'));
+      setErrorMessage(null);
+      if (autoSaveTimerRef.current !== null) {
+        window.clearTimeout(autoSaveTimerRef.current);
+        autoSaveTimerRef.current = null;
+      }
+      void doSave({ silent: true });
     },
-    [tagInput, updateBuffer],
+    [tagInput, doSave],
   );
 
   const handleRemoveCustomTag = useCallback(

--- a/src/renderer/timeline/event-editor/EventEditorModal.tsx
+++ b/src/renderer/timeline/event-editor/EventEditorModal.tsx
@@ -506,7 +506,7 @@ export function EventEditorModal({
                   />
                   {hasReservedTagPrefix(buffer.tagsText) && (
                     <span className="event-editor-field-warning">
-                      Tags starting with &apos;id:&apos; are reserved for system-generated tags
+                      {"Tags starting with 'id:' or 'sesh:' are reserved for system-generated tags"}
                     </span>
                   )}
                   <TagChipPreview

--- a/src/renderer/timeline/event-editor/EventEditorModal.tsx
+++ b/src/renderer/timeline/event-editor/EventEditorModal.tsx
@@ -15,10 +15,13 @@ import {
   getColorPresetValue,
   buildTagChips,
   hasReservedTagPrefix,
+  addTagsToText,
+  removeTagFromText,
   type EditorBuffer,
   type EditorMode,
 } from './domain';
 import { ThemeProvider } from '../../theme';
+import { isValidCustomTag } from '../../../shared/entity-tags';
 import {
   buildEntityLabelMap,
   buildEntityTagLabelMap,
@@ -26,16 +29,20 @@ import {
 } from '../../../shared/entity-labels';
 import './EventEditorModal.css';
 
-function TagChipPreview({
+function TagChipList({
   tagsText,
   body,
+  systemTags,
   entityTagLabelMap,
+  onRemoveCustomTag,
 }: {
   tagsText: string;
   body: string;
+  systemTags: string[];
   entityTagLabelMap: Map<string, string>;
+  onRemoveCustomTag: (tag: string) => void;
 }) {
-  const chips = buildTagChips(tagsText, body, entityTagLabelMap);
+  const chips = buildTagChips(tagsText, body, entityTagLabelMap, systemTags);
   if (chips.length === 0) return null;
   return (
     <div className="event-editor-tag-chips">
@@ -45,6 +52,16 @@ function TagChipPreview({
           className={`event-editor-tag-chip${isEntity ? ' entity-tag-chip--resolved' : ''}`}
         >
           {display}
+          {isValidCustomTag(raw) && (
+            <button
+              type="button"
+              className="event-editor-tag-chip-remove"
+              onClick={() => onRemoveCustomTag(raw)}
+              aria-label={`Remove tag ${raw}`}
+            >
+              ×
+            </button>
+          )}
         </span>
       ))}
     </div>
@@ -117,6 +134,8 @@ export function EventEditorModal({
   const bufferRef = useRef<EditorBuffer>(buffer);
   bufferRef.current = buffer;
   const savedTimerRef = useRef<number | null>(null);
+
+  const [tagInput, setTagInput] = useState('');
 
   const viewRef = useRef<EditorView | null>(null);
   const titleInputRef = useRef<HTMLInputElement>(null);
@@ -268,6 +287,26 @@ export function EventEditorModal({
       scheduleAutoSave();
     },
     [scheduleAutoSave],
+  );
+
+  const handleTagInputKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key !== 'Enter') return;
+      e.preventDefault();
+      const trimmed = tagInput.trim();
+      if (!trimmed) return;
+      const newText = addTagsToText(bufferRef.current.tagsText, trimmed);
+      setTagInput('');
+      if (newText !== bufferRef.current.tagsText) updateBuffer({ tagsText: newText });
+    },
+    [tagInput, updateBuffer],
+  );
+
+  const handleRemoveCustomTag = useCallback(
+    (tag: string) => {
+      updateBuffer({ tagsText: removeTagFromText(bufferRef.current.tagsText, tag) });
+    },
+    [updateBuffer],
   );
 
   // Escape + Ctrl+Enter: capture phase wins over CodeMirror keybindings.
@@ -495,24 +534,30 @@ export function EventEditorModal({
                 </label>
 
                 <label className="event-editor-field">
-                  <span className="event-editor-field-label">Tags (comma-separated)</span>
+                  <span className="event-editor-field-label">
+                    Add tags (comma-separated, Enter to confirm)
+                  </span>
                   <input
                     type="text"
                     className="event-editor-input"
-                    value={buffer.tagsText}
-                    onChange={(e) => updateBuffer({ tagsText: e.target.value })}
+                    value={tagInput}
+                    onChange={(e) => setTagInput(e.target.value)}
+                    onKeyDown={handleTagInputKeyDown}
                     placeholder="plot:beast, location:fort"
                     autoComplete="off"
+                    disabled={isBusy}
                   />
-                  {hasReservedTagPrefix(buffer.tagsText) && (
+                  {hasReservedTagPrefix(tagInput) && (
                     <span className="event-editor-field-warning">
                       {"Tags starting with 'id:' or 'sesh:' are reserved for system-generated tags"}
                     </span>
                   )}
-                  <TagChipPreview
+                  <TagChipList
                     tagsText={buffer.tagsText}
                     body={buffer.body}
+                    systemTags={buffer.systemTags}
                     entityTagLabelMap={entityTagLabelMap}
+                    onRemoveCustomTag={handleRemoveCustomTag}
                   />
                 </label>
 

--- a/src/renderer/timeline/event-editor/__tests__/domain.test.ts
+++ b/src/renderer/timeline/event-editor/__tests__/domain.test.ts
@@ -8,6 +8,7 @@ import {
   getColorPresetValue,
   parseTagsText,
   buildTagChips,
+  hasReservedTagPrefix,
   type EditorBuffer,
 } from '../domain';
 import { ThemeProvider } from '../../../theme';
@@ -224,6 +225,16 @@ describe('bufferToFrontmatter', () => {
     expect(fm.tags).toEqual(['combat']);
   });
 
+  it('filters out manually-entered entity-format tags from tagsText', () => {
+    const fm = bufferToFrontmatter(buf({ tagsText: 'id:ab12, combat', body: '' }));
+    expect(fm.tags).toEqual(['combat']);
+  });
+
+  it('omits tags field entirely when only entity-format tags were typed', () => {
+    const fm = bufferToFrontmatter(buf({ tagsText: 'id:ab12', body: '' }));
+    expect('tags' in fm).toBe(false);
+  });
+
   it('round-trips through bufferFromEvent', () => {
     const original = buf({
       title: 'Round-trip',
@@ -249,6 +260,31 @@ describe('bufferToFrontmatter', () => {
     expect(restored.tagsText.split(', ').sort()).toEqual(original.tagsText.split(', ').sort());
     expect(restored.tagLabelOverride).toBe(original.tagLabelOverride);
     expect(restored.linkLabelOverride).toBe(original.linkLabelOverride);
+  });
+});
+
+// ---- hasReservedTagPrefix ----
+
+describe('hasReservedTagPrefix', () => {
+  it('returns false for empty tagsText', () => {
+    expect(hasReservedTagPrefix('')).toBe(false);
+  });
+
+  it('returns false for normal tags', () => {
+    expect(hasReservedTagPrefix('combat, plot, location:fort')).toBe(false);
+  });
+
+  it('returns true when a tag matches id:XXXX format', () => {
+    expect(hasReservedTagPrefix('id:ab12')).toBe(true);
+  });
+
+  it('returns true when one of multiple tags matches', () => {
+    expect(hasReservedTagPrefix('combat, id:ab12, plot')).toBe(true);
+  });
+
+  it('returns false for tags that start with id: but do not match the 4-char format', () => {
+    expect(hasReservedTagPrefix('id:toolong')).toBe(false);
+    expect(hasReservedTagPrefix('id:abc')).toBe(false);
   });
 });
 

--- a/src/renderer/timeline/event-editor/__tests__/domain.test.ts
+++ b/src/renderer/timeline/event-editor/__tests__/domain.test.ts
@@ -9,6 +9,8 @@ import {
   parseTagsText,
   buildTagChips,
   hasReservedTagPrefix,
+  addTagsToText,
+  removeTagFromText,
   type EditorBuffer,
 } from '../domain';
 import { ThemeProvider } from '../../../theme';
@@ -25,6 +27,7 @@ function buf(overrides: Partial<EditorBuffer> = {}): EditorBuffer {
     body: '',
     tagLabelOverride: '',
     linkLabelOverride: '',
+    systemTags: [],
     ...overrides,
   };
 }
@@ -54,6 +57,7 @@ describe('emptyBuffer', () => {
       body: '',
       tagLabelOverride: '',
       linkLabelOverride: '',
+      systemTags: [],
     });
   });
 
@@ -158,6 +162,16 @@ describe('bufferFromEvent', () => {
     expect(bufferFromEvent(ev).tagLabelOverride).toBe('');
     expect(bufferFromEvent(ev).linkLabelOverride).toBe('');
   });
+
+  it('populates systemTags with session tags from the event', () => {
+    const ev = event({ tags: ['combat', 'sesh:Session 1', 'id:ab12'] });
+    expect(bufferFromEvent(ev).systemTags).toEqual(['sesh:Session 1']);
+  });
+
+  it('populates empty systemTags when the event has no session tags', () => {
+    const ev = event({ tags: ['combat', 'id:ab12'] });
+    expect(bufferFromEvent(ev).systemTags).toEqual([]);
+  });
 });
 
 // ---- bufferToFrontmatter ----
@@ -255,6 +269,17 @@ describe('bufferToFrontmatter', () => {
     expect('tags' in fm).toBe(false);
   });
 
+  it('preserves systemTags in the output', () => {
+    const fm = bufferToFrontmatter(buf({ tagsText: 'combat', systemTags: ['sesh:01'] }));
+    expect(fm.tags).toContain('sesh:01');
+    expect(fm.tags).toContain('combat');
+  });
+
+  it('omits tags field when only systemTags and no custom/entity tags', () => {
+    const fm = bufferToFrontmatter(buf({ tagsText: '', systemTags: [] }));
+    expect('tags' in fm).toBe(false);
+  });
+
   it('round-trips through bufferFromEvent', () => {
     const original = buf({
       title: 'Round-trip',
@@ -280,6 +305,56 @@ describe('bufferToFrontmatter', () => {
     expect(restored.tagsText.split(', ').sort()).toEqual(original.tagsText.split(', ').sort());
     expect(restored.tagLabelOverride).toBe(original.tagLabelOverride);
     expect(restored.linkLabelOverride).toBe(original.linkLabelOverride);
+  });
+});
+
+// ---- addTagsToText ----
+
+describe('addTagsToText', () => {
+  it('adds new tags to an empty list', () => {
+    expect(addTagsToText('', 'combat, plot')).toBe('combat, plot');
+  });
+
+  it('appends new tags to existing ones', () => {
+    expect(addTagsToText('combat', 'plot, location:fort')).toBe('combat, plot, location:fort');
+  });
+
+  it('deduplicates tags already present', () => {
+    expect(addTagsToText('combat, plot', 'combat, location:fort')).toBe(
+      'combat, plot, location:fort',
+    );
+  });
+
+  it('returns unchanged text when all inputs are duplicates', () => {
+    expect(addTagsToText('combat', 'combat')).toBe('combat');
+  });
+
+  it('silently ignores reserved-format tags', () => {
+    expect(addTagsToText('combat', 'id:ab12, sesh:01, plot')).toBe('combat, plot');
+  });
+
+  it('returns unchanged text when input is empty', () => {
+    expect(addTagsToText('combat', '')).toBe('combat');
+  });
+});
+
+// ---- removeTagFromText ----
+
+describe('removeTagFromText', () => {
+  it('removes a tag from a list', () => {
+    expect(removeTagFromText('combat, plot', 'combat')).toBe('plot');
+  });
+
+  it('returns empty string when the only tag is removed', () => {
+    expect(removeTagFromText('combat', 'combat')).toBe('');
+  });
+
+  it('returns unchanged text when tag is not present', () => {
+    expect(removeTagFromText('combat, plot', 'npc')).toBe('combat, plot');
+  });
+
+  it('removes only the matching tag when multiple exist', () => {
+    expect(removeTagFromText('combat, plot, location:fort', 'plot')).toBe('combat, location:fort');
   });
 });
 
@@ -353,6 +428,20 @@ describe('buildTagChips', () => {
   it('ignores entity tags that may have been manually typed into tagsText', () => {
     const chips = buildTagChips('id:ab12', '', resolvedMap);
     expect(chips).toEqual([{ raw: 'id:ab12', display: 'id:ab12', isEntity: false }]);
+  });
+
+  it('includes systemTags as non-entity chips between custom and entity chips', () => {
+    const chips = buildTagChips('combat', '[[ab12]]', resolvedMap, ['sesh:01']);
+    expect(chips).toEqual([
+      { raw: 'combat', display: 'combat', isEntity: false },
+      { raw: 'sesh:01', display: 'sesh:01', isEntity: false },
+      { raw: 'id:ab12', display: 'Bob the Wizard', isEntity: true },
+    ]);
+  });
+
+  it('defaults systemTags to empty when not provided', () => {
+    const chips = buildTagChips('combat', '', emptyMap);
+    expect(chips).toEqual([{ raw: 'combat', display: 'combat', isEntity: false }]);
   });
 });
 

--- a/src/renderer/timeline/event-editor/__tests__/domain.test.ts
+++ b/src/renderer/timeline/event-editor/__tests__/domain.test.ts
@@ -128,8 +128,18 @@ describe('bufferFromEvent', () => {
     expect(bufferFromEvent(ev).tagsText).toBe('combat, plot');
   });
 
+  it('excludes session tags from tagsText', () => {
+    const ev = event({ tags: ['combat', 'sesh:Session 1', 'plot'] });
+    expect(bufferFromEvent(ev).tagsText).toBe('combat, plot');
+  });
+
   it('produces empty tagsText when all tags are entity tags', () => {
     const ev = event({ tags: ['id:ab12', 'id:cd34'] });
+    expect(bufferFromEvent(ev).tagsText).toBe('');
+  });
+
+  it('produces empty tagsText when all tags are session tags', () => {
+    const ev = event({ tags: ['sesh:01', 'sesh:02'] });
     expect(bufferFromEvent(ev).tagsText).toBe('');
   });
 
@@ -235,6 +245,16 @@ describe('bufferToFrontmatter', () => {
     expect('tags' in fm).toBe(false);
   });
 
+  it('filters out manually-entered session tags from tagsText', () => {
+    const fm = bufferToFrontmatter(buf({ tagsText: 'sesh:Session 1, combat', body: '' }));
+    expect(fm.tags).toEqual(['combat']);
+  });
+
+  it('omits tags field entirely when only session tags were typed', () => {
+    const fm = bufferToFrontmatter(buf({ tagsText: 'sesh:01', body: '' }));
+    expect('tags' in fm).toBe(false);
+  });
+
   it('round-trips through bufferFromEvent', () => {
     const original = buf({
       title: 'Round-trip',
@@ -278,8 +298,14 @@ describe('hasReservedTagPrefix', () => {
     expect(hasReservedTagPrefix('id:ab12')).toBe(true);
   });
 
+  it('returns true when a tag matches sesh: format', () => {
+    expect(hasReservedTagPrefix('sesh:Session 1')).toBe(true);
+    expect(hasReservedTagPrefix('sesh:01')).toBe(true);
+  });
+
   it('returns true when one of multiple tags matches', () => {
     expect(hasReservedTagPrefix('combat, id:ab12, plot')).toBe(true);
+    expect(hasReservedTagPrefix('combat, sesh:01, plot')).toBe(true);
   });
 
   it('returns false for tags that start with id: but do not match the 4-char format', () => {

--- a/src/renderer/timeline/event-editor/domain.ts
+++ b/src/renderer/timeline/event-editor/domain.ts
@@ -58,8 +58,12 @@ export function parseTagsText(tagsText: string): string[] {
     .filter(Boolean);
 }
 
+export function hasReservedTagPrefix(tagsText: string): boolean {
+  return parseTagsText(tagsText).some(isEntityTag);
+}
+
 export function bufferToFrontmatter(buf: EditorBuffer): EventFrontmatter {
-  const tags = parseTagsText(buf.tagsText);
+  const tags = parseTagsText(buf.tagsText).filter((t) => !isEntityTag(t));
   const linkedIds = extractWikiLinkIds(buf.body);
   const syncedTags = syncEntityTags(tags, linkedIds);
   const fm: EventFrontmatter = {

--- a/src/renderer/timeline/event-editor/domain.ts
+++ b/src/renderer/timeline/event-editor/domain.ts
@@ -4,7 +4,7 @@ import { ThemeProvider } from '../../theme';
 import {
   extractWikiLinkIds,
   syncEntityTags,
-  isEntityTag,
+  isValidCustomTag,
   formatEntityTag,
   resolveEntityTagLabel,
 } from '../../../shared/entity-tags';
@@ -42,7 +42,7 @@ export function bufferFromEvent(ev: Event): EditorBuffer {
   return {
     title: ev.title,
     date: ev.date,
-    tagsText: (ev.tags ?? []).filter((t) => !isEntityTag(t)).join(', '),
+    tagsText: (ev.tags ?? []).filter(isValidCustomTag).join(', '),
     color: ev.color ?? '',
     body: ev.body,
     id: ev.id,
@@ -59,11 +59,11 @@ export function parseTagsText(tagsText: string): string[] {
 }
 
 export function hasReservedTagPrefix(tagsText: string): boolean {
-  return parseTagsText(tagsText).some(isEntityTag);
+  return parseTagsText(tagsText).some((t) => !isValidCustomTag(t));
 }
 
 export function bufferToFrontmatter(buf: EditorBuffer): EventFrontmatter {
-  const tags = parseTagsText(buf.tagsText).filter((t) => !isEntityTag(t));
+  const tags = parseTagsText(buf.tagsText).filter(isValidCustomTag);
   const linkedIds = extractWikiLinkIds(buf.body);
   const syncedTags = syncEntityTags(tags, linkedIds);
   const fm: EventFrontmatter = {

--- a/src/renderer/timeline/event-editor/domain.ts
+++ b/src/renderer/timeline/event-editor/domain.ts
@@ -4,6 +4,7 @@ import { ThemeProvider } from '../../theme';
 import {
   extractWikiLinkIds,
   syncEntityTags,
+  isSessionTag,
   isValidCustomTag,
   formatEntityTag,
   resolveEntityTagLabel,
@@ -18,6 +19,7 @@ export interface EditorBuffer {
   id?: string;
   tagLabelOverride: string;
   linkLabelOverride: string;
+  systemTags: string[];
 }
 
 export type EditorMode =
@@ -35,6 +37,7 @@ export function emptyBuffer(initialDate?: string): EditorBuffer {
     body: '',
     tagLabelOverride: '',
     linkLabelOverride: '',
+    systemTags: [],
   };
 }
 
@@ -48,6 +51,7 @@ export function bufferFromEvent(ev: Event): EditorBuffer {
     id: ev.id,
     tagLabelOverride: ev.tagLabelOverride ?? '',
     linkLabelOverride: ev.linkLabelOverride ?? '',
+    systemTags: (ev.tags ?? []).filter(isSessionTag),
   };
 }
 
@@ -62,15 +66,31 @@ export function hasReservedTagPrefix(tagsText: string): boolean {
   return parseTagsText(tagsText).some((t) => !isValidCustomTag(t));
 }
 
+export function addTagsToText(currentText: string, input: string): string {
+  const existing = new Set(parseTagsText(currentText));
+  const toAdd = parseTagsText(input)
+    .filter(isValidCustomTag)
+    .filter((t) => !existing.has(t));
+  if (toAdd.length === 0) return currentText;
+  return [...parseTagsText(currentText), ...toAdd].join(', ');
+}
+
+export function removeTagFromText(currentText: string, tag: string): string {
+  return parseTagsText(currentText)
+    .filter((t) => t !== tag)
+    .join(', ');
+}
+
 export function bufferToFrontmatter(buf: EditorBuffer): EventFrontmatter {
   const tags = parseTagsText(buf.tagsText).filter(isValidCustomTag);
   const linkedIds = extractWikiLinkIds(buf.body);
   const syncedTags = syncEntityTags(tags, linkedIds);
+  const allTags = [...syncedTags, ...buf.systemTags];
   const fm: EventFrontmatter = {
     title: buf.title.trim(),
     date: buf.date.trim(),
   };
-  if (syncedTags.length > 0) fm.tags = syncedTags;
+  if (allTags.length > 0) fm.tags = allTags;
   if (buf.color) fm.color = buf.color;
   if (buf.id) fm.id = buf.id;
   if (buf.tagLabelOverride.trim()) fm.tagLabelOverride = buf.tagLabelOverride.trim();
@@ -122,12 +142,14 @@ export function buildTagChips(
   tagsText: string,
   body: string,
   entityTagLabelMap: Map<string, string>,
+  systemTags: string[] = [],
 ): TagChip[] {
   const customChips = parseTagsText(tagsText).map((t) => ({ raw: t, display: t, isEntity: false }));
+  const sysChips = systemTags.map((t) => ({ raw: t, display: t, isEntity: false }));
   const entityChips = extractWikiLinkIds(body).map((id) => {
     const raw = formatEntityTag(id);
     const { display } = resolveEntityTagLabel(raw, entityTagLabelMap);
     return { raw, display, isEntity: true };
   });
-  return [...customChips, ...entityChips];
+  return [...customChips, ...sysChips, ...entityChips];
 }

--- a/src/renderer/timeline/filter/logic.ts
+++ b/src/renderer/timeline/filter/logic.ts
@@ -2,7 +2,7 @@ import type { EventListItem, Session } from '../data/types';
 import { parseISOString, toAbsoluteSeconds } from '../calendar/golarian';
 import { computeSessionLabel } from '../render/session-bands';
 import type { DateField, TagFilter, DateFilter, Filter, FilterState } from './types';
-import { resolveEntityTagLabel } from '../../../shared/entity-tags';
+import { resolveEntityTagLabel, isSessionTag } from '../../../shared/entity-tags';
 
 export interface TagInfo {
   raw: string;
@@ -52,7 +52,7 @@ function matchesDateFilter(event: EventListItem, filter: DateFilter, sessions: S
   }
 
   if (filter.field === 'session') {
-    const seshTags = new Set((event.tags ?? []).filter((t) => t.startsWith('sesh:')));
+    const seshTags = new Set((event.tags ?? []).filter(isSessionTag));
     if (seshTags.size === 0) return false;
     for (const session of sessions) {
       const label = computeSessionLabel(session, sessions);

--- a/src/renderer/timeline/interactions/session-tag-sync.ts
+++ b/src/renderer/timeline/interactions/session-tag-sync.ts
@@ -1,12 +1,13 @@
 import type { EventListItem, Session } from '../data/types';
 import { parseISOString, toAbsoluteSeconds } from '../calendar/golarian';
 import { sessionTagsForSeconds } from '../render/session-bands';
+import { isSessionTag } from '../../../shared/entity-tags';
 
 export function seshTagsMatch(
   existingTags: readonly string[] | undefined,
   computed: readonly string[],
 ): boolean {
-  const existing = (existingTags ?? []).filter((t) => t.startsWith('sesh:'));
+  const existing = (existingTags ?? []).filter((t) => isSessionTag(t));
   return existing.length === computed.length && computed.every((t) => existing.includes(t));
 }
 
@@ -14,7 +15,7 @@ export function mergeSeshTags(
   existingTags: readonly string[] | undefined,
   computed: readonly string[],
 ): string[] {
-  const nonSesh = (existingTags ?? []).filter((t) => !t.startsWith('sesh:'));
+  const nonSesh = (existingTags ?? []).filter((t) => !isSessionTag(t));
   return [...nonSesh, ...computed];
 }
 
@@ -31,7 +32,7 @@ export function computeEventsNeedingSeshTagUpdate(
       continue;
     }
     const computed = sessionTagsForSeconds(secs, sessions as Session[]);
-    const existing = (ev.tags ?? []).filter((t) => t.startsWith('sesh:'));
+    const existing = (ev.tags ?? []).filter((t) => isSessionTag(t));
     if (seshTagsMatch(ev.tags, computed)) continue;
     if (computed.length > 0 || existing.length > 0) toUpdate.push(ev.filename);
   }

--- a/src/renderer/timeline/render/cards.css
+++ b/src/renderer/timeline/render/cards.css
@@ -114,6 +114,22 @@
   line-height: 1.4;
 }
 
+.event-card-tag-remove {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+  margin-left: 3px;
+  padding: 0 1px;
+  opacity: 0.5;
+}
+
+.event-card-tag-remove:hover {
+  opacity: 1;
+}
+
 /* ===== Expanded card ===== */
 
 .event-card.is-expanded {

--- a/src/renderer/timeline/render/cards.tsx
+++ b/src/renderer/timeline/render/cards.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, type CSSProperties, type ReactElement } from 'rea
 import './cards.css';
 import type { EventListItem } from '../data/types';
 import type { WeekdayColors } from '../../theme';
-import { resolveEntityTagLabel } from '../../../shared/entity-tags';
+import { resolveEntityTagLabel, isValidCustomTag } from '../../../shared/entity-tags';
 import type { ViewState, ViewportSize } from '../math/zoom';
 import { formatCardFace } from '../calendar/format';
 import {
@@ -50,6 +50,7 @@ interface CardsProps {
   onDeleteClick: (item: EventListItem) => void;
   onContextMenu?: (item: EventListItem, x: number, y: number) => void;
   onOpenById?: (id: string) => void;
+  onRemoveTag?: (filename: string, tag: string) => void;
   entityLabelMap?: Map<string, string>;
   entityTagLabelMap?: Map<string, string>;
 }
@@ -69,6 +70,7 @@ export function Cards({
   onDeleteClick,
   onContextMenu,
   onOpenById,
+  onRemoveTag,
   entityLabelMap,
   entityTagLabelMap,
 }: CardsProps): ReactElement | null {
@@ -141,6 +143,7 @@ export function Cards({
             onDeleteClick={onDeleteClick}
             onContextMenu={onContextMenu}
             onOpenById={onOpenById}
+            onRemoveTag={onRemoveTag}
             entityLabelMap={entityLabelMap}
             entityTagLabelMap={entityTagLabelMap}
           />
@@ -166,6 +169,7 @@ interface CardItemProps {
   onDeleteClick: (item: EventListItem) => void;
   onContextMenu?: (item: EventListItem, x: number, y: number) => void;
   onOpenById?: (id: string) => void;
+  onRemoveTag?: (filename: string, tag: string) => void;
   entityLabelMap?: Map<string, string>;
   entityTagLabelMap?: Map<string, string>;
 }
@@ -186,6 +190,7 @@ function CardItem({
   onDeleteClick,
   onContextMenu,
   onOpenById,
+  onRemoveTag,
   entityLabelMap,
   entityTagLabelMap,
 }: CardItemProps): ReactElement {
@@ -275,12 +280,26 @@ function CardItem({
           <div className="event-card-tags">
             {tags.map((t) => {
               const { display, isEntity } = resolveEntityTagLabel(t, entityTagLabelMap);
+              const canRemove = !!onRemoveTag && isValidCustomTag(t);
               return (
                 <span
                   key={t}
                   className={`event-card-tag${isEntity ? ' entity-tag-chip--resolved' : ''}`}
                 >
                   {display}
+                  {canRemove && (
+                    <button
+                      type="button"
+                      className="event-card-tag-remove"
+                      aria-label={`Remove tag ${t}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onRemoveTag!(card.event.filename, t);
+                      }}
+                    >
+                      ×
+                    </button>
+                  )}
                 </span>
               );
             })}

--- a/src/renderer/views/timeline/timeline-view.tsx
+++ b/src/renderer/views/timeline/timeline-view.tsx
@@ -292,6 +292,28 @@ export function TimelineView({
     [campaignPath, refreshEvents],
   );
 
+  const handleRemoveTag = useCallback(
+    async (filename: string, tag: string) => {
+      const { event, lastModified } = await timelinePort.getEvent(campaignPath, filename);
+      const newTags = (event.tags ?? []).filter((t) => t !== tag);
+      await timelinePort.updateEvent(
+        campaignPath,
+        filename,
+        {
+          title: event.title,
+          date: event.date,
+          ...(newTags.length > 0 ? { tags: newTags } : {}),
+          ...(event.color ? { color: event.color } : {}),
+          ...(event.status ? { status: event.status } : {}),
+        },
+        event.body,
+        lastModified,
+      );
+      await refreshEvents();
+    },
+    [campaignPath, refreshEvents],
+  );
+
   const reschedule = useReschedule(
     viewportRef,
     dragLabelRef,
@@ -508,6 +530,7 @@ export function TimelineView({
           onDeleteClick={sessionModeActiveRef.current ? undefined : editor.requestDeleteFromCard}
           onContextMenu={sessionModeActiveRef.current ? undefined : handleCardContextMenu}
           onOpenById={onOpenById}
+          onRemoveTag={sessionModeActiveRef.current ? undefined : handleRemoveTag}
           entityLabelMap={entityLabelMap}
           entityTagLabelMap={entityTagLabelMap}
         />

--- a/src/renderer/views/timeline/timeline-view.tsx
+++ b/src/renderer/views/timeline/timeline-view.tsx
@@ -44,6 +44,7 @@ import { FooterButton } from '../../components/footer-button';
 import { loadSavedViewState, saveViewState } from './view-state-persistence';
 import { useFilterState } from '../../timeline/filter/use-filter-state';
 import { applyFilters } from '../../timeline/filter/logic';
+import { isSessionTag } from '../../../shared/entity-tags';
 import { FilterPanel } from '../../timeline/filter/filter-panel';
 import { EventContextMenu } from '../../timeline/components/event-context-menu';
 import { LabelOverrideEditor } from '../../shared/components/label-override-editor';
@@ -259,7 +260,7 @@ export function TimelineView({
       try {
         const { event, lastModified } = await timelinePort.getEvent(campaignPath, filename);
         const newDate = toISOString(fromAbsoluteSeconds(newSeconds));
-        const nonSeshTags = (event.tags ?? []).filter((t) => !t.startsWith('sesh:'));
+        const nonSeshTags = (event.tags ?? []).filter((t) => !isSessionTag(t));
         const newSeshTags = sessionTagsForSeconds(newSeconds, sessionsRef.current);
         const updatedTags = [...nonSeshTags, ...newSeshTags];
         await timelinePort.updateEvent(

--- a/src/renderer/views/timeline/timeline-view.tsx
+++ b/src/renderer/views/timeline/timeline-view.tsx
@@ -309,9 +309,14 @@ export function TimelineView({
         event.body,
         lastModified,
       );
-      await refreshEvents();
+      setLoadedData((d) => ({
+        ...d,
+        events: d.events.map((e) =>
+          e.filename === filename ? { ...e, tags: newTags.length > 0 ? newTags : undefined } : e,
+        ),
+      }));
     },
-    [campaignPath, refreshEvents],
+    [campaignPath],
   );
 
   const reschedule = useReschedule(

--- a/src/shared/__tests__/entity-tags.test.ts
+++ b/src/shared/__tests__/entity-tags.test.ts
@@ -3,6 +3,7 @@ import {
   isEntityTag,
   parseEntityTag,
   formatEntityTag,
+  isSessionTag,
   isValidCustomTag,
   resolveEntityTagLabel,
   extractWikiLinkIds,
@@ -64,6 +65,21 @@ describe('formatEntityTag', () => {
   });
 });
 
+describe('isSessionTag', () => {
+  it('returns true for tags starting with sesh:', () => {
+    expect(isSessionTag('sesh:Session 1')).toBe(true);
+    expect(isSessionTag('sesh:01')).toBe(true);
+    expect(isSessionTag('sesh:')).toBe(true);
+  });
+
+  it('returns false for tags that do not start with sesh:', () => {
+    expect(isSessionTag('combat')).toBe(false);
+    expect(isSessionTag('id:ab12')).toBe(false);
+    expect(isSessionTag('session-1')).toBe(false);
+    expect(isSessionTag('')).toBe(false);
+  });
+});
+
 describe('isValidCustomTag', () => {
   it('returns true for normal custom tags', () => {
     expect(isValidCustomTag('combat')).toBe(true);
@@ -74,6 +90,12 @@ describe('isValidCustomTag', () => {
   it('returns false for tags that match entity tag format', () => {
     expect(isValidCustomTag('id:ab12')).toBe(false);
     expect(isValidCustomTag('id:0000')).toBe(false);
+  });
+
+  it('returns false for session tags', () => {
+    expect(isValidCustomTag('sesh:Session 1')).toBe(false);
+    expect(isValidCustomTag('sesh:01')).toBe(false);
+    expect(isValidCustomTag('sesh:')).toBe(false);
   });
 
   it('returns true for near-misses that do not match entity tag format', () => {

--- a/src/shared/entity-tags.ts
+++ b/src/shared/entity-tags.ts
@@ -12,8 +12,12 @@ export function formatEntityTag(id: string): string {
   return `id:${id}`;
 }
 
+export function isSessionTag(tag: string): boolean {
+  return tag.startsWith('sesh:');
+}
+
 export function isValidCustomTag(tag: string): boolean {
-  return !isEntityTag(tag);
+  return !isEntityTag(tag) && !isSessionTag(tag);
 }
 
 export function resolveEntityTagLabel(


### PR DESCRIPTION
## Summary

- Adds inline validation warning below the Tags input when a user types a tag matching the `id:XXXX` entity tag format, with message: _"Tags starting with 'id:' are reserved for system-generated tags"_
- Makes the entity-format tag filter explicit in `bufferToFrontmatter()` so manually-typed `id:XXXX` tags are never persisted (filtering was already happening inside `syncEntityTags`, but is now also applied before that call)
- System-generated entity tags from wiki links continue to bypass the guard — they are added by `syncEntityTags` from the body, not from `tagsText`

## Test plan

- [ ] Type `id:ab12` into the Tags field — warning message appears below the input
- [ ] Type `combat, id:ab12, plot` — warning appears; `combat` and `plot` chips render normally
- [ ] Save with a manually-typed `id:XXXX` tag — the saved event does not contain the invalid tag
- [ ] Add a `[[ab12]]` wiki link to the body — entity tag chip appears; no warning is shown (guard only fires on `tagsText`)
- [ ] Type `id:toolong` — no warning (does not match the exact 4-char format)
- [ ] All 1158 unit tests pass (`npm test`)

Closes #161

https://claude.ai/code/session_01XWtLf3ACFewUPFdwtV5xTv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWtLf3ACFewUPFdwtV5xTv)_