### PR TITLE
Document oversight:orchestrator and oversight:orchestrated labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ Before doing anything else, fetch both the **body** and the **labels** of the is
 | `oversight:none` | Sonnet plans inline.                                                             | No opus review required. |
 | `oversight:basic` | Sonnet plans inline.                                                             | Opus advisor reviews the diff before the PR is opened. |
 | `oversight:extended` | Spawn an Opus `Plan` subagent first and post its plan as a comment on the issue. | Opus advisor reviews the diff before the PR is opened. |
+| `oversight:orchestrator` | Fire up the `orchestrate` skill. All sub-tasks of this issue are taken into account and orchestrated together as a single coordinated effort. | The orchestrator handles review across sub-tasks before opening the PR. |
+| `oversight:orchestrated` | This issue is a sub-task being driven by an `oversight:orchestrator` parent. Oversight is provided by the orchestrator model itself — do not plan or open a PR independently. | Review is handled by the orchestrator. |
 | (no `oversight:*` label) | Treat as `oversight:basic`.                                                      | Treat as `oversight:basic`. |
 
 The ticket body may add **extra** reviewer criteria (e.g. "zero changes outside `./desktop/`"). It cannot waive the ones below.


### PR DESCRIPTION
## 📝 Description

**Issue(s):** _(none — workflow doc update requested in chat)_

Adds two new rows to the oversight-tier table in `CLAUDE.md` so the `orchestrate` skill has a documented home in the issue-driven workflow.

- `oversight:orchestrator` — issue should be handled end-to-end by the `orchestrate` skill, taking all sub-tasks into account.
- `oversight:orchestrated` — issue is a sub-task being driven by an `oversight:orchestrator` parent; the orchestrator provides oversight, so the sub-task doesn't plan or open a PR on its own.

---

## 🔍 Details

* **CLAUDE.md:** Added two rows to the oversight tier table, slotted between `oversight:extended` and the default fallback row.

---

## 🧪 Manual Test Cases

A human reviewer should verify and tick off the following scenarios

### 🚀 New Behavior
- [ ] Table renders correctly on GitHub (two new rows visible, columns aligned).
- [ ] Wording matches your intent for how each label should drive agent behaviour.

### 🛡️ Regression Checks
- [ ] Existing `oversight:none` / `basic` / `extended` rows are unchanged.
- [ ] The "(no `oversight:*` label)" fallback row is still present and still says "Treat as `oversight:basic`."


---
_Generated by [Claude Code](https://claude.ai/code/session_019M7jgRkCfQzEF8nENFEYRD)_