### PR TITLE
Sub-Epic 6: Documentation & Skills

### DIFF
--- a/.claude/skills/add-loading-task/SKILL.md
+++ b/.claude/skills/add-loading-task/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: add-loading-task
+description: Use this skill when adding a new loading task to the campaign loader — e.g. pre-warming a cache, validating files, migrating data, or building a secondary index during campaign open. Enforces the LoadingTask contract and the registration pattern in src/main/index.ts.
+---
+
+# Add a Campaign Loading Task
+
+Campaign open runs a sequential list of `NamedTask` entries through
+`CampaignLoader`. Each task reports incremental progress; the loader
+aggregates all tasks into a single percentage and streams it to the
+renderer via IPC.
+
+## When to use this skill
+
+| Scenario | Use this skill? |
+|---|---|
+| Work that must complete before the campaign is usable | Yes |
+| Heavy IO that benefits from a visible progress bar | Yes |
+| Background work that can happen after open | No — do it lazily or on a file-change event |
+| Renderer-side data loading | No — that goes through the data port, not here |
+
+## Files
+
+```
+src/main/
+  campaign-loader.ts          # LoadingTask type, NamedTask interface, CampaignLoader class
+  entity-index.ts             # Reference implementation of a task function
+  index.ts                    # Registration site — add your NamedTask here
+  __tests__/
+    campaign-loader.test.ts   # Tests for CampaignLoader itself (aggregation, sequencing, error)
+    <your-task>.test.ts       # Add your own tests for the task function
+```
+
+## Interfaces
+
+```ts
+// src/main/campaign-loader.ts
+export type LoadingTask = (onProgress: (completed: number, total: number) => void) => Promise<void>;
+
+export interface NamedTask {
+  name: string;   // shown in the loading overlay (e.g. "Building entity index")
+  task: LoadingTask;
+}
+```
+
+`completed` and `total` are raw counts in whatever unit makes sense
+(files processed, bytes read, items validated). Keep them consistent
+within one task — don't mix units.
+
+## How progress aggregation works
+
+`CampaignLoader` keeps a `{ completed, total }` slot per task.
+On every `onProgress` call it sums across all slots:
+
+```
+percentage = Math.round(sum(completed) / sum(total) * 100)
+```
+
+Tasks that never call `onProgress` contribute 0/0 and are ignored in
+the sum (no divide-by-zero). Tasks run **sequentially** — a task cannot
+start until the previous one resolves.
+
+The renderer subscribes via `window.fsApi.onLoadProgress` (set up in
+`src/preload/index.cts`) and drives `CampaignLoadOverlay` through
+`useCampaigns`. You do not need to touch the renderer unless the task
+produces new data that must flow back to the renderer (see step 5).
+
+## Recipe
+
+### 1. Write the task function
+
+Create `src/main/<your-task>.ts`. Export a named function that matches
+the `LoadingTask` signature. Keep IO sync-friendly where possible
+(Node's `fs` sync APIs inside a task are fine — the main process is not
+the render thread):
+
+```ts
+// src/main/validate-timeline.ts
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export function validateTimeline(
+  campaignPath: string,
+  onProgress: (completed: number, total: number) => void,
+): void {
+  const dir = path.join(campaignPath, 'timeline');
+  if (!fs.existsSync(dir)) return;
+
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith('.md'));
+  const total = files.length;
+
+  for (let i = 0; i < files.length; i++) {
+    // ... validate files[i]
+    onProgress(i + 1, total);
+  }
+}
+```
+
+If your task is truly async (network, child process), make the function
+`async` and `await` naturally. The signature that reaches
+`CampaignLoader` is still `LoadingTask` — a function that receives
+`onProgress` and returns `Promise<void>`.
+
+### 2. Return data through the `campaign:open` result (if needed)
+
+`campaign:open` in `src/main/index.ts` already returns `{ success, entityIndex }`.
+If your task produces data the renderer needs:
+
+- Declare a mutable variable alongside `entityIndex` (see the pattern
+  used for `entityIndex`).
+- Assign inside the task closure.
+- Add the variable to the return object.
+- Update `src/preload/index.cts` and `src/types/global.d.ts` if the
+  shape of `fsApi.openCampaign`'s return type changes.
+
+If your task is side-effects only (writes files, warms caches), skip
+this step.
+
+### 3. Register the task in `src/main/index.ts`
+
+```ts
+// src/main/index.ts — inside the ipcMain.handle('campaign:open', ...) handler
+
+import { validateTimeline } from './validate-timeline.js';
+
+let entityIndex: EntityIndexEntry[] = [];
+let myData: MyData | null = null;   // only if you need to return data
+
+const loader = new CampaignLoader([
+  {
+    name: 'Building entity index',
+    task: async (onProgress) => {
+      entityIndex = buildEntityIndex(resolvedPath, onProgress);
+    },
+  },
+  {
+    name: 'Validating timeline',          // shown in the loading overlay
+    task: async (onProgress) => {
+      validateTimeline(resolvedPath, onProgress);
+    },
+  },
+]);
+```
+
+Tasks run in array order. Put fast tasks first so the progress bar
+moves early and gives visual feedback.
+
+### 4. Test the task function
+
+Create `src/main/__tests__/<your-task>.test.ts`. Test the task function
+directly — no need to wrap it in a `CampaignLoader`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { validateTimeline } from '../validate-timeline.js';
+
+function makeTmpCampaign(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'campaign-'));
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content, 'utf-8');
+  }
+  return dir;
+}
+
+describe('validateTimeline', () => {
+  it('reports one tick per file', () => {
+    const dir = makeTmpCampaign({
+      'timeline/event-a.md': '---\ntitle: A\n---\nbody',
+      'timeline/event-b.md': '---\ntitle: B\n---\nbody',
+    });
+    const ticks: Array<[number, number]> = [];
+    validateTimeline(dir, (c, t) => ticks.push([c, t]));
+    expect(ticks).toEqual([[1, 2], [2, 2]]);
+  });
+
+  it('does nothing when the directory is absent', () => {
+    const ticks: Array<[number, number]> = [];
+    validateTimeline('/no/such/path', (c, t) => ticks.push([c, t]));
+    expect(ticks).toHaveLength(0);
+  });
+});
+```
+
+See `src/main/__tests__/campaign-loader.test.ts` for how to test
+multi-task aggregation behaviour using `CampaignLoader` directly.
+
+### 5. Verify
+
+```
+npm test                        # all tests pass
+npm run build                   # TypeScript clean
+```
+
+## Common pitfalls
+
+- **Never call `onProgress(0, 0)` as a "start" signal.** The loader
+  only tracks the last values you pass. A `0/0` emit is a no-op in the
+  percentage math, but it will overwrite a previous non-zero slot and
+  drag the aggregate back to 0 if called after any real progress.
+- **Don't emit after the task resolves.** `onProgress` callbacks after
+  the `await` of your task is gone are silently swallowed but indicate
+  a logic error (e.g., a stray async callback firing late).
+- **Keep `total` stable within a task.** Changing `total` mid-run
+  causes the progress bar to jump backwards. Count first, then iterate.
+  See `buildEntityIndex` in `entity-index.ts` for the `countFiles`
+  → `scanDir` pattern.
+- **Throw real errors.** `CampaignLoader` catches exceptions, sends
+  `campaign:loadError` to the renderer, and rethrows. Don't swallow
+  errors silently inside a task — let them propagate so the UI shows the
+  error state.
+- **Task name is user-visible.** It appears in the loading overlay
+  (`CampaignLoadOverlay`) as `progress.taskName`. Use title-case prose
+  ("Validating timeline files"), not identifiers ("validateTimeline").
+
+## See also
+
+- `src/main/campaign-loader.ts` — `LoadingTask`, `NamedTask`, `CampaignLoader`
+- `src/main/entity-index.ts` — reference task implementation (`buildEntityIndex`)
+- `src/main/index.ts` — registration site
+- `src/preload/index.cts` — IPC bridge (`onLoadProgress`, `onLoadComplete`, `onLoadError`)
+- `src/renderer/components/campaign-load-overlay.tsx` — the loading UI
+- `src/renderer/hooks/useCampaigns.ts` — renderer-side state for load progress

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,142 @@
+# tabletop-timeline — Campaign On-Disk Format
+
+This document is the entry point for AI agents. It covers what a campaign is on disk, how files are structured, and how the ID system works.
+
+## What a campaign is
+
+A campaign is a directory inside a user-chosen root folder. The app scans the root for subdirectories containing a `campaign.md` file; each such directory is one campaign. The campaign directory holds markdown files for notes and timeline events, asset images, and a few JSON sidecar files.
+
+## Directory structure
+
+```
+<root>/
+  my-campaign/                    # campaign folder (name is slugified from campaign title)
+    campaign.md                   # config — must exist for the folder to be recognised
+    notes/                        # note markdown files, may be arbitrarily nested
+      player characters/
+        aria.a1b2.md
+      factions/
+        iron-circle.c3d4.md
+      locations/
+      npcs/
+      plots/
+      map.png                     # asset files live alongside notes
+    timeline/                     # event markdown files (flat — no subdirectories scanned)
+      0001-01-15-battle-of-dawn.md
+      state.json                  # { in_game_now, campaign_start } — ISO date strings
+    sessions.json                 # session records (top-level, optional)
+    tags.json                     # tag registry { [tagName]: { color, description } } (optional)
+    relationships/                # created on campaign init, not yet used by the app
+```
+
+The app creates `notes/player characters`, `notes/factions`, `notes/locations`, `notes/npcs`, and `notes/plots` on first open if they do not exist.
+
+## IDs
+
+Every note and event gets a **4-character alphanumeric ID** (chars `a-z0-9`, 36^4 = ~1.7 M combinations). The app generates one automatically when a file is first read and lacks an `id` frontmatter field, then writes it back.
+
+IDs appear in three places:
+
+1. **Frontmatter** — `id: a1b2` in the YAML block of the file.
+2. **Wiki links in body text** — `[[a1b2]]` or `[[Display Label|a1b2]]`.
+3. **Event tags** — `id:a1b2` (entity tag format, auto-synced from wiki links in the event body).
+
+Filenames do **not** need to embed the ID; the app finds entities by scanning frontmatter. Event filenames are derived from date + title slug and never include the ID.
+
+## `campaign.md`
+
+```yaml
+---
+id: x7k2          # short ID for the campaign itself
+name: My Campaign
+description: A short blurb
+---
+
+Optional markdown body (shown nowhere in the UI currently).
+```
+
+## Note files (`notes/**/*.md`)
+
+```yaml
+---
+id: a1b2                         # required; auto-generated if absent
+title: Aria Lunashadow           # synced from H1; auto-generated if absent
+tagLabelOverride: Aria           # optional — label used on event tag chips
+linkLabelOverride: Aria L.       # optional — label used in wiki-link previews
+---
+
+# Aria Lunashadow
+
+Body markdown. May contain wiki links: [[c3d4]] or [[Iron Circle|c3d4]].
+```
+
+- H1 is the source of truth for the display title. When present it overrides `title` in frontmatter; the app writes the updated frontmatter back on load.
+- Frontmatter fields beyond `id`, `title`, and the two label overrides are preserved as-is.
+- Asset files (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg`) inside `notes/` are indexed as type `asset`; they carry no frontmatter.
+
+## Event files (`timeline/*.md`)
+
+```yaml
+---
+title: Battle of Dawn
+date: "0001-01-15T07:00:00"      # Golarian ISO-like date string (quoted to prevent YAML date parsing)
+tags:
+  - combat                        # custom tags (free strings)
+  - id:a1b2                       # entity tags — auto-synced from wiki links in the body
+  - sesh:s1                       # session tags — managed by the app, not user-editable
+color: "#8b5cf6"                  # optional hex color
+status: happened                  # "happened" | "planned" (optional)
+id: e5f6                          # optional; auto-generated on create
+tagLabelOverride: Battle          # optional
+linkLabelOverride: Dawn Battle    # optional
+---
+
+Event body markdown. Wiki links here drive the `id:XXXX` entity tags automatically.
+```
+
+Event filenames follow this pattern: `<date-only>-<title-slug>.md` where the slug is lowercased, apostrophes stripped, and non-alphanumeric runs replaced with `-`, capped at 60 chars. Example: `0001-01-15-battle-of-dawn.md`.
+
+## `timeline/state.json`
+
+```json
+{ "in_game_now": "0001-01-15T07:00:00", "campaign_start": "0001-01-01T00:00:00" }
+```
+
+Both fields are Golarian ISO date strings (or empty strings when unset).
+
+## `sessions.json`
+
+Top-level array of session records:
+
+```json
+[
+  {
+    "id": "s1",
+    "inGameStart": "0001-01-01T00:00:00",
+    "inGameEnd": "0001-01-15T07:00:00",
+    "realStart": "2024-03-01T18:00:00",
+    "realEnd": "2024-03-01T22:00:00",
+    "color": "#8b5cf6"
+  }
+]
+```
+
+## Tags on events
+
+Three tag namespaces co-exist in the `tags` array:
+
+| Prefix | Example | Meaning |
+|---|---|---|
+| (none) | `combat` | Custom tag — user-editable free strings |
+| `id:` | `id:a1b2` | Entity tag — auto-synced from `[[a1b2]]` wiki links in the body |
+| `sesh:` | `sesh:s1` | Session tag — managed by the app |
+
+`isEntityTag`, `isSessionTag`, and `isValidCustomTag` in `src/shared/entity-tags.ts` are the canonical classifiers.
+
+## Entity index
+
+On campaign load the main process scans `notes/` (recursively) and `timeline/` to build an in-memory index of `{ id, path, title, type, tagLabelOverride?, linkLabelOverride? }` entries. The path is campaign-relative with forward slashes. Notes also include asset entries (type `asset`, id `''`). The index is the runtime source of truth for wiki-link resolution and entity tag labels.
+
+## Campaign path resolution
+
+The user picks a root directory once via OS dialog; the app stores it in Electron's `userData/config.json` as `rootDir`. On startup it scans `rootDir` for campaign folders and presents the list. The selected campaign's absolute path is held in `src/main/campaign-state.ts` (`getCampaignPath` / `setCampaignPath`).

--- a/src/main/AGENTS.md
+++ b/src/main/AGENTS.md
@@ -1,0 +1,149 @@
+# `src/main/` — Electron Main Process
+
+Electron's main process: IPC handlers, file system access, file watcher, and the entity index.
+All business logic that requires Node.js APIs lives here; the renderer communicates through IPC.
+
+## Layout
+
+```
+main/
+  index.ts                    # app bootstrap: BrowserWindow, menu, autoUpdater
+  ipcHandlers.ts              # registers all IPC handlers (delegates to sub-registrars)
+  entity-index.ts             # buildEntityIndex, indexSingleEntity, findEntityById
+  entity-index-handlers.ts    # IPC handlers: entity:getAll, entity:updateLabelOverride
+  fileWatcher.ts              # chokidar watcher → entity:indexDelta events
+  campaign-state.ts           # getCampaignPath / setCampaignPath singleton
+  campaign-loader.ts          # progress-reporting task runner for campaign open
+  timelineIpcHandlers.ts      # timeline IPC (events, sessions, state, tags)
+  windowManager.ts            # BrowserWindow lifecycle helpers
+  __tests__/
+    entity-index.test.ts      # integration tests using real tmp dirs
+```
+
+## Entity Index
+
+The entity index is an in-memory (on the renderer side) + on-disk (in frontmatter) registry of
+every tracked file in a campaign. It lets the renderer resolve entity IDs to display labels for
+wiki links and inline tags without reading individual files.
+
+### EntityIndexEntry shape
+
+```ts
+interface EntityIndexEntry {
+  id: string;               // stable UUID from frontmatter
+  path: string;             // campaign-relative forward-slash path, e.g. "notes/npcs/elara.md"
+  title: string;            // frontmatter title (falls back to filename stem)
+  type: 'note' | 'event' | 'asset';
+  tagLabelOverride?: string;   // overrides title when entity appears as a tag
+  linkLabelOverride?: string;  // overrides title when entity appears as a wiki link
+}
+```
+
+Assets (images, etc. in `notes/`) carry `id: ''` and have no overrides — they exist in the index
+so the link-suggestion UI can surface them.
+
+### How the index is built
+
+`buildEntityIndex(campaignPath, onProgress?)` scans `notes/` (`.md` + asset extensions) and
+`timeline/` (`.md` only) recursively. For each `.md` file it calls `parseNote`, which assigns a
+stable `id` and `title` if the frontmatter is missing them, writing the file back when it does
+(`needsWrite`). Progress is reported as `(completed, total)` per file for the loading overlay.
+
+This full build runs once at campaign open. The result is handed to the renderer via
+`openCampaign`'s return value (`{ success: true; entityIndex: EntityIndexEntry[] }`).
+
+### Delta updates (file watcher)
+
+After load, `FileWatcher` (chokidar) keeps the renderer in sync without a full rebuild:
+
+- **add / change** → `indexSingleEntity(fullPath, campaignPath)` re-parses the single file and
+  emits `entity:indexDelta` with `{ op: 'add' | 'update', entry }`.
+- **unlink** → emits `entity:indexDelta` with `{ op: 'remove', path }` (no disk read needed).
+
+The renderer applies deltas with `applyEntityDelta` from `src/shared/entity-labels.ts`.
+
+`indexSingleEntity` handles the same `needsWrite` logic as the bulk scan so auto-generated IDs
+are persisted immediately.
+
+### Label override flow
+
+Two optional frontmatter keys — `tagLabelOverride` and `linkLabelOverride` — let the user rename
+how an entity is displayed in tags and wiki links independently of its canonical title.
+
+**Writing an override** goes through a single IPC handler:
+
+```
+entity:updateLabelOverride(id, target, value)
+  target: 'tagLabel' | 'linkLabel'
+  value:  string  → sets the key
+          null    → deletes the key (reset to title)
+```
+
+`entity-index-handlers.ts` finds the file by ID, reads it, mutates the frontmatter, writes it
+back, and returns. The file watcher then picks up the write and emits `entity:indexDelta` —
+**no separate event is needed for overrides**.
+
+**Reading an override** uses helpers in `src/shared/entity-labels.ts`:
+
+```ts
+effectiveTagLabel(entry)   // entry.tagLabelOverride ?? entry.title
+effectiveLinkLabel(entry)  // entry.linkLabelOverride ?? entry.title
+buildEntityLabelMap(index) // Map<id, effectiveLinkLabel>  (used by wiki-link renderer)
+buildEntityTagLabelMap(index) // Map<id, effectiveTagLabel>  (used by tag chips)
+```
+
+Never access `tagLabelOverride` / `linkLabelOverride` directly — always go through these helpers.
+
+## Data flow
+
+```
+campaign:open (IPC)
+  └── buildEntityIndex → EntityIndexEntry[]
+        └── returned inline to renderer (pendingEntityIndex in useCampaigns)
+
+FileWatcher (chokidar)
+  ├── add/change → indexSingleEntity → entity:indexDelta { op, entry }
+  └── unlink     →                     entity:indexDelta { op: 'remove', path }
+
+entity:updateLabelOverride (IPC)
+  └── writes frontmatter → FileWatcher detects change → entity:indexDelta
+```
+
+Renderer side (`src/renderer/app.tsx`):
+- `entityIndexRef` (stable ref) holds the live array.
+- `entityLabelMap` / `entityTagLabelMap` (state) drive React re-renders.
+- `onEntityDelta` listener calls `applyEntityDelta` and rebuilds both maps.
+
+## Preload bridge
+
+`src/preload/index.cts` exposes these methods on `window.fsApi`:
+
+| Method | IPC channel |
+|---|---|
+| `getEntityIndex()` | `entity:getAll` |
+| `updateEntityLabelOverride(id, target, value)` | `entity:updateLabelOverride` |
+| `onEntityDelta(callback)` | `entity:indexDelta` (event, returns unsubscribe) |
+
+The renderer-side port is `src/renderer/shared/entity-index.ts` — use it instead of calling
+`window.fsApi` directly from renderer code.
+
+## Conventions
+
+- **Main process owns truth at rest.** Overrides live in frontmatter, not in a separate DB.
+  The index is always reconstructible by re-scanning the campaign directory.
+- **File watcher is the update bus.** Anything that mutates a `.md` file (rename, delete,
+  frontmatter edit) automatically propagates through `entity:indexDelta`. Don't emit a separate
+  event for label override writes.
+- **`indexSingleEntity` is the canonical single-file parser.** Use it in tests and in any new
+  code path that needs to read one entity's metadata.
+
+## Don't
+
+- Don't build a secondary label store in the renderer — the ref + two derived Maps in `app.tsx`
+  are the source of truth on the renderer side.
+- Don't call `buildEntityIndex` on every file change — use `indexSingleEntity` for incremental
+  updates.
+- Don't skip `effectiveTagLabel` / `effectiveLinkLabel` — reading `entry.title` directly ignores
+  user-set overrides.
+- Don't add new frontmatter keys for per-entity display config without updating both
+  `indexSingleEntity` and `buildEntityIndex` (the bulk scanner) to read them.

--- a/src/renderer/components/AGENTS.md
+++ b/src/renderer/components/AGENTS.md
@@ -1,0 +1,94 @@
+# `src/renderer/components/` — Shared UI Components
+
+Shared, view-agnostic components used across the renderer. The most important pattern here is the
+footer portal system.
+
+## Footer portal pattern
+
+The footer bar is constant across all views. Users see it at all times and learn to look there for
+context-sensitive action buttons. Each view injects its own buttons without the footer component
+knowing anything about them.
+
+### How it works
+
+1. `footer.tsx` renders four **empty slot divs** with stable DOM IDs:
+   - `footer-slot-far-left` — sits immediately to the right of the view-switcher menu; use for
+     view-level navigation or mode toggles that need to be close to the label.
+   - `footer-slot-left` — left column of the three-column grid (right-aligned content).
+   - `footer-slot-center` — centre column of the three-column grid (centred content).
+   - `footer-slot-right` — right column of the three-column grid (left-aligned content).
+
+2. A view renders `<FooterPortal slot="...">` anywhere inside its component tree. On mount,
+   `FooterPortal` locates the matching slot div by ID and uses React's `createPortal` to render its
+   children there. On unmount the portal is removed automatically — no cleanup code required.
+
+### Layout diagram
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────────┐
+│  ☰ Timeline  │ far-left │       left       │   center   │       right       │        │
+└──────────────────────────────────────────────────────────────────────────────────────┘
+               ^           ^──────────────── three-column grid ──────────────^
+```
+
+### Adding footer buttons to a new view
+
+Render `<FooterPortal>` anywhere inside your view component — typically at the end of the JSX:
+
+```tsx
+import { FooterPortal } from '../../components/footer-portal';
+import { FooterButton } from '../../components/footer-button';
+
+export function MyView() {
+  return (
+    <>
+      {/* ...view content... */}
+
+      <FooterPortal slot="right">
+        <FooterButton onClick={handleSomething}>Do thing</FooterButton>
+      </FooterPortal>
+
+      <FooterPortal slot="center">
+        <FooterButton variant="primary" onClick={handleCreate}>+ Add</FooterButton>
+      </FooterPortal>
+    </>
+  );
+}
+```
+
+Content appears when the view mounts and disappears when it unmounts. No wiring in `footer.tsx`
+or the app shell is needed.
+
+## FooterButton
+
+`FooterButton` provides consistent button styling for footer content.
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `onClick` | `() => void` | required | |
+| `variant` | `'default' \| 'primary' \| 'active'` | `'default'` | `primary` = warm accent fill; `active` = gold border, indicates a toggle is on |
+| `title` | `string` | — | Tooltip text |
+| `children` | `ReactNode` | required | Label or icon |
+
+## Key files
+
+| File | Role |
+|---|---|
+| `footer.tsx` | Renders the footer bar and the four empty slot divs. Owns the view-switcher menu. |
+| `footer-portal.tsx` | `FooterPortal` — `createPortal` wrapper. Waits for DOM mount before rendering. |
+| `footer-button.tsx` | `FooterButton` — styled button with `default`, `primary`, `active` variants. |
+| `footer-button.css` | CSS for `.footer-btn` and its variant modifiers (theme vars only, no hex). |
+
+## Don't
+
+- Don't add view-specific logic or imports to `footer.tsx`. The footer knows nothing about views;
+  views inject into it.
+- Don't render a `FooterPortal` outside a component tree that is mounted inside the app shell
+  (i.e. outside a rendered view). `FooterPortal` guards against this with a `mounted` state flag —
+  it renders `null` on the first paint — but if the target slot div is absent the portal is also
+  silently dropped.
+- Don't use more than one `FooterPortal` per slot from the same view. Multiple portals targeting
+  the same slot will stack their children inside that div, which may be intentional for composing
+  buttons but can cause layout surprises.
+- Don't hardcode colours in footer button content. Use `var(--theme-*)` CSS variables or
+  `ThemeProvider.get()`.

--- a/src/renderer/shared/markdown-editor/AGENTS.md
+++ b/src/renderer/shared/markdown-editor/AGENTS.md
@@ -50,6 +50,51 @@ Use `<MarkdownPreview>` — it accepts `content`, `images`, `wikiLinks`, and `cl
 
 When you add a new extension, write its tests in `extensions/__tests__/`. When you change the wrapper's prop contract, update `markdown-editor.test.tsx` and the props table above.
 
+## Editor architecture
+
+### Extension stack
+
+`<MarkdownEditor>` builds its extension list at mount time and never remounts for prop changes. The stack has two layers:
+
+**Base extensions (always active, built once):**
+CodeMirror standard extensions (history, keymaps, bracket matching, closeBrackets, etc.), the markdown language grammar with code language auto-detection, `lastGaspThemeExtensions`, `EditorView.lineWrapping`, and the `updateListener` that fires `onChange`. `imagePaste` and `dropLink` are pushed into this layer when their config objects are supplied — they must be fixed at mount and cannot be toggled.
+
+**Mode compartment (hot-swappable via `Compartment`):**
+`markdownDecorations()`, `imageDecorations(imagesConfig)`, `wikiLinks(...)`, and `markdownLinkClick(...)` are all bundled inside a single `Compartment`. In source mode the compartment holds an empty array; in live mode it holds these four. Switching mode calls `compartment.reconfigure(...)` — no editor recreation. The compartment instance is part of the `SavedEditorInstance` and must always round-trip with the state it belongs to.
+
+### Read vs write mode
+
+`readOnly` is applied once at mount by pushing `EditorState.readOnly.of(true)` and `EditorView.editable.of(false)` into the base extensions. `highlightActiveLine` is omitted in this case. Both read and write modes use the same CodeMirror instance with the same mode-compartment extensions — decorations, image widgets, and wiki-link widgets all work in read-only mode. `<MarkdownPreview>` is simply `<MarkdownEditor readOnly ... />` wrapped in a `<div>` for layout; it accepts `content`, `images`, `wikiLinks`, and `baseDir` (used by the peek stack for plain `<a>` link resolution).
+
+### Host-local wiring: the `editor-bindings.ts` pattern
+
+A host is responsible for constructing the config objects that activate optional editor behaviors. Notes does this in `src/renderer/notes/editor-bindings.ts`, which exports three factory functions:
+
+- `makeImagePasteConfig(folder, campaignPath)` — returns an `ImagePasteConfig` with `onImagePaste` that saves the blob to `notes/{folder}/assets/pasted-*.ext` and returns a `notes-asset://` URL.
+- `makeDropLinkConfig()` — returns a `DropLinkConfig` that decodes the `application/x-last-gasp-note` MIME type from sidebar drags and produces either a `![…](notes-asset://…)` or `[[label|id]]` insert.
+- `makePeekWikiLinksConfig()` — returns the hover callbacks (`onHover`, `onHoverEnd`) that open/close the peek stack.
+
+The host passes these config objects as `imagePaste`, `dropLink`, and a spread into `wikiLinks` props. The shared editor never knows about campaign paths, sidebar MIME types, or the peek system.
+
+The event editor (`EventEditorModal.tsx`) follows the same approach with a simpler setup: no image paste, no drop-link, wiki-links wired inline with `suggestLinksForIndex`, `onOpenById`, peek hover callbacks, `knownIds`, and `entityLabelMap`. No `editor-bindings.ts` is needed when the config is short enough to build inline.
+
+### How state flows into the editor
+
+`knownIds` and `entityLabels` are React props on `WikiLinksHostConfig`, but they do **not** flow through React's prop update path in the usual way. After mount, the editor holds a stable CodeMirror view. When these props change (because the entity index updated), dedicated `useEffect` hooks dispatch `StateEffect`s directly onto the view:
+
+```ts
+view.dispatch({ effects: setKnownIds.of(wikiLinksConfig.knownIds) });
+view.dispatch({ effects: setEntityLabels.of(wikiLinksConfig.entityLabels) });
+```
+
+Inside the wiki-links extension, `knownIdsField` and `entityLabelMapField` are `StateField`s that update in response to those effects. The decoration `StateField` rebuilds whenever either effect arrives (`e.is(setKnownIds) || e.is(setEntityLabels)`). This means decoration rebuilds are O(doc) but happen only when the index actually changes — not on every keystroke.
+
+The same dispatch-based pattern applies to external content updates (file reloaded from disk) and mode toggles: all use `view.dispatch(...)` rather than remounting.
+
+### Key distinction
+
+The editor is a shared rendering primitive. Hosts are responsible for wiring behavior via config objects; they must not modify the editor. If you find yourself wanting to add host-specific logic inside `markdown-editor.tsx`, add a callback prop instead and implement the behavior in the host's `editor-bindings.ts` (or inline).
+
 ## Common pitfalls
 
 - **Don't put the campaign path or folder into the editor's props.** That's a notes-ism. Build the IO callback in the host and pass it as `imagePaste.onImagePaste`.

--- a/src/renderer/shared/markdown-editor/extensions/AGENTS.md
+++ b/src/renderer/shared/markdown-editor/extensions/AGENTS.md
@@ -1,0 +1,126 @@
+# Extensions — Wiki Links
+
+This directory contains CodeMirror 6 extensions for the shared markdown editor. This file documents the wiki-link subsystem specifically. See the parent `AGENTS.md` for the broader editor contract.
+
+## Wiki link syntax
+
+Two formats are supported:
+
+| Format | When to use |
+| --- | --- |
+| `[[id]]` | Let the display label be resolved from the entity index. |
+| `[[label\|id]]` | Override the display label locally. The local label always wins. |
+
+The `id` is a short alphanumeric entity key (e.g. `abc1`). IDs are trimmed of surrounding whitespace; an empty `id` after trimming causes the token to be silently skipped.
+
+## Parsing — `findWikiLinksInLine`
+
+`findWikiLinksInLine(text, lineStart)` scans a single line of text and returns every `ParsedWikiLink` found:
+
+```ts
+interface ParsedWikiLink {
+  from: number;      // absolute doc position of the opening [[
+  to: number;        // absolute doc position just after the closing ]]
+  id: string;        // trimmed entity id
+  label: string | null;  // trimmed local label, or null when format is [[id]]
+  labelFrom: number | null;
+  labelTo: number | null;
+}
+```
+
+The scanner is a simple index-based loop — no regex — finding `[[` then the nearest `]]`, splitting on the first `|` inside the body. All positions are offset by `lineStart` so callers can work in doc coordinates directly.
+
+## Decoration lifecycle
+
+`wikiLinks(config)` returns an `Extension` bundle. The core is a `StateField<DecorationSet>` that calls `buildDecorations(state, config)` whenever:
+
+- the document changes (`transaction.docChanged`)
+- the selection changes (`transaction.selection`) — needed to toggle raw vs. widget rendering for the cursor-is-inside case
+- a `setKnownIds` or `setEntityLabels` effect arrives
+
+### Widget rendering — `WikiLinkWidget`
+
+For every link whose range does **not** overlap the current selection, `buildDecorations` inserts a `Decoration.replace` wrapping a `WikiLinkWidget`. The widget renders a `<span>` with:
+
+- `class="cm-note-link"` (or `cm-note-link cm-note-link-broken` for a missing entity)
+- `data-note-id="{id}"` — used by peek and click handlers
+- `textContent` set via the **label resolution chain**:
+  1. Local label from `[[label|id]]` if present
+  2. Lookup in `entityLabelMapField` by id
+  3. Raw id as fallback
+
+When the cursor is inside the link range, the range gets a `Decoration.mark({ class: 'cm-wiki-link-raw' })` instead, exposing the raw source so the user can edit it. In `readOnly` mode the selection check is skipped and links always render as widgets.
+
+## StateFields
+
+### `knownIdsField` — broken-link detection
+
+Holds a `Set<string>` of all entity ids that currently exist. A link is marked broken when `knownIds.has(link.id)` is false **and** the set is non-empty. An empty set means "index not loaded yet — don't highlight anything as broken."
+
+Dispatch a `setKnownIds` effect to update it without rebuilding the editor:
+
+```ts
+view.dispatch({ effects: setKnownIds.of(new Set(['abc1', 'def2'])) });
+```
+
+### `entityLabelMapField` — label resolution
+
+Holds a `Map<string, string>` mapping entity id → display label. Used by `WikiLinkWidget` when no local label override is present.
+
+Dispatch a `setEntityLabels` effect to push a new map:
+
+```ts
+view.dispatch({ effects: setEntityLabels.of(new Map([['abc1', 'Alice the Wizard']])) });
+```
+
+Both StateFields replace their entire value on each matching effect — they do not merge.
+
+## Completions — `wikiLinkCompletions`
+
+Activated when `config.suggest` is provided. Matches the regex `/(?:\[\[|@)[^\]\n|@]*$/` at the cursor — so both `[[query` and `@query` trigger the completion menu (`@` is a shorthand alias).
+
+Flow:
+1. `parseTrigger` extracts the trigger prefix length (2 for `[[`, 1 for `@`) and the raw query string.
+2. `config.suggest(query)` is called (async); returns `WikiLinkSuggestion[]`.
+3. Each suggestion's `apply` callback calls `buildWikiLinkInsert`, which:
+   - For normal entities: inserts `[[id]]` (label-free format), absorbing a trailing `]]` if already present.
+   - For image assets (`suggestion.assetPath` set): inserts `![label](notes-asset://current/{assetPath})` instead.
+
+`config.suggest` is implemented in `src/renderer/shared/suggest-links.ts` (`suggestLinks`) which filters `EntityIndexEntry[]` by title or id substring match.
+
+## Keyboard bindings
+
+`wikiLinkEditKeymap` (highest precedence):
+
+- **Backspace** at the closing `]]` of a label-free `[[id]]` link: moves cursor to just after `[[` instead of deleting, preventing accidental destruction of the whole token.
+- **Ctrl-Enter** (or Cmd-Enter): opens the link under the cursor via `config.onOpen(id)`.
+
+**Cmd/Ctrl-click** on a rendered `.cm-note-link` span also calls `config.onOpen(id)`.
+
+## Peek integration
+
+Peek integrates at the DOM level — it does not depend on CodeMirror APIs.
+
+`src/renderer/peek/stack.ts` listens to `document` `mouseover`/`mouseout` events. When the hovered element is a `.cm-note-link` span, it reads `dataset.noteId` and calls `resolvePeekTarget(noteId, '', entityIndex)` from `src/renderer/peek/resolve.ts`. If a target is found, a peek window is scheduled to open after 150 ms (cancelled on mouse-out after 250 ms).
+
+The notes editor wires this up via `makePeekWikiLinksConfig()` in `editor-bindings.ts`, which supplies `onHover` → `openFromWikiLink` and `onHoverEnd` → `closeFromWikiLink` as `WikiLinksConfig` callbacks. These callbacks are the bridge between CodeMirror's `mouseover`/`mouseout` handlers (inside `makeWikiLinkPointerGuard`) and the peek stack.
+
+`resolvePeekTarget` accepts a bare id (no slashes, no protocol, no `.md` extension) and looks it up in the entity index, returning `{ path }` or `null` for unresolvable or asset entries.
+
+## Key files
+
+| File | Role |
+| --- | --- |
+| `extensions/wiki-links.ts` | Parser, `WikiLinkWidget`, StateFields (`knownIdsField`, `entityLabelMapField`), StateEffects (`setKnownIds`, `setEntityLabels`), completions, click/hover handlers |
+| `extensions/__tests__/wiki-links.test.ts` | Unit tests for parsing, decoration modes, label resolution, completion insertion, hover callbacks |
+| `src/renderer/shared/suggest-links.ts` | `suggestLinks(entityIndex, query)` — pure filter used as `config.suggest` |
+| `src/renderer/notes/editor-bindings.ts` | `makePeekWikiLinksConfig()` — wires `onHover`/`onHoverEnd` to peek stack; `makeDropLinkConfig()` — generates `[[label|id]]` inserts on sidebar drag-drop |
+| `src/renderer/peek/resolve.ts` | `resolvePeekTarget(href, baseDir, entityIndex)` — resolves a wiki-link id or plain href to a peekable file path |
+| `src/renderer/peek/stack.ts` | Peek open/close scheduling; `openFromWikiLink` / `closeFromWikiLink` consumed by `WikiLinksConfig` |
+
+## Common pitfalls
+
+- **`knownIds` empty ≠ all links valid.** Pass `undefined` (causes `wikiLinks.knownIds` to not dispatch `setKnownIds`) while the index is loading, not an empty `Set`. An empty `Set` suppresses broken-link highlighting entirely.
+- **Do not read entity labels from within the extension itself.** Labels flow in via `setEntityLabels` — the extension never imports from notes or the entity index directly.
+- **The completion always inserts `[[id]]`, not `[[label|id]]`.** Label resolution happens at render time via the StateField, so storing the label in the doc is unnecessary.
+- **Decoration rebuilds on selection change.** The raw-vs-widget switch needs selection tracking. This is intentional; don't remove the `transaction.selection` check from the StateField update guard.

--- a/src/renderer/theme/AGENTS.md
+++ b/src/renderer/theme/AGENTS.md
@@ -1,0 +1,119 @@
+# `src/renderer/theme/` — Theme System
+
+Single source of truth for every color in the app.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `dark-pathfinder.ts` | The one and only theme. Every color value lives here. |
+| `types.ts` | `Theme` interface plus helpers (`DeepPartial`, `WeekdayColors`, `KindColors`, `ColorPreset`). |
+| `provider.ts` | `ThemeProvider` singleton — reads `activeTheme`, applies CSS vars to `document.documentElement`. |
+| `index.ts` | Barrel — import everything from here, not from individual files. |
+
+## ThemeProvider API
+
+`ThemeProvider` is a module-level singleton. It is **not** a React context.
+
+```ts
+import { ThemeProvider } from 'src/renderer/theme';
+
+// Called once in main.tsx before React mounts — sets all CSS variables.
+ThemeProvider.init();
+
+// Read the active theme object anywhere (TypeScript / canvas / non-React code).
+const theme = ThemeProvider.get();
+
+// Override individual tokens. Deep-merges on top of darkPathfinder and re-applies CSS vars.
+ThemeProvider.set({ chrome: { accentGold: '#ffcc00' } });
+```
+
+`init()` is called in `main.tsx` before `ReactDOM.createRoot(...)`, so CSS variables are available before the first React render.
+
+## Theme sections (`Theme` interface)
+
+| Section | What it covers |
+|---------|---------------|
+| `chrome` | App-wide shell: backgrounds, surfaces, panels, text, accents, links, borders, danger. These are the tokens exposed as `--theme-*` CSS variables. |
+| `timeline` | Day-of-week colors (`days`), session band palette (`sessions[]`), event color presets (`eventColorPresets[]`). Used by timeline render and editor code, not in CSS variables. |
+| `notes` | Note-kind accent colors (`kinds.*`) exposed as `--kind-*` CSS variables; `savedIndicator` and `errorToast` exposed as `--notes-saved` / `--notes-error`. |
+| `editor` | CodeMirror-specific tokens (`foldPlaceholder`, `invalid`). Passed directly to the editor theme builder. |
+| `bootstrap` | Campaign-selector / pre-campaign screens only. A darker, higher-contrast palette for the app before a campaign is loaded. **Do not use `bootstrap` tokens inside campaign views.** |
+
+## Consuming colors
+
+### In CSS / stylesheets — prefer CSS variables
+
+```css
+/* chrome tokens */
+color: var(--theme-text-primary);
+background: var(--theme-surface);
+border-color: var(--theme-border);
+
+/* note-kind accent colors */
+color: var(--kind-npc);
+
+/* RGB variants (available for accent-gold, accent-warm, danger) */
+background: rgba(var(--theme-danger-rgb) / 0.15);
+```
+
+### In TypeScript / inline styles — use `ThemeProvider.get()`
+
+```ts
+const theme = ThemeProvider.get();
+style={{ color: theme.chrome.textPrimary }}
+
+// Pre-campaign / bootstrap screens:
+const bs = ThemeProvider.get().bootstrap;
+style={{ backgroundColor: bs.bg, color: bs.text }}
+
+// Timeline rendering (canvas / DOM):
+const weekdays = ThemeProvider.get().timeline.days;
+const sessionColor = ThemeProvider.get().timeline.sessions[0];
+```
+
+## CSS variable mapping
+
+`applyCssVars` (internal to `provider.ts`) maps `chrome.*` camelCase keys to `--theme-kebab-case` variables. The full set:
+
+```
+--theme-background       chrome.background
+--theme-surface          chrome.surface
+--theme-panel            chrome.panel
+--theme-panel-accent     chrome.panelAccent
+--theme-text-primary     chrome.textPrimary
+--theme-text-secondary   chrome.textSecondary
+--theme-text-muted       chrome.textMuted
+--theme-accent-gold      chrome.accentGold
+--theme-accent-warm      chrome.accentWarm
+--theme-accent           chrome.accent
+--theme-link             chrome.link
+--theme-border           chrome.border
+--theme-border-strong    chrome.borderStrong
+--theme-danger           chrome.danger
+--theme-danger-hover     chrome.dangerHover
+--theme-dotted-future    chrome.dottedFuture
+```
+
+RGB triplet variants (space-separated, suitable for `rgba()`):
+```
+--theme-accent-gold-rgb
+--theme-accent-warm-rgb
+--theme-danger-rgb
+```
+
+Note-kind and indicator variables:
+```
+--kind-pc  --kind-npc  --kind-location  --kind-faction
+--kind-plot  --kind-rule  --kind-session  --kind-misc
+--notes-saved
+--notes-error
+```
+
+## Don't
+
+- **Never hardcode a hex color.** If a value isn't in the theme, add it to `dark-pathfinder.ts` and the `Theme` interface.
+- **Don't use `bootstrap` tokens in campaign views.** `bootstrap` is for pre-load screens (campaign selector, setup) only.
+- **Don't import from sub-files directly.** Use the barrel: `import { ThemeProvider } from 'src/renderer/theme'`.
+- **Don't call `ThemeProvider.set()` in a render path.** It re-applies all CSS variables — call it only in response to explicit user action or at startup.
+- **Don't reach into `timeline` or `editor` tokens via CSS variables** — they are not exposed as CSS vars; read them through `ThemeProvider.get()` in TypeScript.

--- a/src/shared/AGENTS.md
+++ b/src/shared/AGENTS.md
@@ -1,0 +1,87 @@
+# `src/shared/` — Shared Utilities
+
+Cross-cutting helpers used by both the renderer and any future main-process code. No React, no IO.
+
+## Entity tags (system-generated tags)
+
+**Intent:** when a user links an entity (NPC, location, plot thread, etc.) inside an event body, the
+app auto-adds a filterable tag so every event connected to that entity can be found via tag
+filtering. These are called *system-generated tags* in user-facing copy — users do not need to know
+the word "entity".
+
+### Format
+
+```
+id:XXXX
+```
+
+`id:` prefix followed by a 4-character lowercase alphanumeric entity ID (e.g. `id:ab12`). The
+format is enforced by `/^id:[a-z0-9]{4}$/`.
+
+### Utility functions — `entity-tags.ts`
+
+| Function | Purpose |
+|---|---|
+| `isEntityTag(tag)` | Returns `true` if `tag` matches the `id:XXXX` format. |
+| `parseEntityTag(tag)` | Returns the 4-char ID, or `null` if not an entity tag. |
+| `formatEntityTag(id)` | Produces the canonical `id:XXXX` string from a bare ID. |
+| `isValidCustomTag(tag)` | Returns `true` only for user-entered tags — rejects anything matching `id:XXXX` or `sesh:*`. |
+| `resolveEntityTagLabel(raw, map)` | Looks up a display label from an entity-ID→label `Map`. Returns `{ display, isEntity }`. Falls back to the raw tag string if the ID is unknown or the map is absent. |
+| `extractWikiLinkIds(body)` | Scans a markdown body for `[[...]]` links, extracts valid 4-char entity IDs (handles `[[id]]` and `[[label\|id]]` forms), deduplicates. |
+| `syncEntityTags(existingTags, linkedEntityIds)` | Derives the full tag list for an event on save: strips all existing entity tags, keeps custom tags, then appends one `id:XXXX` tag per linked entity ID. Stale entity tags (whose link was removed) are discarded automatically. |
+
+### Session tags
+
+A second reserved namespace `sesh:*` is used for session tags. `isSessionTag` and `isValidCustomTag`
+both treat these as system-reserved so users cannot create or remove them via the tag UI.
+
+### Lifecycle: how entity tags are written
+
+On every save, `bufferToFrontmatter` in `src/renderer/timeline/event-editor/domain.ts`:
+
+1. Calls `extractWikiLinkIds(buf.body)` to find every entity referenced in the body.
+2. Passes the result to `syncEntityTags(customTags, linkedIds)`, which rebuilds the entity-tag
+   subset from scratch.
+3. Appends session tags (`buf.systemTags`) that are managed separately.
+4. Writes the combined list to `EventFrontmatter.tags`.
+
+### Validation guard
+
+`hasReservedTagPrefix` (also in `event-editor/domain.ts`) rejects user-typed tags that match any
+reserved prefix by calling `isValidCustomTag`. This prevents users from manually crafting `id:XXXX`
+entries in the tag input field.
+
+### Display: label resolution
+
+Entity tags are **never shown as raw `id:XXXX` strings** in the UI. Every display site receives an
+`entityTagLabelMap: Map<string, string>` (entity ID → human-readable name) and calls
+`resolveEntityTagLabel` to get the `display` string. If the entity is not in the map the raw tag
+is shown as a fallback.
+
+Display sites:
+- `src/renderer/timeline/render/cards.tsx` — tag chips on event cards; entity tags get CSS class
+  `entity-tag-chip--resolved` and their remove button is hidden (only custom tags are removable).
+- `src/renderer/timeline/filter/tag-editor.tsx` — tag filter picker; entity tags display their
+  resolved name and receive class `filter-tag-result--entity`.
+- `src/renderer/timeline/event-editor/domain.ts` — `buildTagChips` assembles the chip list shown
+  in the editor preview.
+
+## Key files
+
+| File | Role |
+|---|---|
+| `src/shared/entity-tags.ts` | All entity-tag and wiki-link utilities. No IO, no React. |
+| `src/shared/__tests__/entity-tags.test.ts` | Unit tests for every exported function. |
+| `src/renderer/timeline/event-editor/domain.ts` | `bufferToFrontmatter`, `hasReservedTagPrefix`, `buildTagChips` — consumes the utilities on save and in the editor. |
+| `src/renderer/timeline/filter/tag-editor.tsx` | Tag filter UI; resolves entity-tag labels for the picker. |
+| `src/renderer/timeline/render/cards.tsx` | Renders tag chips on timeline cards; resolves labels and suppresses remove button for entity tags. |
+| `src/renderer/timeline/data/types.ts` | `EventFrontmatter.tags?: string[]` — the storage field; entity, session, and custom tags all live here. |
+
+## Don't
+
+- Don't display raw `id:XXXX` strings to users — always pass through `resolveEntityTagLabel`.
+- Don't let users add entity-format tags via the tag input — `isValidCustomTag` is the guard.
+- Don't manually maintain entity tags — call `syncEntityTags` on save; it is the single source of
+  truth for which entity tags an event should have.
+- Don't put any IO or React imports in `entity-tags.ts` — it must stay pure so it can be used
+  anywhere.


### PR DESCRIPTION
## Description

Adds documentation and skills for the systems built in the Auto-Tagging and Label Management epic (#147), plus documentation for pre-existing systems that future agents need to understand.

### Details

**8 new/updated documentation files** (989 lines, zero code changes):

| File | Ticket | System Documented |
|------|--------|-------------------|
| `.claude/skills/add-loading-task/SKILL.md` | #166 | Skill: step-by-step recipe for adding a new campaign loading task |
| `src/main/AGENTS.md` | #167 | Entity index system, label override flow, delta events |
| `src/renderer/shared/markdown-editor/extensions/AGENTS.md` | #168 | Wiki-link extension: parsing, widgets, StateFields, completions, peek |
| `src/shared/AGENTS.md` | #169 | Entity tags (system-generated tags): format, sync, validation, rendering |
| `src/renderer/shared/markdown-editor/AGENTS.md` (updated) | #170 | Editor architecture: extension stack, read/write mode, host wiring |
| `src/renderer/theme/AGENTS.md` | #171 | Theme system: ThemeProvider, CSS variables, color usage |
| `src/renderer/components/AGENTS.md` | #172 | Footer portal pattern: slots, layout, how views inject buttons |
| `AGENTS.md` (root) | #173 | Campaign on-disk format: directory structure, file formats, ID system |

Closes #166, #167, #168, #169, #170, #171, #172, #173, #185

### Manual Test Cases

**New Behavior**
- [ ] `add-loading-task` skill appears in Claude Code's available skills list
- [ ] All AGENTS.md files are in the correct directories
- [ ] Documentation accurately describes the current codebase (spot-check 2-3 files)

**Regression Checks**
- [ ] All 9366 tests pass (verified locally)
- [ ] No production code changed — documentation only

https://claude.ai/code/session_01E6u4uUNgJD3HwLx5yPMJhL

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6u4uUNgJD3HwLx5yPMJhL)_