### PR TITLE
Clarify oversight:orchestrator, drop oversight:orchestrated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,7 @@ Before doing anything else, fetch both the **body** and the **labels** of the is
 | `oversight:none` | Sonnet plans inline.                                                             | No opus review required. |
 | `oversight:basic` | Sonnet plans inline.                                                             | Opus advisor reviews the diff before the PR is opened. |
 | `oversight:extended` | Spawn an Opus `Plan` subagent first and post its plan as a comment on the issue. | Opus advisor reviews the diff before the PR is opened. |
-| `oversight:orchestrator` | Fire up the `orchestrate` skill. All sub-tasks of this issue are taken into account and orchestrated together as a single coordinated effort. | The orchestrator handles review across sub-tasks before opening the PR. |
-| `oversight:orchestrated` | This issue is a sub-task being driven by an `oversight:orchestrator` parent. Oversight is provided by the orchestrator model itself — do not plan or open a PR independently. | Review is handled by the orchestrator. |
+| `oversight:orchestrator` | Fire up the `orchestrate` skill. The work for this ticket is split across parallel sub-agents (in separate worktrees) that each handle a slice of the same deliverable. | The orchestrator reviews each sub-agent's output, resolves conflicts, merges into one base branch, and opens a single PR. |
 | (no `oversight:*` label) | Treat as `oversight:basic`.                                                      | Treat as `oversight:basic`. |
 
 The ticket body may add **extra** reviewer criteria (e.g. "zero changes outside `./desktop/`"). It cannot waive the ones below.


### PR DESCRIPTION
## 📝 Description

**Issue(s):** _(none — workflow doc fix-up requested in chat)_

Clarifies what `oversight:orchestrator` actually means. The earlier wording (PR #207) misrepresented the skill as a multi-ticket coordinator. In reality `orchestrate` parallelises work *within a single ticket* across sub-agents in worktrees, then merges into one PR.

- Drops the `oversight:orchestrated` row entirely — that label was based on the misunderstanding that orchestrate spans multiple tickets, so there's no "I'm being orchestrated by a parent" state to label.
- Rewords the `oversight:orchestrator` row to describe the real mechanism: parallel sub-agents, merged into one base branch, one PR.

---

## 🔍 Details

* **CLAUDE.md:** Removed the `oversight:orchestrated` row. Rewrote the `oversight:orchestrator` row to describe parallel sub-agents within a single deliverable.

---

## 🧪 Manual Test Cases

A human reviewer should verify and tick off the following scenarios

### 🚀 New Behavior
- [ ] Table renders correctly on GitHub (one new row in place of the previous two, columns aligned).
- [ ] Reworded `orchestrator` description matches your mental model of the skill.

### 🛡️ Regression Checks
- [ ] `oversight:none` / `basic` / `extended` rows are unchanged.
- [ ] The "(no `oversight:*` label)" fallback row is still present and still says "Treat as `oversight:basic`."


---
_Generated by [Claude Code](https://claude.ai/code/session_019M7jgRkCfQzEF8nENFEYRD)_