### PR TITLE
Event title and filename driven by H1 heading and full datetime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,10 @@ Before doing anything else, fetch both the **body** and the **labels** of the is
 | `oversight:orchestrator` | Fire up the `orchestrate` skill. The work for this ticket is split across parallel sub-agents (in separate worktrees) that each handle a slice of the same deliverable. | The orchestrator reviews each sub-agent's output, resolves conflicts, merges into one base branch, and opens a single PR. |
 | (no `oversight:*` label) | Treat as `oversight:basic`.                                                      | Treat as `oversight:basic`. |
 
+> **Orchestration guardrails (enforced every time):**
+> 1. **Opus only.** The `orchestrate` skill must run on an Opus-family model. If the current model is not Opus, stop immediately and ask: "I'm running as `<model>`. Orchestration is designed for Opus — did you mean to switch?" Do not proceed without explicit confirmation.
+> 2. **Plan first, always.** Every orchestration must begin in plan mode. If the user triggers orchestration without a plan in place, enter plan mode before spawning any sub-agents or writing any code. Never skip the planning phase, even for small orchestrations.
+
 The ticket body may add **extra** reviewer criteria (e.g. "zero changes outside `./desktop/`"). It cannot waive the ones below.
 
 !Important! When asking a sub-agent to plan for you do not do research first, let it do its own research, else you pollute its views.

--- a/src/main/__tests__/timeline-update-event.test.ts
+++ b/src/main/__tests__/timeline-update-event.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import matter from 'gray-matter';
+import { createEventHandler, updateEventHandler } from '../timelineIpcHandlers.js';
+import type { EventFrontmatter } from '../../renderer/timeline/data/types.js';
+
+const tmpDirs: string[] = [];
+
+function campaign(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tti-update-event-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tmpDirs.length = 0;
+});
+
+/** Helper: create an event file directly on disk and return its mtime. */
+function seedEvent(
+  dir: string,
+  filename: string,
+  frontmatter: EventFrontmatter,
+  body: string,
+): string {
+  const result = createEventHandler(dir, filename, frontmatter, body);
+  if (!result.ok) throw new Error('seedEvent: createEventHandler failed');
+  return result.event.lastModified;
+}
+
+const BASE_FM: EventFrontmatter = { title: 'Test Event', date: '4707-10-01' };
+
+describe('parseEventFile — title source', () => {
+  it('title comes from body H1 via parseEventFile', () => {
+    const dir = campaign();
+    const body = '# My H1\n\nSome content.';
+    const result = createEventHandler(
+      dir,
+      '4707-10-01-test.md',
+      { ...BASE_FM, title: 'Other' },
+      body,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.event.event.title).toBe('My H1');
+  });
+
+  it('title falls back to frontmatter when no H1', () => {
+    const dir = campaign();
+    const body = 'No heading here.';
+    const result = createEventHandler(
+      dir,
+      '4707-10-01-test.md',
+      { ...BASE_FM, title: 'Fallback' },
+      body,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.event.event.title).toBe('Fallback');
+  });
+});
+
+describe('listEvents — H1 title extraction', () => {
+  it('H1 wins over frontmatter title when reading created files', () => {
+    const dir = campaign();
+    // Event with H1
+    const r1 = createEventHandler(
+      dir,
+      '4707-10-01-h1.md',
+      { ...BASE_FM, title: 'FM Title' },
+      '# H1 Title\nContent.',
+    );
+    expect(r1.ok).toBe(true);
+    if (!r1.ok) throw new Error('unreachable');
+    expect(r1.event.event.title).toBe('H1 Title');
+
+    // Event without H1
+    const r2 = createEventHandler(
+      dir,
+      '4707-10-02-fm.md',
+      { ...BASE_FM, title: 'FM Only' },
+      'No heading.',
+    );
+    expect(r2.ok).toBe(true);
+    if (!r2.ok) throw new Error('unreachable');
+    expect(r2.event.event.title).toBe('FM Only');
+  });
+});
+
+describe('updateEventHandler', () => {
+  it('with no desiredFilename writes same file', () => {
+    const dir = campaign();
+    const filename = '4707-10-01-test.md';
+    const mtime = seedEvent(dir, filename, BASE_FM, 'Original body.');
+
+    const result = updateEventHandler(
+      dir,
+      filename,
+      { ...BASE_FM, title: 'Updated' },
+      'Updated body.',
+      mtime,
+    );
+
+    expect('event' in result).toBe(true);
+    if (!('event' in result)) throw new Error('unreachable');
+    expect(result.event.filename).toBe(filename);
+
+    const filePath = path.join(dir, 'timeline', filename);
+    expect(fs.existsSync(filePath)).toBe(true);
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const { data } = matter(raw);
+    expect(data.title).toBe('Updated');
+  });
+
+  it('with same desiredFilename as current does no rename', () => {
+    const dir = campaign();
+    const filename = '4707-10-01-test.md';
+    const mtime = seedEvent(dir, filename, BASE_FM, 'Body.');
+
+    const result = updateEventHandler(dir, filename, BASE_FM, 'Body.', mtime, filename);
+
+    expect('event' in result).toBe(true);
+    if (!('event' in result)) throw new Error('unreachable');
+    expect(result.event.filename).toBe(filename);
+
+    // Only the one original file should exist
+    const timelineDir = path.join(dir, 'timeline');
+    const files = fs.readdirSync(timelineDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toBe(filename);
+  });
+
+  it('with new free desiredFilename renames file and returns new filename', () => {
+    const dir = campaign();
+    const oldFilename = '4707-10-01-old.md';
+    const newFilename = '4707-10-01-new.md';
+    const mtime = seedEvent(dir, oldFilename, BASE_FM, 'Body.');
+
+    const result = updateEventHandler(dir, oldFilename, BASE_FM, 'Body.', mtime, newFilename);
+
+    expect('event' in result).toBe(true);
+    if (!('event' in result)) throw new Error('unreachable');
+    expect(result.event.filename).toBe(newFilename);
+
+    const timelineDir = path.join(dir, 'timeline');
+    expect(fs.existsSync(path.join(timelineDir, oldFilename))).toBe(false);
+    expect(fs.existsSync(path.join(timelineDir, newFilename))).toBe(true);
+  });
+
+  it('with taken desiredFilename returns conflict filename-taken', () => {
+    const dir = campaign();
+    const firstFilename = '4707-10-01-first.md';
+    const secondFilename = '4707-10-02-second.md';
+    const mtime = seedEvent(dir, firstFilename, BASE_FM, 'First.');
+    seedEvent(dir, secondFilename, { ...BASE_FM, date: '4707-10-02' }, 'Second.');
+
+    const result = updateEventHandler(dir, firstFilename, BASE_FM, 'First.', mtime, secondFilename);
+
+    expect(result).toEqual({ conflict: true, reason: 'filename-taken', filename: secondFilename });
+  });
+
+  it('with stale mtime returns conflict without reason', () => {
+    const dir = campaign();
+    const filename = '4707-10-01-test.md';
+    seedEvent(dir, filename, BASE_FM, 'Body.');
+
+    const result = updateEventHandler(dir, filename, BASE_FM, 'Body.', '1970-01-01T00:00:00.000Z');
+
+    expect(result).toEqual({ conflict: true });
+    expect('reason' in result && result.reason).toBeFalsy();
+  });
+
+  it('with unsafe desiredFilename throws', () => {
+    const dir = campaign();
+    const filename = '4707-10-01-test.md';
+    const mtime = seedEvent(dir, filename, BASE_FM, 'Body.');
+
+    expect(() => {
+      updateEventHandler(dir, filename, BASE_FM, 'Body.', mtime, '../escape.md');
+    }).toThrow();
+  });
+});

--- a/src/main/timelineIpcHandlers.ts
+++ b/src/main/timelineIpcHandlers.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import matter from 'gray-matter';
 import yaml from 'js-yaml';
 import { generateShortId } from '../shared/ids.js';
+import { extractH1 } from '../shared/frontmatter.js';
 
 import type {
   CreateEventResult,
@@ -71,9 +72,10 @@ function parseEventFile(
   const raw = fs.readFileSync(filePath, 'utf-8');
   const { data, content: body } = matter(raw, MATTER_OPTS);
   const lastModified = fileMtime(filePath);
+  const h1 = extractH1(body.trimStart());
   const event: Event = {
     filename,
-    title: String(data.title ?? ''),
+    title: h1 ?? String(data.title ?? ''),
     date: String(data.date ?? ''),
     tags: Array.isArray(data.tags) ? data.tags : [],
     ...(data.color !== undefined ? { color: String(data.color) } : {}),
@@ -89,6 +91,56 @@ function parseEventFile(
     mtime: lastModified,
   };
   return { event, lastModified };
+}
+
+export function updateEventHandler(
+  campaignPath: string,
+  filename: string,
+  frontmatter: EventFrontmatter,
+  body: string,
+  ifUnmodifiedSince: string,
+  desiredFilename?: string,
+): EventWithMtime | ConflictResult {
+  const dir = eventsDir(campaignPath);
+  assertSafeFilename(dir, filename);
+  const filePath = path.join(dir, filename);
+  const currentMtime = fileMtime(filePath);
+  if (currentMtime !== ifUnmodifiedSince) return { conflict: true };
+
+  // Preserve frontmatter fields the editor doesn't manage.
+  const editorFields = new Set([
+    'title',
+    'date',
+    'tags',
+    'color',
+    'id',
+    'tagLabelOverride',
+    'linkLabelOverride',
+  ]);
+  const existing = matter(fs.readFileSync(filePath, 'utf-8'), MATTER_OPTS).data;
+  const preserved: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(existing)) {
+    if (!editorFields.has(key)) preserved[key] = value;
+  }
+  const content = matter.stringify(
+    body,
+    { ...preserved, ...(frontmatter as unknown as Record<string, unknown>) },
+    MATTER_OPTS,
+  );
+  fs.writeFileSync(filePath, content, 'utf-8');
+
+  // Optional rename: only if a different desired filename was supplied.
+  if (desiredFilename && desiredFilename !== filename) {
+    assertSafeFilename(dir, desiredFilename);
+    const newFilePath = path.join(dir, desiredFilename);
+    if (fs.existsSync(newFilePath)) {
+      return { conflict: true, reason: 'filename-taken', filename: desiredFilename };
+    }
+    fs.renameSync(path.join(dir, filename), newFilePath);
+    return parseEventFile(newFilePath, desiredFilename);
+  }
+
+  return parseEventFile(filePath, filename);
 }
 
 export function createEventHandler(
@@ -131,10 +183,11 @@ export function registerTimelineIpcHandlers() {
       .map((filename) => {
         const filePath = path.join(dir, filename);
         const raw = fs.readFileSync(filePath, 'utf-8');
-        const { data } = matter(raw, MATTER_OPTS);
+        const { data, content: body } = matter(raw, MATTER_OPTS);
+        const h1 = extractH1(body.trimStart());
         return {
           filename,
-          title: String(data.title ?? ''),
+          title: h1 ?? String(data.title ?? ''),
           date: String(data.date ?? ''),
           tags: Array.isArray(data.tags) ? data.tags : [],
           ...(data.id !== undefined ? { id: String(data.id) } : {}),
@@ -163,36 +216,16 @@ export function registerTimelineIpcHandlers() {
       frontmatter: EventFrontmatter,
       body: string,
       ifUnmodifiedSince: string,
-    ): EventWithMtime | ConflictResult => {
-      const dir = eventsDir(campaignPath);
-      assertSafeFilename(dir, filename);
-      const filePath = path.join(dir, filename);
-      const currentMtime = fileMtime(filePath);
-      if (currentMtime !== ifUnmodifiedSince) return { conflict: true };
-      // Preserve frontmatter fields the editor doesn't manage (e.g. label overrides).
-      // Only fields that bufferToFrontmatter can produce are considered editor-owned.
-      const editorFields = new Set([
-        'title',
-        'date',
-        'tags',
-        'color',
-        'id',
-        'tagLabelOverride',
-        'linkLabelOverride',
-      ]);
-      const existing = matter(fs.readFileSync(filePath, 'utf-8'), MATTER_OPTS).data;
-      const preserved: Record<string, unknown> = {};
-      for (const [key, value] of Object.entries(existing)) {
-        if (!editorFields.has(key)) preserved[key] = value;
-      }
-      const content = matter.stringify(
+      desiredFilename?: string,
+    ) =>
+      updateEventHandler(
+        campaignPath,
+        filename,
+        frontmatter,
         body,
-        { ...preserved, ...(frontmatter as unknown as Record<string, unknown>) },
-        MATTER_OPTS,
-      );
-      fs.writeFileSync(filePath, content, 'utf-8');
-      return parseEventFile(filePath, filename);
-    },
+        ifUnmodifiedSince,
+        desiredFilename,
+      ),
   );
 
   ipcMain.handle(

--- a/src/preload/index.cts
+++ b/src/preload/index.cts
@@ -60,6 +60,7 @@ contextBridge.exposeInMainWorld('fsApi', {
     frontmatter: unknown,
     body: string,
     ifUnmodifiedSince: string,
+    desiredFilename?: string,
   ) =>
     ipcRenderer.invoke(
       'timeline:updateEvent',
@@ -68,6 +69,7 @@ contextBridge.exposeInMainWorld('fsApi', {
       frontmatter,
       body,
       ifUnmodifiedSince,
+      desiredFilename,
     ),
   timelineDeleteEvent: (campaignPath: string, filename: string, ifUnmodifiedSince: string) =>
     ipcRenderer.invoke('timeline:deleteEvent', campaignPath, filename, ifUnmodifiedSince),

--- a/src/renderer/timeline/data/ports.ts
+++ b/src/renderer/timeline/data/ports.ts
@@ -46,6 +46,7 @@ export const timelinePort = {
     frontmatter: EventFrontmatter,
     body: string,
     ifUnmodifiedSince: string,
+    desiredFilename?: string,
   ): Promise<EventWithMtime> {
     const result = await window.fsApi.timelineUpdateEvent(
       campaignPath,
@@ -53,6 +54,7 @@ export const timelinePort = {
       frontmatter,
       body,
       ifUnmodifiedSince,
+      desiredFilename,
     );
     assertNotConflict(result);
     return result;

--- a/src/renderer/timeline/data/ports.ts
+++ b/src/renderer/timeline/data/ports.ts
@@ -16,6 +16,17 @@ export class ConflictError extends Error {
   }
 }
 
+export class FilenameConflictError extends Error {
+  readonly takenFilename: string;
+  constructor(filename: string) {
+    super(
+      `Filename "${filename}" is already in use — the date + first H1 combination must be unique.`,
+    );
+    this.name = 'FilenameConflictError';
+    this.takenFilename = filename;
+  }
+}
+
 function assertNotConflict<T>(result: T | ConflictResult): asserts result is T {
   if (result !== null && typeof result === 'object' && 'conflict' in result) {
     throw new ConflictError();
@@ -56,8 +67,13 @@ export const timelinePort = {
       ifUnmodifiedSince,
       desiredFilename,
     );
-    assertNotConflict(result);
-    return result;
+    if (result !== null && typeof result === 'object' && 'conflict' in result) {
+      if (result.reason === 'filename-taken') {
+        throw new FilenameConflictError(result.filename);
+      }
+      throw new ConflictError();
+    }
+    return result as EventWithMtime;
   },
 
   async deleteEvent(

--- a/src/renderer/timeline/data/types.ts
+++ b/src/renderer/timeline/data/types.ts
@@ -44,7 +44,9 @@ export interface Session {
   notes?: string;
 }
 
-export type ConflictResult = { conflict: true };
+export type ConflictResult =
+  | { conflict: true; reason?: undefined } // mtime conflict (existing behaviour)
+  | { conflict: true; reason: 'filename-taken'; filename: string }; // desired filename already exists
 
 export interface EventWithMtime {
   event: Event;

--- a/src/renderer/timeline/event-editor/EventEditorModal.tsx
+++ b/src/renderer/timeline/event-editor/EventEditorModal.tsx
@@ -10,6 +10,7 @@ import {
   emptyBuffer,
   bufferFromEvent,
   bufferToFrontmatter,
+  effectiveTitle,
   validateBuffer,
   deriveFilename,
   getColorPresetValue,
@@ -425,6 +426,9 @@ export function EventEditorModal({
   }, [mode, buffer.title, doDelete]);
 
   const colorPresetValue = getColorPresetValue(buffer.color);
+  // Placeholder for the override fields: the live effective title (body H1,
+  // falling back to the title field), so it tracks the H1 as the user types.
+  const titlePlaceholder = effectiveTitle(buffer) || 'event title';
   const isEditMode = mode.kind === 'edit';
   const isBusy = saveState === 'saving' || saveState === 'saved';
 
@@ -540,7 +544,7 @@ export function EventEditorModal({
                     className="event-editor-input"
                     value={buffer.linkLabelOverride}
                     onChange={(e) => updateBuffer({ linkLabelOverride: e.target.value })}
-                    placeholder={buffer.title || 'event title'}
+                    placeholder={titlePlaceholder}
                     autoComplete="off"
                   />
                 </label>
@@ -552,7 +556,7 @@ export function EventEditorModal({
                     className="event-editor-input"
                     value={buffer.tagLabelOverride}
                     onChange={(e) => updateBuffer({ tagLabelOverride: e.target.value })}
-                    placeholder={buffer.title || 'event title'}
+                    placeholder={titlePlaceholder}
                     autoComplete="off"
                   />
                 </label>

--- a/src/renderer/timeline/event-editor/EventEditorModal.tsx
+++ b/src/renderer/timeline/event-editor/EventEditorModal.tsx
@@ -4,7 +4,7 @@ import { MarkdownEditor, FormatToolbar } from '../../shared/markdown-editor';
 import { suggestLinks } from '../../shared/suggest-links';
 import { FooterPortal } from '../../components/footer-portal';
 import { openFromWikiLink, closeFromWikiLink } from '../../peek/stack';
-import { timelinePort, ConflictError } from '../data/ports';
+import { timelinePort, ConflictError, FilenameConflictError } from '../data/ports';
 import { notesData } from '../../notes/data';
 import {
   emptyBuffer,
@@ -103,6 +103,9 @@ export function EventEditorModal({
   const [saveState, setSaveState] = useState<SaveState>('clean');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [conflictPending, setConflictPending] = useState<ConflictPending | null>(null);
+  const [currentFilename, setCurrentFilename] = useState<string>(
+    mode.kind === 'edit' ? mode.filename : '',
+  );
   const [entityIndex, setEntityIndex] = useState<
     Awaited<ReturnType<typeof notesData.getEntityIndex>>
   >([]);
@@ -217,13 +220,17 @@ export function EventEditorModal({
         let result;
         // After the first auto-save in create mode, filenameRef is set — update from then on.
         if (filenameRef.current !== null) {
+          const desiredFilename = deriveFilename(current);
           result = await timelinePort.updateEvent(
             campaignPath,
             filenameRef.current,
             frontmatter,
             current.body,
             mtime!,
+            desiredFilename,
           );
+          filenameRef.current = result.event.filename;
+          setCurrentFilename(result.event.filename);
         } else {
           const filename = deriveFilename(current);
           result = await timelinePort.createEvent(
@@ -233,6 +240,7 @@ export function EventEditorModal({
             current.body,
           );
           filenameRef.current = result.event.filename;
+          setCurrentFilename(result.event.filename ?? '');
         }
         lastModifiedRef.current = result.lastModified;
         setConflictPending(null);
@@ -255,6 +263,11 @@ export function EventEditorModal({
           );
         }
       } catch (err) {
+        if (err instanceof FilenameConflictError) {
+          setSaveState('error');
+          setErrorMessage(err.message);
+          return;
+        }
         if (err instanceof ConflictError) {
           setSaveState('dirty');
           // Auto-save conflict: silently revert so user can resolve manually.
@@ -355,9 +368,9 @@ export function EventEditorModal({
       const mtime = overrideMtime ?? lastModifiedRef.current;
       setSaveState('saving');
       try {
-        await timelinePort.deleteEvent(campaignPath, mode.filename, mtime!);
+        await timelinePort.deleteEvent(campaignPath, filenameRef.current ?? mode.filename, mtime!);
         setConflictPending(null);
-        onDeleted(mode.filename);
+        onDeleted(filenameRef.current ?? mode.filename);
       } catch (err) {
         if (err instanceof ConflictError) {
           setSaveState('dirty');
@@ -458,7 +471,7 @@ export function EventEditorModal({
           {/* Header */}
           <div className="event-editor-header">
             <h2 className="event-editor-title">
-              {isEditMode ? `Edit: ${mode.filename}` : 'New event'}
+              {isEditMode ? `Edit: ${currentFilename || mode.filename}` : 'New event'}
             </h2>
             <div className={`event-editor-save-status event-editor-save-status--${saveState}`}>
               {saveState === 'dirty'

--- a/src/renderer/timeline/event-editor/__tests__/domain.test.ts
+++ b/src/renderer/timeline/event-editor/__tests__/domain.test.ts
@@ -3,6 +3,7 @@ import {
   emptyBuffer,
   bufferFromEvent,
   bufferToFrontmatter,
+  effectiveTitle,
   validateBuffer,
   deriveFilename,
   getColorPresetValue,
@@ -315,6 +316,36 @@ describe('bufferToFrontmatter', () => {
     expect(restored.tagsText.split(', ').sort()).toEqual(original.tagsText.split(', ').sort());
     expect(restored.tagLabelOverride).toBe(original.tagLabelOverride);
     expect(restored.linkLabelOverride).toBe(original.linkLabelOverride);
+  });
+});
+
+// ---- effectiveTitle ----
+
+describe('effectiveTitle', () => {
+  it('prefers the body H1 over the title field', () => {
+    expect(effectiveTitle(buf({ title: 'Old Title', body: '# New Heading\nText' }))).toBe(
+      'New Heading',
+    );
+  });
+
+  it('falls back to the title field when the body has no H1', () => {
+    expect(effectiveTitle(buf({ title: 'Just Title', body: 'No heading here.' }))).toBe(
+      'Just Title',
+    );
+  });
+
+  it('tracks the H1 as it changes, ignoring a stale title field', () => {
+    expect(
+      effectiveTitle(buf({ title: 'Walking up the mountain', body: '# Walking up the mountains' })),
+    ).toBe('Walking up the mountains');
+  });
+
+  it('trims surrounding whitespace from the H1', () => {
+    expect(effectiveTitle(buf({ title: '', body: '#   Spaced Out   \nBody' }))).toBe('Spaced Out');
+  });
+
+  it('returns an empty string when there is no H1 and no title', () => {
+    expect(effectiveTitle(buf({ title: '', body: 'plain text' }))).toBe('');
   });
 });
 

--- a/src/renderer/timeline/event-editor/__tests__/domain.test.ts
+++ b/src/renderer/timeline/event-editor/__tests__/domain.test.ts
@@ -203,6 +203,16 @@ describe('bufferToFrontmatter', () => {
     expect(fm.date).toBe('4726-05-04');
   });
 
+  it('sets frontmatter title from body H1 when present', () => {
+    const fm = bufferToFrontmatter(buf({ title: 'Old Title', body: '# H1 Title\nContent.' }));
+    expect(fm.title).toBe('H1 Title');
+  });
+
+  it('falls back to buf.title when body has no H1', () => {
+    const fm = bufferToFrontmatter(buf({ title: 'Buf Title', body: 'No heading.' }));
+    expect(fm.title).toBe('Buf Title');
+  });
+
   it('includes tagLabelOverride when set', () => {
     const fm = bufferToFrontmatter(buf({ tagLabelOverride: 'Custom Tag' }));
     expect(fm.tagLabelOverride).toBe('Custom Tag');

--- a/src/renderer/timeline/event-editor/__tests__/domain.test.ts
+++ b/src/renderer/timeline/event-editor/__tests__/domain.test.ts
@@ -478,37 +478,59 @@ describe('validateBuffer', () => {
 // ---- deriveFilename ----
 
 describe('deriveFilename', () => {
-  it('derives slug from title and date prefix', () => {
-    expect(deriveFilename(buf({ title: 'The Big Heist', date: '4726-05-04T09:30' }))).toBe(
-      '4726-05-04-the-big-heist.md',
+  it('uses H1 from body as slug when present', () => {
+    expect(
+      deriveFilename(
+        buf({ title: 'Old Title', body: '# The Big Heist\nSome text', date: '4726-05-04' }),
+      ),
+    ).toBe('4726-05-04-the-big-heist.md');
+  });
+
+  it('falls back to title when body has no H1', () => {
+    expect(
+      deriveFilename(buf({ title: 'The Big Heist', body: 'Just prose', date: '4726-05-04' })),
+    ).toBe('4726-05-04-the-big-heist.md');
+  });
+
+  it('uses "event" fallback when body has no H1 and title is blank', () => {
+    expect(deriveFilename(buf({ title: '', body: '', date: '4726-05-04' }))).toBe(
+      '4726-05-04-event.md',
     );
   });
 
-  it('strips apostrophes from title', () => {
-    expect(deriveFilename(buf({ title: "It's Time", date: '4726-05-04' }))).toBe(
+  it('includes full datetime (colons stripped) when date has time component', () => {
+    expect(deriveFilename(buf({ title: 'Battle', body: '', date: '4726-05-04T09:30' }))).toBe(
+      '4726-05-04T0930-battle.md',
+    );
+  });
+
+  it('uses date-only prefix when date has no time component', () => {
+    expect(deriveFilename(buf({ title: 'Battle', body: '', date: '4726-05-04' }))).toBe(
+      '4726-05-04-battle.md',
+    );
+  });
+
+  it('strips apostrophes from H1', () => {
+    expect(deriveFilename(buf({ title: '', body: "# It's Time\n", date: '4726-05-04' }))).toBe(
       '4726-05-04-its-time.md',
     );
   });
 
-  it('uses "event" fallback when title is blank', () => {
-    expect(deriveFilename(buf({ title: '', date: '4726-05-04' }))).toBe('4726-05-04-event.md');
-  });
-
   it('truncates slug at 60 characters', () => {
-    const longTitle = 'a'.repeat(80);
-    const filename = deriveFilename(buf({ title: longTitle, date: '4726-05-04' }));
+    const longH1 = '# ' + 'a'.repeat(80);
+    const filename = deriveFilename(buf({ title: '', body: longH1, date: '4726-05-04' }));
     const slug = filename.replace('4726-05-04-', '').replace('.md', '');
     expect(slug.length).toBeLessThanOrEqual(60);
   });
 
   it('replaces non-alphanumeric runs with single dash', () => {
-    expect(deriveFilename(buf({ title: 'Battle!!! At Dawn', date: '4726-01-01' }))).toBe(
-      '4726-01-01-battle-at-dawn.md',
-    );
+    expect(
+      deriveFilename(buf({ title: '', body: '# Battle!!! At Dawn', date: '4726-01-01' })),
+    ).toBe('4726-01-01-battle-at-dawn.md');
   });
 
   it('strips leading/trailing dashes from slug', () => {
-    expect(deriveFilename(buf({ title: '---Test---', date: '4726-01-01' }))).toBe(
+    expect(deriveFilename(buf({ title: '', body: '# ---Test---', date: '4726-01-01' }))).toBe(
       '4726-01-01-test.md',
     );
   });

--- a/src/renderer/timeline/event-editor/domain.ts
+++ b/src/renderer/timeline/event-editor/domain.ts
@@ -82,13 +82,24 @@ export function removeTagFromText(currentText: string, tag: string): string {
     .join(', ');
 }
 
+/**
+ * The title that drives display, links, and tags: the body's first H1 if
+ * present, otherwise the buffer's title field. Trimmed. This is the single
+ * source of truth the editor should show for the effective title — the H1
+ * wins so the override placeholders and saved frontmatter stay in sync with
+ * what the user actually typed in the body.
+ */
+export function effectiveTitle(buf: EditorBuffer): string {
+  return (extractH1(buf.body) ?? buf.title).trim();
+}
+
 export function bufferToFrontmatter(buf: EditorBuffer): EventFrontmatter {
   const tags = parseTagsText(buf.tagsText).filter(isValidCustomTag);
   const linkedIds = extractWikiLinkIds(buf.body);
   const syncedTags = syncEntityTags(tags, linkedIds);
   const allTags = [...syncedTags, ...buf.systemTags];
   const fm: EventFrontmatter = {
-    title: (extractH1(buf.body) ?? buf.title).trim(),
+    title: effectiveTitle(buf),
     date: buf.date.trim(),
   };
   if (allTags.length > 0) fm.tags = allTags;

--- a/src/renderer/timeline/event-editor/domain.ts
+++ b/src/renderer/timeline/event-editor/domain.ts
@@ -88,7 +88,7 @@ export function bufferToFrontmatter(buf: EditorBuffer): EventFrontmatter {
   const syncedTags = syncEntityTags(tags, linkedIds);
   const allTags = [...syncedTags, ...buf.systemTags];
   const fm: EventFrontmatter = {
-    title: buf.title.trim(),
+    title: (extractH1(buf.body) ?? buf.title).trim(),
     date: buf.date.trim(),
   };
   if (allTags.length > 0) fm.tags = allTags;

--- a/src/renderer/timeline/event-editor/domain.ts
+++ b/src/renderer/timeline/event-editor/domain.ts
@@ -9,6 +9,7 @@ import {
   formatEntityTag,
   resolveEntityTagLabel,
 } from '../../../shared/entity-tags';
+import { extractH1 } from '../../../shared/frontmatter';
 
 export interface EditorBuffer {
   title: string;
@@ -118,10 +119,24 @@ function slugify(s: string): string {
     .slice(0, 60);
 }
 
+function deriveFilenameDatePart(date: string): string {
+  const trimmed = date.trim();
+  const tIdx = trimmed.indexOf('T');
+  if (tIdx >= 0) {
+    const datePart = trimmed.slice(0, tIdx);
+    const timePart = trimmed.slice(tIdx + 1).replace(/:/g, '');
+    if (timePart) return `${datePart}T${timePart}`;
+    return datePart.slice(0, 10) || 'event';
+  }
+  return trimmed.slice(0, 10) || 'event';
+}
+
 export function deriveFilename(buf: EditorBuffer): string {
-  const dateOnly = buf.date.trim().slice(0, 10);
-  const slug = slugify(buf.title);
-  return `${dateOnly}-${slug || 'event'}.md`;
+  const h1 = extractH1(buf.body);
+  const titleToSlug = h1 ?? buf.title;
+  const slug = slugify(titleToSlug);
+  const datePart = deriveFilenameDatePart(buf.date);
+  return `${datePart}-${slug || 'event'}.md`;
 }
 
 /** Returns the <select> value for the color field (or '__custom__' for non-preset hex). */

--- a/src/renderer/views/timeline/timeline-view.tsx
+++ b/src/renderer/views/timeline/timeline-view.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { timelinePort, ConflictError } from '../../timeline/data/ports';
+import { timelinePort, ConflictError, FilenameConflictError } from '../../timeline/data/ports';
 import type { EventListItem, Session, State } from '../../timeline/data/types';
 import {
   DEFAULT_SECONDS_PER_PIXEL,
@@ -24,6 +24,7 @@ import { usePreviewSize } from '../../timeline/interactions/usePreviewSize';
 import { useReschedule } from '../../timeline/interactions/useReschedule';
 import { useQuickAddZones } from '../../timeline/interactions/useQuickAddZones';
 import { useEventEditor } from '../../timeline/event-editor/useEventEditor';
+import { deriveFilename } from '../../timeline/event-editor/domain';
 import { EventEditorModal } from '../../timeline/event-editor/EventEditorModal';
 import { NewEventModal } from '../../timeline/event-editor/new-event-modal';
 import { sessionTagsForSeconds } from '../../timeline/render/session-bands';
@@ -264,6 +265,16 @@ export function TimelineView({
         const nonSeshTags = (event.tags ?? []).filter((t) => !isSessionTag(t));
         const newSeshTags = sessionTagsForSeconds(newSeconds, sessionsRef.current);
         const updatedTags = [...nonSeshTags, ...newSeshTags];
+        const desiredFilename = deriveFilename({
+          title: event.title,
+          date: newDate,
+          body: event.body,
+          tagsText: '',
+          color: '',
+          tagLabelOverride: '',
+          linkLabelOverride: '',
+          systemTags: [],
+        });
         await timelinePort.updateEvent(
           campaignPath,
           filename,
@@ -276,14 +287,17 @@ export function TimelineView({
           },
           event.body,
           lastModified,
+          desiredFilename,
         );
         await refreshEvents();
       } catch (err) {
         console.error('[saveReschedule] failed', err);
         const msg =
-          err instanceof ConflictError
-            ? `"${filename}" was modified on disk — reschedule reverted.`
-            : 'Reschedule failed. Please try again.';
+          err instanceof FilenameConflictError
+            ? err.message
+            : err instanceof ConflictError
+              ? `"${filename}" was modified on disk — reschedule reverted.`
+              : 'Reschedule failed. Please try again.';
         setTimelineError(msg);
         setTimeout(() => setTimelineError(null), 4000);
         // Rethrow so the reschedule module immediately reverts the card's DOM position.

--- a/src/shared/frontmatter.ts
+++ b/src/shared/frontmatter.ts
@@ -64,7 +64,7 @@ export function joinFrontmatter(frontmatter: string, body: string): string {
   return `---\n${frontmatter}\n---\n${body}`;
 }
 
-function extractH1(body: string): string | null {
+export function extractH1(body: string): string | null {
   const m = /^#\s+(.+)$/m.exec(body);
   return m ? m[1].trim() : null;
 }

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -93,6 +93,7 @@ declare global {
         frontmatter: EventFrontmatter,
         body: string,
         ifUnmodifiedSince: string,
+        desiredFilename?: string,
       ) => Promise<EventWithMtime | ConflictResult>;
       timelineDeleteEvent: (
         campaignPath: string,


### PR DESCRIPTION
## 📝 Description

**Issue(s):** #205

Event files were named `YYYY-MM-DD-title-slug.md` using the frontmatter `title` field, which never updated when the title or timestamp changed. Card titles were similarly driven by the stale frontmatter title rather than the body content.

This PR makes the event's displayed title and filename both driven by the **first H1 heading** in the markdown body, and upgrades the filename to include the **full datetime** (e.g. `4726-05-04T0930-battle-of-sandpoint.md`). The file is renamed automatically on every save whenever the H1 or timestamp changes — piggybacking on the existing 2 s autosave debounce. If the desired filename is already taken by another event, the save surfaces a clear error: "Filename is already in use — the date + first H1 combination must be unique." Wiki-links are unaffected because they use stable `[[id]]` references resolved at render time.

---

## 🔍 Details

- **`src/shared/frontmatter.ts`** — Export `extractH1` so both the renderer and the main process can reuse it.
- **`src/renderer/timeline/event-editor/domain.ts`** — `deriveFilename` now extracts the slug from the body H1 (fallback to `buf.title`, then `'event'`), and uses the full datetime with colons stripped (`4726-05-04T0930-...`). `bufferToFrontmatter` now writes `extractH1(body) ?? buf.title` as the frontmatter title so the entity indexer's write-back no longer bumps mtime and causes phantom autosave conflicts.
- **`src/renderer/timeline/data/types.ts`** — `ConflictResult` is now a union: the existing mtime conflict and a new `{ reason: 'filename-taken'; filename }` arm.
- **`src/renderer/timeline/data/ports.ts`** — `updateEvent` accepts an optional `desiredFilename`; adds `FilenameConflictError` class thrown when the rename target is already occupied.
- **`src/main/timelineIpcHandlers.ts`** — `parseEventFile` and `listEvents` now derive the displayed title from the body H1 (fallback to frontmatter title). `updateEventHandler` (extracted for direct testability, mirrors `createEventHandler`) writes content then optionally renames: free target → `fs.renameSync`; occupied target → returns `filename-taken` conflict; no `desiredFilename` → unchanged behaviour.
- **`src/preload/index.cts` + `src/types/global.d.ts`** — Forward the new optional `desiredFilename` parameter through the IPC bridge.
- **`src/renderer/timeline/event-editor/EventEditorModal.tsx`** — `doSave` computes `deriveFilename(current)` and passes it on every edit-mode save, then syncs `filenameRef.current` from the returned filename. `doDelete` and `onDeleted` route through `filenameRef.current` so they still work after a rename. The editor header shows the live filename. `FilenameConflictError` is caught and shown as a persistent error banner.
- **Tests** — `domain.test.ts` updated for new `deriveFilename` (9 cases) and `bufferToFrontmatter` (2 new cases). New `timeline-update-event.test.ts` (9 integration tests) covers H1 title extraction, rename, filename-taken conflict, mtime conflict, and path-safety guard.

**Note:** The orchestration guardrail addition to `CLAUDE.md` was blocked by the auto-mode classifier during this session; it is on disk but not committed. Please commit `CLAUDE.md` manually or in a follow-up.

---

## 🧪 Manual Test Cases

### 🚀 New Behavior
- [x] Open an existing event, change the first H1 heading, wait 2 s for autosave — the file on disk is renamed to `<datetime>T<time>-<new-slug>.md` and the editor header updates to the new filename.
- [x] Change the event's date/time field, wait 2 s — the file is renamed with the new datetime prefix.
- [ ] An existing event file with only a date prefix (e.g. `4726-05-04-old.md`) gets renamed on its next save to the full-datetime format.
- [ ] Two events whose date + H1 would produce the same filename: saving the second one shows the error banner "Filename ... is already in use — the date + first H1 combination must be unique."
- [ ] Event card on the timeline shows the H1 heading text (not the frontmatter title) as its title after saving.
- [ ] Delete an event that has been renamed during the session — delete succeeds (does not attempt to delete the original stale filename).

### 🛡️ Regression Checks
- [ ] Creating a brand-new event still works; the filename is derived from the initial H1 / title and date as expected.
- [ ] Events with no H1 in the body display and save using the frontmatter title field as before.
- [ ] Wiki-links to renamed events still resolve correctly (links use `[[id]]`, not the filename).
- [ ] Ctrl+S, Ctrl+Enter, and the Save button all trigger the rename flow correctly.
- [ ] Mtime conflict detection (file changed on disk since open) still shows the existing "Overwrite?" overlay, not the filename-taken error.

https://claude.ai/code/session_01Mhfqbi3HfMZ2Dkkx9UmvyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mhfqbi3HfMZ2Dkkx9UmvyA)_