### PR TITLE
#210 Replace native confirm/alert dialogs with in-app modals

### DIFF
--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -194,7 +194,7 @@ Read the key files the agent created/modified. Check for:
 | Verdict | Action |
 |---|---|
 | **Approve** | Cherry-pick the commit into your branch (Phase 5) |
-| **Minor fix needed** | Send a follow-up message to the same agent (via `SendMessage` with the agent's ID) with specific fix instructions. Or spin up a new agent in the same worktree. |
+| **Minor fix needed** | Spin up a fresh agent **in the same worktree** with specific fix instructions (see *Resuming a cut-off or incomplete agent*). Don't rely on `SendMessage`/continue-the-same-agent — that lives behind experimental Agent Teams (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) and is not available to a plain orchestrator. |
 | **Major problems** | Discard the worktree. Diagnose what went wrong with the prompt. Rewrite the prompt and launch a fresh agent. |
 
 ### Rogue agent detection
@@ -371,6 +371,59 @@ When a cherry-pick does conflict:
   up after each batch with `npm run prune-worktrees` (see Phase 5).
   Note: `vite.config.ts` excludes `.claude/worktrees/**` from
   vitest, but always prune anyway to avoid disk bloat.
+
+## Resuming a cut-off or incomplete agent (resume-by-worktree)
+
+An agent can stop before it finishes and commits — a usage-limit reset,
+a crash, or a turn that ends early. **You cannot send it a "continue"
+message.** The tool for that (`SendMessage`, the agent "mailbox") belongs
+to experimental **Agent Teams**, which is disabled by default
+(`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`); plain subagents are
+spawn-and-return and have no resume channel. The prompt/notifications may
+still *mention* `SendMessage` — ignore that, it isn't wired up.
+
+**The good news: the work is not lost.** Each agent runs in a git
+worktree under `.claude/worktrees/agent-<id>/` on its own branch
+`worktree-agent-<id>`. Its changes — **committed *and* uncommitted** —
+sit on disk until you prune that worktree. A cut-off only loses the
+agent's *reasoning context*, not its files. So don't restart from zero;
+resume from the worktree.
+
+When an agent stops mid-task:
+
+1. **Don't prune its worktree.** That's the only copy of uncommitted
+   work.
+2. **Inspect what's there:**
+   ```bash
+   git -C <wt> log --oneline <feature-branch>..HEAD   # any commits?
+   git -C <wt> status --short                          # uncommitted files
+   git -C <wt> diff                                    # the actual edits
+   ```
+3. **If a usage limit caused the stop, wait for the reset window**
+   before relaunching — otherwise the new agent stops too. Check the
+   reset time in the completion notice.
+4. **If the partial work is sound, finish it in place.** Spawn a
+   **fresh** agent *without* `isolation: "worktree"` and tell it to work
+   in the existing worktree path, so it sees the uncommitted edits:
+   > "Work in the existing worktree at `<absolute wt path>`
+   > (`cd` there first). A previous agent partially completed
+   > `<task>` and left edits to `<files>`: `<one-line summary of
+   > what's done>`. Finish the remaining work: `<X, Y>`. Then run
+   > `npm test` and `npm run lint` (both must pass) and commit as a
+   > single commit `#<issue> <message>`."
+
+   This keeps every on-disk change; only the lost context is rebuilt.
+   Then review and cherry-pick as in Phase 5, and prune.
+5. **If the partial work is wrong or unsalvageable,** treat it as
+   *Major problems*: discard the worktree and re-run with a better
+   prompt. Don't pour effort into salvaging a bad start.
+
+> **Cheaper insurance:** for longer tasks, tell each agent to make an
+> intermediate **checkpoint commit** the moment its core change compiles
+> (in addition to the final squashed commit). A cut-off then leaves a
+> committed, cherry-pickable state and the resume step is trivial — but
+> note pre-commit hooks (lint + tests) still run on a checkpoint, so it
+> must at least pass those.
 
 ## Aborting mid-orchestration
 

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -418,13 +418,6 @@ When an agent stops mid-task:
    *Major problems*: discard the worktree and re-run with a better
    prompt. Don't pour effort into salvaging a bad start.
 
-> **Cheaper insurance:** for longer tasks, tell each agent to make an
-> intermediate **checkpoint commit** the moment its core change compiles
-> (in addition to the final squashed commit). A cut-off then leaves a
-> committed, cherry-pickable state and the resume step is trivial — but
-> note pre-commit hooks (lint + tests) still run on a checkpoint, so it
-> must at least pass those.
-
 ## Aborting mid-orchestration
 
 If the user asks to stop, or something goes fundamentally wrong:

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -374,49 +374,32 @@ When a cherry-pick does conflict:
 
 ## Resuming a cut-off or incomplete agent (resume-by-worktree)
 
-An agent can stop before it finishes and commits — a usage-limit reset,
-a crash, or a turn that ends early. **You cannot send it a "continue"
-message.** The tool for that (`SendMessage`, the agent "mailbox") belongs
-to experimental **Agent Teams**, which is disabled by default
-(`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`); plain subagents are
-spawn-and-return and have no resume channel. The prompt/notifications may
-still *mention* `SendMessage` — ignore that, it isn't wired up.
+A sub-agent can stop before it finishes — a crash, or a turn that ends
+early. **Sub-agents are spawn-and-return: once one stops, it is done,
+and there is no way to resume it.** Ignore `SendMessage` entirely — it
+is gated behind the experimental **Agent Teams** feature, which this
+workflow does not use. The harness will erroneously suggest it many
+times; treat every such mention as noise.
 
-**The good news: the work is not lost.** Each agent runs in a git
-worktree under `.claude/worktrees/agent-<id>/` on its own branch
-`worktree-agent-<id>`. Its changes — **committed *and* uncommitted** —
-sit on disk until you prune that worktree. A cut-off only loses the
-agent's *reasoning context*, not its files. So don't restart from zero;
-resume from the worktree.
+The work survives in the agent's worktree (under
+`.claude/worktrees/agent-<id>/`), committed *and* uncommitted, until you
+prune it. To carry it forward, **start a new sub-agent in that same
+worktree** and have it finish or amend the existing work:
 
-When an agent stops mid-task:
+- Spawn the agent **without** `isolation: "worktree"` (that flag creates
+  a fresh worktree; you want the existing one).
+- Tell it to `cd` into the absolute worktree path first, so it sees the
+  prior agent's committed and uncommitted edits.
+- Give it the original prompt (or a revised one), state that a previous
+  agent already did part of the work, and tell it to finish or amend and
+  commit.
 
-1. **Don't prune its worktree.** That's the only copy of uncommitted
-   work.
-2. **Inspect what's there:**
-   ```bash
-   git -C <wt> log --oneline <feature-branch>..HEAD   # any commits?
-   git -C <wt> status --short                          # uncommitted files
-   git -C <wt> diff                                    # the actual edits
-   ```
-3. **If a usage limit caused the stop, wait for the reset window**
-   before relaunching — otherwise the new agent stops too. Check the
-   reset time in the completion notice.
-4. **If the partial work is sound, finish it in place.** Spawn a
-   **fresh** agent *without* `isolation: "worktree"` and tell it to work
-   in the existing worktree path, so it sees the uncommitted edits:
-   > "Work in the existing worktree at `<absolute wt path>`
-   > (`cd` there first). A previous agent partially completed
-   > `<task>` and left edits to `<files>`: `<one-line summary of
-   > what's done>`. Finish the remaining work: `<X, Y>`. Then run
-   > `npm test` and `npm run lint` (both must pass) and commit as a
-   > single commit `#<issue> <message>`."
+Keep the worktree for the new agent, unless either:
 
-   This keeps every on-disk change; only the lost context is rebuilt.
-   Then review and cherry-pick as in Phase 5, and prune.
-5. **If the partial work is wrong or unsalvageable,** treat it as
-   *Major problems*: discard the worktree and re-run with a better
-   prompt. Don't pour effort into salvaging a bad start.
+- The existing changes aren't worth finishing — discard the worktree and
+  start fresh from a better prompt (as with *Major problems* in Phase 4).
+- The work is already cherry-picked onto your feature branch — then prune
+  it as usual.
 
 ## Aborting mid-orchestration
 

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2,11 +2,14 @@ import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 import { ThemeProvider } from './theme';
 import App from './app.tsx';
+import { ConfirmDialogProvider } from './shared/confirm-dialog/confirm-provider';
 
 ThemeProvider.init();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ConfirmDialogProvider>
+      <App />
+    </ConfirmDialogProvider>
   </StrictMode>,
 );

--- a/src/renderer/shared/confirm-dialog/__tests__/confirm-dialog.test.tsx
+++ b/src/renderer/shared/confirm-dialog/__tests__/confirm-dialog.test.tsx
@@ -268,4 +268,104 @@ describe('ConfirmDialog', () => {
       console.error = originalError;
     }
   });
+
+  it('a second confirm request resolves the first promise as false', async () => {
+    const handle = renderConsumer({ action: 'confirm', options: { message: 'First dialog' } });
+
+    // Open first dialog
+    await handle.triggerOpen();
+    const firstPromise = handle.capturedPromise as Promise<boolean>;
+
+    let firstResult: boolean | undefined;
+    void firstPromise.then((v) => {
+      firstResult = v;
+    });
+
+    // Re-render with a different message and trigger a second confirm
+    act(() => {
+      root.render(
+        <ConfirmDialogProvider>
+          <TestConsumer
+            action="confirm"
+            options={{ message: 'Second dialog' }}
+            onPromise={(p) => {
+              handle.capturedPromise = p;
+            }}
+          />
+        </ConfirmDialogProvider>,
+      );
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>('[data-testid="trigger"]');
+    if (!trigger) throw new Error('trigger button not found');
+    await act(async () => {
+      trigger.click();
+    });
+
+    // First promise must have resolved as false (cancelled)
+    expect(firstResult).toBe(false);
+
+    // The second dialog message should now be displayed
+    const msgEl = container.querySelector('.confirm-dialog-message');
+    expect(msgEl?.textContent).toContain('Second dialog');
+  });
+
+  it('clicking the backdrop cancels the dialog (resolves false)', async () => {
+    const handle = renderConsumer({ action: 'confirm' });
+
+    await handle.triggerOpen();
+
+    let result: boolean | undefined;
+    void (handle.capturedPromise as Promise<boolean>).then((v) => {
+      result = v;
+    });
+
+    const backdrop = container.querySelector<HTMLDivElement>('.confirm-dialog-backdrop');
+    expect(backdrop).not.toBeNull();
+
+    await act(async () => {
+      // Dispatch mousedown where target === currentTarget (i.e. on the backdrop itself)
+      const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+      Object.defineProperty(event, 'target', { value: backdrop, writable: false });
+      backdrop!.dispatchEvent(event);
+    });
+
+    expect(result).toBe(false);
+    // Dialog should be unmounted
+    expect(container.querySelector('.confirm-dialog-backdrop')).toBeNull();
+  });
+
+  it('the primary/confirm button is focused on mount', async () => {
+    const handle = renderConsumer({ action: 'confirm' });
+
+    await handle.triggerOpen();
+
+    const primaryBtn = container.querySelector<HTMLButtonElement>('.confirm-dialog-btn--primary');
+    expect(primaryBtn).not.toBeNull();
+    expect(document.activeElement).toBe(primaryBtn);
+  });
+
+  it('a pending confirm resolves false when the provider unmounts', async () => {
+    const handle = renderConsumer({ action: 'confirm' });
+
+    await handle.triggerOpen();
+    const promise = handle.capturedPromise as Promise<boolean>;
+
+    let result: boolean | undefined;
+    void promise.then((v) => {
+      result = v;
+    });
+
+    // Unmount the provider/root
+    await act(async () => {
+      root.unmount();
+    });
+
+    // Flush microtasks so the .then callback runs
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result).toBe(false);
+  });
 });

--- a/src/renderer/shared/confirm-dialog/__tests__/confirm-dialog.test.tsx
+++ b/src/renderer/shared/confirm-dialog/__tests__/confirm-dialog.test.tsx
@@ -1,0 +1,271 @@
+// @vitest-environment happy-dom
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+import { ConfirmDialogProvider, useConfirm } from '../confirm-provider';
+
+// ---- Test consumer component ----
+
+interface TestConsumerProps {
+  onPromise: (p: Promise<boolean> | Promise<void>) => void;
+  action: 'confirm' | 'alert';
+  options?: {
+    title?: string;
+    message?: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    okLabel?: string;
+    danger?: boolean;
+  };
+}
+
+function TestConsumer({ onPromise, action, options = {} }: TestConsumerProps) {
+  const { confirm, alert } = useConfirm();
+
+  const handleClick = () => {
+    if (action === 'confirm') {
+      const p = confirm({
+        message: options.message ?? 'Are you sure?',
+        title: options.title,
+        confirmLabel: options.confirmLabel,
+        cancelLabel: options.cancelLabel,
+        danger: options.danger,
+      });
+      onPromise(p);
+    } else {
+      const p = alert({
+        message: options.message ?? 'Something happened.',
+        title: options.title,
+        okLabel: options.okLabel,
+      });
+      onPromise(p);
+    }
+  };
+
+  return (
+    <button type="button" data-testid="trigger" onClick={handleClick}>
+      Open
+    </button>
+  );
+}
+
+// ---- Test harness ----
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setup() {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+}
+
+function teardown() {
+  act(() => root.unmount());
+  container.remove();
+}
+
+function getAllButtons(): HTMLButtonElement[] {
+  return Array.from(container.querySelectorAll('button'));
+}
+
+function findButton(text: string): HTMLButtonElement | undefined {
+  return getAllButtons().find((b) => b.textContent?.trim() === text);
+}
+
+interface ConsumerHandle {
+  capturedPromise: Promise<boolean> | Promise<void> | null;
+  triggerOpen: () => Promise<void>;
+}
+
+function renderConsumer(props: Omit<TestConsumerProps, 'onPromise'>): ConsumerHandle {
+  const handle: ConsumerHandle = {
+    capturedPromise: null,
+    triggerOpen: async () => {
+      const trigger = container.querySelector<HTMLButtonElement>('[data-testid="trigger"]');
+      if (!trigger) throw new Error('trigger button not found');
+      await act(async () => {
+        trigger.click();
+      });
+    },
+  };
+
+  act(() => {
+    root.render(
+      <ConfirmDialogProvider>
+        <TestConsumer
+          action={props.action}
+          options={props.options}
+          onPromise={(p) => {
+            handle.capturedPromise = p;
+          }}
+        />
+      </ConfirmDialogProvider>,
+    );
+  });
+
+  return handle;
+}
+
+// ---- Tests ----
+
+describe('ConfirmDialog', () => {
+  beforeEach(() => {
+    setup();
+  });
+
+  afterEach(() => {
+    teardown();
+  });
+
+  it('confirm resolves true when the confirm button is clicked', async () => {
+    const handle = renderConsumer({ action: 'confirm' });
+
+    await handle.triggerOpen();
+    expect(findButton('OK')).not.toBeUndefined();
+
+    let result: boolean | undefined;
+    void (handle.capturedPromise as Promise<boolean>).then((v) => {
+      result = v;
+    });
+
+    await act(async () => {
+      findButton('OK')!.click();
+    });
+
+    expect(result).toBe(true);
+    // Dialog should be gone after resolving
+    expect(findButton('OK')).toBeUndefined();
+  });
+
+  it('confirm resolves false when the cancel button is clicked', async () => {
+    const handle = renderConsumer({ action: 'confirm' });
+
+    await handle.triggerOpen();
+    expect(findButton('Cancel')).not.toBeUndefined();
+
+    let result: boolean | undefined;
+    void (handle.capturedPromise as Promise<boolean>).then((v) => {
+      result = v;
+    });
+
+    await act(async () => {
+      findButton('Cancel')!.click();
+    });
+
+    expect(result).toBe(false);
+    expect(findButton('Cancel')).toBeUndefined();
+  });
+
+  it('Escape resolves confirm as false', async () => {
+    const handle = renderConsumer({ action: 'confirm' });
+
+    await handle.triggerOpen();
+    expect(findButton('OK')).not.toBeUndefined();
+
+    let result: boolean | undefined;
+    void (handle.capturedPromise as Promise<boolean>).then((v) => {
+      result = v;
+    });
+
+    await act(async () => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(result).toBe(false);
+    expect(findButton('OK')).toBeUndefined();
+  });
+
+  it('Enter resolves confirm as true', async () => {
+    const handle = renderConsumer({ action: 'confirm' });
+
+    await handle.triggerOpen();
+    expect(findButton('OK')).not.toBeUndefined();
+
+    let result: boolean | undefined;
+    void (handle.capturedPromise as Promise<boolean>).then((v) => {
+      result = v;
+    });
+
+    await act(async () => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(result).toBe(true);
+    expect(findButton('OK')).toBeUndefined();
+  });
+
+  it('renders multi-line message preserving line breaks', async () => {
+    const { triggerOpen } = renderConsumer({
+      action: 'confirm',
+      options: { message: 'Line one\nLine two' },
+    });
+
+    await triggerOpen();
+
+    const msgEl = container.querySelector('.confirm-dialog-message');
+    expect(msgEl).not.toBeNull();
+    // white-space: pre-wrap preserves \n; textContent will contain both parts
+    expect(msgEl!.textContent).toContain('Line one');
+    expect(msgEl!.textContent).toContain('Line two');
+  });
+
+  it('alert resolves void when OK is clicked and shows no Cancel button', async () => {
+    const handle = renderConsumer({ action: 'alert' });
+
+    await handle.triggerOpen();
+    expect(findButton('OK')).not.toBeUndefined();
+    expect(findButton('Cancel')).toBeUndefined();
+
+    let resolved = false;
+    void (handle.capturedPromise as Promise<void>).then(() => {
+      resolved = true;
+    });
+
+    await act(async () => {
+      findButton('OK')!.click();
+    });
+
+    expect(resolved).toBe(true);
+    expect(findButton('OK')).toBeUndefined();
+  });
+
+  it('danger confirm applies destructive styling to the confirm button', async () => {
+    const { triggerOpen } = renderConsumer({
+      action: 'confirm',
+      options: { danger: true, confirmLabel: 'Delete' },
+    });
+
+    await triggerOpen();
+
+    const confirmBtn = findButton('Delete');
+    expect(confirmBtn).not.toBeUndefined();
+    expect(confirmBtn!.className).toContain('confirm-dialog-btn--danger');
+  });
+
+  it('useConfirm throws when used outside the provider', () => {
+    function BadConsumer() {
+      useConfirm();
+      return null;
+    }
+
+    // Suppress console.error from React's error boundary output
+    const originalError = console.error;
+    console.error = () => {};
+    try {
+      expect(() => {
+        act(() => {
+          root.render(<BadConsumer />);
+        });
+      }).toThrow('useConfirm must be used within a ConfirmDialogProvider');
+    } finally {
+      console.error = originalError;
+    }
+  });
+});

--- a/src/renderer/shared/confirm-dialog/confirm-dialog.css
+++ b/src/renderer/shared/confirm-dialog/confirm-dialog.css
@@ -1,0 +1,81 @@
+/* ===== Confirm / Alert Dialog ===== */
+
+.confirm-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.confirm-dialog-panel {
+  background: var(--theme-surface);
+  border: 1px solid var(--theme-border-strong);
+  border-radius: 4px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.8);
+  padding: 24px 28px;
+  min-width: 320px;
+  max-width: 480px;
+  width: calc(100vw - 64px);
+}
+
+.confirm-dialog-title {
+  margin: 0 0 10px;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--theme-text-primary);
+}
+
+.confirm-dialog-message {
+  margin: 0 0 20px;
+  font-size: 14px;
+  color: var(--theme-text-secondary);
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+.confirm-dialog-buttons {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+/* ===== Dialog Buttons ===== */
+
+.confirm-dialog-btn {
+  padding: 5px 14px;
+  border: 1px solid var(--theme-border);
+  border-radius: 2px;
+  background: var(--theme-surface);
+  color: var(--theme-text-secondary);
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.confirm-dialog-btn:hover:not(:disabled) {
+  background: var(--theme-panel-accent);
+  color: var(--theme-text-primary);
+}
+
+.confirm-dialog-btn--primary {
+  background: var(--theme-panel-accent);
+  border-color: var(--theme-accent);
+  color: var(--theme-accent);
+  font-weight: 600;
+}
+
+.confirm-dialog-btn--primary:hover:not(:disabled) {
+  filter: brightness(1.15);
+}
+
+.confirm-dialog-btn--danger {
+  color: var(--theme-danger);
+}
+
+.confirm-dialog-btn--danger:hover:not(:disabled) {
+  background: rgba(var(--theme-danger-rgb) / 0.15);
+  border-color: var(--theme-danger);
+}

--- a/src/renderer/shared/confirm-dialog/confirm-dialog.tsx
+++ b/src/renderer/shared/confirm-dialog/confirm-dialog.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef } from 'react';
+import './confirm-dialog.css';
+
+export interface ConfirmDialogProps {
+  title?: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  okLabel?: string;
+  danger?: boolean;
+  mode: 'confirm' | 'alert';
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  title,
+  message,
+  confirmLabel = 'OK',
+  cancelLabel = 'Cancel',
+  okLabel = 'OK',
+  danger = false,
+  mode,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const primaryBtnRef = useRef<HTMLButtonElement>(null);
+
+  // Focus the primary button on mount
+  useEffect(() => {
+    primaryBtnRef.current?.focus();
+  }, []);
+
+  // Keyboard handling: Escape => cancel, Enter => confirm (capture phase)
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onCancel();
+      } else if (e.key === 'Enter') {
+        e.stopPropagation();
+        onConfirm();
+      }
+    };
+    document.addEventListener('keydown', onKey, { capture: true });
+    return () => document.removeEventListener('keydown', onKey, { capture: true });
+  }, [onConfirm, onCancel]);
+
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onCancel();
+    }
+  };
+
+  const confirmBtnClass = [
+    'confirm-dialog-btn',
+    'confirm-dialog-btn--primary',
+    danger ? 'confirm-dialog-btn--danger' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className="confirm-dialog-backdrop" onMouseDown={handleBackdropMouseDown}>
+      <div className="confirm-dialog-panel">
+        {title && <h2 className="confirm-dialog-title">{title}</h2>}
+        <p className="confirm-dialog-message">{message}</p>
+        <div className="confirm-dialog-buttons">
+          {mode === 'confirm' && (
+            <button type="button" className="confirm-dialog-btn" onClick={onCancel}>
+              {cancelLabel}
+            </button>
+          )}
+          <button ref={primaryBtnRef} type="button" className={confirmBtnClass} onClick={onConfirm}>
+            {mode === 'alert' ? okLabel : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/shared/confirm-dialog/confirm-provider.tsx
+++ b/src/renderer/shared/confirm-dialog/confirm-provider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useRef, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { ConfirmDialog } from './confirm-dialog';
 
 export interface ConfirmOptions {
@@ -46,6 +46,11 @@ export function ConfirmDialogProvider({ children }: { children: React.ReactNode 
 
   const confirm = useCallback((options: ConfirmOptions): Promise<boolean> => {
     return new Promise<boolean>((resolve) => {
+      if (resolverRef.current) {
+        const prev = resolverRef.current;
+        resolverRef.current = null;
+        prev(false);
+      }
       resolverRef.current = resolve;
       setDialog({
         title: options.title,
@@ -60,6 +65,11 @@ export function ConfirmDialogProvider({ children }: { children: React.ReactNode 
 
   const alert = useCallback((options: AlertOptions): Promise<void> => {
     return new Promise<void>((resolve) => {
+      if (resolverRef.current) {
+        const prev = resolverRef.current;
+        resolverRef.current = null;
+        prev(false);
+      }
       resolverRef.current = (value: boolean) => {
         void value;
         resolve();
@@ -85,6 +95,16 @@ export function ConfirmDialogProvider({ children }: { children: React.ReactNode 
     resolverRef.current = null;
     setDialog(null);
     resolve?.(false);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (resolverRef.current) {
+        const r = resolverRef.current;
+        resolverRef.current = null;
+        r(false);
+      }
+    };
   }, []);
 
   return (

--- a/src/renderer/shared/confirm-dialog/confirm-provider.tsx
+++ b/src/renderer/shared/confirm-dialog/confirm-provider.tsx
@@ -1,0 +1,108 @@
+import { createContext, useCallback, useContext, useRef, useState } from 'react';
+import { ConfirmDialog } from './confirm-dialog';
+
+export interface ConfirmOptions {
+  title?: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  danger?: boolean;
+}
+
+export interface AlertOptions {
+  title?: string;
+  message: string;
+  okLabel?: string;
+}
+
+interface DialogState {
+  title?: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  okLabel?: string;
+  danger?: boolean;
+  mode: 'confirm' | 'alert';
+}
+
+interface ConfirmContextValue {
+  confirm: (options: ConfirmOptions) => Promise<boolean>;
+  alert: (options: AlertOptions) => Promise<void>;
+}
+
+const ConfirmContext = createContext<ConfirmContextValue | null>(null);
+
+export function useConfirm(): ConfirmContextValue {
+  const ctx = useContext(ConfirmContext);
+  if (!ctx) {
+    throw new Error('useConfirm must be used within a ConfirmDialogProvider');
+  }
+  return ctx;
+}
+
+export function ConfirmDialogProvider({ children }: { children: React.ReactNode }): JSX.Element {
+  const [dialog, setDialog] = useState<DialogState | null>(null);
+  const resolverRef = useRef<((value: boolean) => void) | null>(null);
+
+  const confirm = useCallback((options: ConfirmOptions): Promise<boolean> => {
+    return new Promise<boolean>((resolve) => {
+      resolverRef.current = resolve;
+      setDialog({
+        title: options.title,
+        message: options.message,
+        confirmLabel: options.confirmLabel ?? 'OK',
+        cancelLabel: options.cancelLabel ?? 'Cancel',
+        danger: options.danger,
+        mode: 'confirm',
+      });
+    });
+  }, []);
+
+  const alert = useCallback((options: AlertOptions): Promise<void> => {
+    return new Promise<void>((resolve) => {
+      resolverRef.current = (value: boolean) => {
+        void value;
+        resolve();
+      };
+      setDialog({
+        title: options.title,
+        message: options.message,
+        okLabel: options.okLabel ?? 'OK',
+        mode: 'alert',
+      });
+    });
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    const resolve = resolverRef.current;
+    resolverRef.current = null;
+    setDialog(null);
+    resolve?.(true);
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    const resolve = resolverRef.current;
+    resolverRef.current = null;
+    setDialog(null);
+    resolve?.(false);
+  }, []);
+
+  return (
+    <ConfirmContext.Provider value={{ confirm, alert }}>
+      {children}
+      {dialog && (
+        <ConfirmDialog
+          title={dialog.title}
+          message={dialog.message}
+          confirmLabel={dialog.confirmLabel}
+          cancelLabel={dialog.cancelLabel}
+          okLabel={dialog.okLabel}
+          danger={dialog.danger}
+          mode={dialog.mode}
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+        />
+      )}
+    </ConfirmContext.Provider>
+  );
+}

--- a/src/renderer/timeline/event-editor/EventEditorModal.tsx
+++ b/src/renderer/timeline/event-editor/EventEditorModal.tsx
@@ -3,6 +3,7 @@ import type { EditorView } from '@codemirror/view';
 import { MarkdownEditor, FormatToolbar } from '../../shared/markdown-editor';
 import { suggestLinks } from '../../shared/suggest-links';
 import { FooterPortal } from '../../components/footer-portal';
+import { useConfirm } from '../../shared/confirm-dialog/confirm-provider';
 import { openFromWikiLink, closeFromWikiLink } from '../../peek/stack';
 import { timelinePort, ConflictError, FilenameConflictError } from '../data/ports';
 import { notesData } from '../../notes/data';
@@ -99,6 +100,7 @@ export function EventEditorModal({
   onAutosaved,
   onOpenById,
 }: EventEditorModalProps) {
+  const { confirm } = useConfirm();
   const [loadState, setLoadState] = useState<LoadState>(mode.kind === 'edit' ? 'loading' : 'ready');
   const [buffer, setBuffer] = useState<EditorBuffer>(
     mode.kind === 'create' ? emptyBuffer(mode.initialDate) : emptyBuffer(),
@@ -428,13 +430,18 @@ export function EventEditorModal({
     return () => document.removeEventListener('keydown', onKey);
   }, [saveState, doSave]);
 
-  const handleDeleteClick = useCallback(() => {
+  const handleDeleteClick = useCallback(async () => {
     if (mode.kind !== 'edit') return;
     const displayName = buffer.title || mode.filename;
-    if (!window.confirm(`Move "${displayName}" to trash?\n\nRecoverable via Settings → Trash.`))
-      return;
+    const ok = await confirm({
+      title: 'Move event to trash',
+      message: `Move "${displayName}" to trash?\n\nRecoverable via Settings → Trash.`,
+      confirmLabel: 'Move to Trash',
+      danger: true,
+    });
+    if (!ok) return;
     void doDelete();
-  }, [mode, buffer.title, doDelete]);
+  }, [mode, buffer.title, doDelete, confirm]);
 
   const colorSelectValue = customMode ? '__custom__' : getColorPresetValue(buffer.color);
   const isCustomColor = colorSelectValue === '__custom__';
@@ -477,7 +484,7 @@ export function EventEditorModal({
         <button
           type="button"
           className="event-editor-btn event-editor-btn--danger"
-          onClick={handleDeleteClick}
+          onClick={() => void handleDeleteClick()}
           disabled={isBusy || loadState !== 'ready'}
         >
           Delete

--- a/src/renderer/timeline/event-editor/__tests__/event-editor-modal.test.tsx
+++ b/src/renderer/timeline/event-editor/__tests__/event-editor-modal.test.tsx
@@ -8,6 +8,11 @@ import { act } from 'react';
 // ---- Mock heavy deps before imports ----
 // NOTE: vi.mock paths are relative to THIS test file, not the component.
 
+const confirmMock = vi.fn();
+vi.mock('../../../shared/confirm-dialog/confirm-provider', () => ({
+  useConfirm: () => ({ confirm: confirmMock, alert: vi.fn().mockResolvedValue(undefined) }),
+}));
+
 vi.mock('../../data/ports', () => ({
   timelinePort: {
     getEvent: vi.fn(),
@@ -227,10 +232,7 @@ async function flush() {
 describe('EventEditorModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.stubGlobal(
-      'confirm',
-      vi.fn(() => false),
-    );
+    confirmMock.mockReset().mockResolvedValue(true);
     Object.defineProperty(window, 'fsApi', {
       value: fsApiStub,
       configurable: true,
@@ -327,8 +329,8 @@ describe('EventEditorModal', () => {
     });
     await flush();
 
-    // No discard confirmation prompt
-    expect(vi.mocked(window.confirm)).not.toHaveBeenCalledWith(expect.stringContaining('unsaved'));
+    // No discard confirmation prompt was shown
+    expect(confirmMock).not.toHaveBeenCalled();
     // Save was triggered and completed
     expect(timelinePort.updateEvent).toHaveBeenCalledTimes(1);
     expect(onSaved).toHaveBeenCalledTimes(1);
@@ -422,7 +424,7 @@ describe('EventEditorModal', () => {
     });
     await flush();
 
-    expect(vi.mocked(window.confirm)).not.toHaveBeenCalledWith(expect.stringContaining('unsaved'));
+    expect(confirmMock).not.toHaveBeenCalled();
     expect(timelinePort.updateEvent).toHaveBeenCalledTimes(1);
     expect(onSaved).toHaveBeenCalledTimes(1);
   });
@@ -529,5 +531,45 @@ describe('EventEditorModal', () => {
     const callArgs = vi.mocked(timelinePort.updateEvent).mock.calls[0];
     // The frontmatter (4th arg) should include the selected color
     expect(callArgs[2]).toMatchObject({ color: '#a83030' });
+  });
+
+  // ── Delete button: confirmed → calls deleteEvent ──
+
+  it('clicking Delete when confirmed calls deleteEvent', async () => {
+    setup();
+    vi.mocked(timelinePort.deleteEvent).mockResolvedValue(undefined);
+    const { onDeleted } = await renderEdit();
+
+    const deleteBtn = findButton('Delete');
+    expect(deleteBtn).not.toBeUndefined();
+
+    await act(async () => {
+      deleteBtn!.click();
+    });
+    await flush();
+
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(timelinePort.deleteEvent).toHaveBeenCalledTimes(1);
+    expect(onDeleted).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Delete button: cancelled → does NOT call deleteEvent ──
+
+  it('clicking Delete when cancelled does not call deleteEvent', async () => {
+    setup();
+    confirmMock.mockResolvedValueOnce(false);
+
+    await renderEdit();
+
+    const deleteBtn = findButton('Delete');
+    expect(deleteBtn).not.toBeUndefined();
+
+    await act(async () => {
+      deleteBtn!.click();
+    });
+    await flush();
+
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(timelinePort.deleteEvent).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/timeline/event-editor/__tests__/useEventEditor.test.ts
+++ b/src/renderer/timeline/event-editor/__tests__/useEventEditor.test.ts
@@ -7,6 +7,11 @@ import type { EventListItem, EventWithMtime } from '../../data/types';
 
 // ---- Mocks ----
 
+const confirmMock = vi.fn();
+vi.mock('../../../shared/confirm-dialog/confirm-provider', () => ({
+  useConfirm: () => ({ confirm: confirmMock, alert: vi.fn().mockResolvedValue(undefined) }),
+}));
+
 vi.mock('../../data/ports', () => ({
   timelinePort: {
     deleteEvent: vi.fn(),
@@ -55,12 +60,9 @@ const EVENT_WITH_MTIME: EventWithMtime = {
   lastModified: FRESH_MTIME,
 };
 
-const confirmMock = vi.fn(() => true);
-
 beforeEach(() => {
   vi.clearAllMocks();
-  confirmMock.mockReturnValue(true);
-  vi.stubGlobal('confirm', confirmMock);
+  confirmMock.mockReset().mockResolvedValue(true);
   mockReadTemplate.mockResolvedValue(null);
 });
 
@@ -144,7 +146,7 @@ describe('requestDeleteFromCard', () => {
 
   it('does nothing when user declines confirm', async () => {
     const onChanged = vi.fn();
-    confirmMock.mockReturnValue(false);
+    confirmMock.mockResolvedValueOnce(false);
     const { result } = renderHook(() => useEventEditor(CAMPAIGN, onChanged));
     await act(async () => {
       await result.current.requestDeleteFromCard(ITEM);

--- a/src/renderer/timeline/event-editor/useEventEditor.ts
+++ b/src/renderer/timeline/event-editor/useEventEditor.ts
@@ -5,6 +5,7 @@ import type { EditorMode } from './domain';
 import { emptyBuffer, bufferToFrontmatter, deriveFilename } from './domain';
 import { buildNewEventContent, duplicateEventMessage } from './domain/new-event-content';
 import { createEventChecked } from './create-event-checked';
+import { useConfirm } from '../../shared/confirm-dialog/confirm-provider';
 
 export type { EditorMode };
 
@@ -39,6 +40,7 @@ export function useEventEditor(
   campaignPath: string,
   onEventsChanged: () => void,
 ): UseEventEditorResult {
+  const { confirm } = useConfirm();
   const [editorMode, setEditorMode] = useState<EditorMode | null>(null);
   const [cardDeleteConflict, setCardDeleteConflict] = useState<CardDeleteConflict | null>(null);
   const [newEventPrompt, setNewEventPrompt] = useState<NewEventPromptState | null>(null);
@@ -76,9 +78,12 @@ export function useEventEditor(
   const requestDeleteFromCard = useCallback(
     async (item: EventListItem) => {
       const displayName = item.title || item.filename;
-      const ok = window.confirm(
-        `Move "${displayName}" to trash?\n\nRecoverable via Settings → Trash.`,
-      );
+      const ok = await confirm({
+        title: 'Move event to trash',
+        message: `Move "${displayName}" to trash?\n\nRecoverable via Settings → Trash.`,
+        confirmLabel: 'Move to Trash',
+        danger: true,
+      });
       if (!ok) return;
       try {
         await timelinePort.deleteEvent(campaignPath, item.filename, item.mtime);
@@ -91,7 +96,7 @@ export function useEventEditor(
         console.error('[useEventEditor] delete failed', err);
       }
     },
-    [campaignPath, onEventsChanged],
+    [campaignPath, onEventsChanged, confirm],
   );
 
   const resolveCardDeleteConflict = useCallback(

--- a/src/renderer/timeline/session-editor/__tests__/session-editor-modal.test.tsx
+++ b/src/renderer/timeline/session-editor/__tests__/session-editor-modal.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment happy-dom
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+
+// ---- Mock heavy deps before imports ----
+
+const confirmMock = vi.fn();
+vi.mock('../../../shared/confirm-dialog/confirm-provider', () => ({
+  useConfirm: () => ({ confirm: confirmMock, alert: vi.fn().mockResolvedValue(undefined) }),
+}));
+
+vi.mock('../../../theme', () => ({
+  ThemeProvider: {
+    get: vi.fn().mockReturnValue({
+      timeline: {
+        sessions: ['#aa0000', '#00aa00', '#0000aa'],
+      },
+    }),
+  },
+}));
+
+// ---- Imports after mocks ----
+
+import { SessionEditorModal } from '../session-editor-modal';
+import type { Session } from '../../data/types';
+import type { SessionEditorMode } from '../session-domain';
+
+// ---- Fixtures ----
+
+const EXISTING_SESSION: Session = {
+  id: 'ses-abc1',
+  inGameStart: '4726-05-04T13:00',
+  inGameEnd: '4726-05-04T18:00',
+  realStart: '2024-01-15T18:00',
+  realEnd: '2024-01-15T22:00',
+  color: '#aa0000',
+};
+
+const EDIT_MODE: SessionEditorMode = { kind: 'edit', sessionId: EXISTING_SESSION.id };
+
+// ---- Test harness ----
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setup() {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+}
+
+function teardown() {
+  act(() => root.unmount());
+  container.remove();
+}
+
+function getAllButtons(): HTMLButtonElement[] {
+  return Array.from(container.querySelectorAll('button'));
+}
+
+function findButton(text: string): HTMLButtonElement | undefined {
+  return getAllButtons().find((b) => b.textContent?.trim() === text);
+}
+
+interface RenderEditOptions {
+  onClose?: () => void;
+  onSave?: () => Promise<void>;
+  onDelete?: () => Promise<void>;
+}
+
+function renderEdit(options: RenderEditOptions = {}) {
+  const onClose = options.onClose ?? vi.fn();
+  const onSave = options.onSave ?? vi.fn().mockResolvedValue(undefined);
+  const onDelete = options.onDelete ?? vi.fn().mockResolvedValue(undefined);
+
+  act(() => {
+    root.render(
+      <SessionEditorModal
+        mode={EDIT_MODE}
+        sessions={[EXISTING_SESSION]}
+        onClose={onClose}
+        onSave={onSave}
+        onDelete={onDelete}
+      />,
+    );
+  });
+
+  return { onClose, onSave, onDelete };
+}
+
+/** Flush pending async microtasks through React. */
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+// ---- Tests ----
+
+describe('SessionEditorModal', () => {
+  beforeEach(() => {
+    confirmMock.mockReset().mockResolvedValue(true);
+    setup();
+  });
+
+  afterEach(() => {
+    teardown();
+  });
+
+  it('clicking delete with confirmation calls onDelete', async () => {
+    confirmMock.mockResolvedValue(true);
+    const { onDelete } = renderEdit();
+
+    const deleteBtn = findButton('Delete');
+    expect(deleteBtn).not.toBeUndefined();
+
+    await act(async () => {
+      deleteBtn!.click();
+    });
+    await flush();
+
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(confirmMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Delete session',
+        danger: true,
+      }),
+    );
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onDelete).toHaveBeenCalledWith(EXISTING_SESSION.id);
+  });
+
+  it('clicking delete and cancelling does not call onDelete', async () => {
+    confirmMock.mockResolvedValue(false);
+    const { onDelete } = renderEdit();
+
+    const deleteBtn = findButton('Delete');
+    expect(deleteBtn).not.toBeUndefined();
+
+    await act(async () => {
+      deleteBtn!.click();
+    });
+    await flush();
+
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/timeline/session-editor/session-editor-modal.tsx
+++ b/src/renderer/timeline/session-editor/session-editor-modal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, type CSSProperties } from 'react';
 import type { Session } from '../data/types';
 import { ThemeProvider } from '../../theme';
+import { useConfirm } from '../../shared/confirm-dialog/confirm-provider';
 import {
   type SessionEditorMode,
   type SessionBuffer,
@@ -32,6 +33,8 @@ export function SessionEditorModal({
   const isNew = mode.kind === 'create';
   const existingSession =
     mode.kind === 'edit' ? (sessions.find((s) => s.id === mode.sessionId) ?? null) : null;
+
+  const { confirm } = useConfirm();
 
   const [buffer, setBuffer] = useState<SessionBuffer>(() =>
     existingSession
@@ -77,9 +80,12 @@ export function SessionEditorModal({
 
   const handleDelete = useCallback(async () => {
     if (!existingSession) return;
-    const ok = window.confirm(
-      `Delete this session (${existingSession.id})? This cannot be undone.`,
-    );
+    const ok = await confirm({
+      title: 'Delete session',
+      message: `Delete this session (${existingSession.id})? This cannot be undone.`,
+      confirmLabel: 'Delete',
+      danger: true,
+    });
     if (!ok) return;
     setSaving(true);
     try {
@@ -88,7 +94,7 @@ export function SessionEditorModal({
       setError(err instanceof Error ? err.message : String(err));
       setSaving(false);
     }
-  }, [existingSession, onDelete]);
+  }, [existingSession, onDelete, confirm]);
 
   return (
     <div

--- a/src/renderer/views/campaigns/__tests__/campaign-manager.test.tsx
+++ b/src/renderer/views/campaigns/__tests__/campaign-manager.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment happy-dom
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+import { fireEvent } from '@testing-library/react';
+
+// ---- Mock heavy deps before imports ----
+
+const alertMock = vi.fn();
+vi.mock('../../../shared/confirm-dialog/confirm-provider', () => ({
+  useConfirm: () => ({ confirm: vi.fn().mockResolvedValue(true), alert: alertMock }),
+}));
+
+vi.mock('../../../theme', () => ({
+  ThemeProvider: {
+    get: vi.fn().mockReturnValue({
+      bootstrap: {
+        bg: '#000',
+        text: '#fff',
+        textDim: '#aaa',
+        textMuted: '#888',
+        dimLabel: '#666',
+        cardBg: '#111',
+        cardBorder: '#222',
+        hoverBorder: '#333',
+        primary: '#444',
+        primaryActive: '#555',
+        warning: '#fa0',
+      },
+    }),
+  },
+}));
+
+vi.mock('../../../../assets/images/TTT.svg', () => ({ default: 'ttt.svg' }));
+
+// ---- Imports after mocks ----
+
+import { CampaignManager } from '../campaign-manager';
+
+// ---- fsApi stub ----
+
+const fsApiStub = {
+  getAppVersion: vi.fn().mockResolvedValue('1.0.0'),
+  onUpdateAvailable: vi.fn().mockReturnValue(() => {}),
+};
+
+// ---- Test harness ----
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setup() {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+}
+
+function teardown() {
+  act(() => root.unmount());
+  container.remove();
+}
+
+/** Flush pending async microtasks through React. */
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function renderManager(
+  overrides: {
+    onCreate?: (name: string, desc: string) => Promise<{ success: boolean; error?: string }>;
+  } = {},
+) {
+  const onOpen = vi.fn();
+  const onCreate = overrides.onCreate ?? vi.fn().mockResolvedValue({ success: true });
+  const onChangeDir = vi.fn();
+
+  act(() => {
+    root.render(
+      <CampaignManager
+        campaigns={[]}
+        onOpen={onOpen}
+        onCreate={onCreate}
+        onChangeDir={onChangeDir}
+        rootDir="/fake/root"
+      />,
+    );
+  });
+
+  return { onOpen, onCreate, onChangeDir };
+}
+
+/** Open the create form by clicking the "Start New Campaign" card. */
+async function openCreateForm() {
+  // The create card is the first child of main
+  const createCard = container.querySelector<HTMLDivElement>('main > div:first-child');
+  expect(createCard).not.toBeNull();
+  await act(async () => {
+    createCard!.click();
+  });
+}
+
+/** Type a campaign name into the name input field. */
+async function typeName(name: string) {
+  const input = container.querySelector<HTMLInputElement>('input[placeholder="Campaign Name"]');
+  expect(input).not.toBeNull();
+  await act(async () => {
+    fireEvent.change(input!, { target: { value: name } });
+  });
+}
+
+/** Submit the create campaign form. */
+async function submitForm() {
+  const form = container.querySelector('form');
+  expect(form).not.toBeNull();
+  await act(async () => {
+    fireEvent.submit(form!);
+  });
+}
+
+// ---- Tests ----
+
+describe('CampaignManager', () => {
+  beforeEach(() => {
+    alertMock.mockReset().mockResolvedValue(undefined);
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'fsApi', {
+      value: fsApiStub,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    teardown();
+  });
+
+  it('shows an in-app alert when campaign creation fails', async () => {
+    setup();
+    const onCreate = vi.fn().mockResolvedValue({ success: false, error: 'boom' });
+    renderManager({ onCreate });
+
+    await openCreateForm();
+    await typeName('My Campaign');
+    await submitForm();
+    await flush();
+
+    expect(alertMock).toHaveBeenCalledTimes(1);
+    const callArg = alertMock.mock.calls[0][0] as { title?: string; message: string };
+    expect(callArg.message).toContain('boom');
+  });
+
+  it('does not alert when creation succeeds', async () => {
+    setup();
+    const onCreate = vi.fn().mockResolvedValue({ success: true });
+    renderManager({ onCreate });
+
+    await openCreateForm();
+    await typeName('My Campaign');
+    await submitForm();
+    await flush();
+
+    expect(alertMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/views/campaigns/campaign-manager.tsx
+++ b/src/renderer/views/campaigns/campaign-manager.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Campaign } from '../../../types/global';
 import { ThemeProvider } from '../../theme';
+import { useConfirm } from '../../shared/confirm-dialog/confirm-provider';
 import tttIconUrl from '../../../assets/images/TTT.svg';
 
 interface CampaignManagerProps {
@@ -23,6 +24,7 @@ export function CampaignManager({
   rootDir,
 }: CampaignManagerProps) {
   const bs = ThemeProvider.get().bootstrap;
+  const { alert } = useConfirm();
 
   const [isCreating, setIsCreating] = useState(false);
   const [newName, setNewName] = useState('');
@@ -52,7 +54,10 @@ export function CampaignManager({
       setNewName('');
       setNewDesc('');
     } else {
-      alert(result.error);
+      await alert({
+        title: 'Unable to create campaign',
+        message: result.error ?? 'Failed to create campaign.',
+      });
     }
   };
 


### PR DESCRIPTION
## 📝 Description

**Issue(s):** #210

Native `window.confirm()` / `window.alert()` dialogs steal OS focus and leave the Electron renderer unresponsive to mouse/keyboard after closing (inputs go dead until the window is blurred/refocused). This PR introduces a reusable in-app confirm/alert modal and migrates every native dialog call site in the renderer to it, eliminating the focus-loss bug.

> Note: the issue listed 5 sites; the `EventEditorModal` "close with unsaved changes" confirm (~line 329) was already removed by the prior "save as you go" refactor (#206), so there are 4 live sites. All are migrated.

---

## 🔍 Details

* **`src/renderer/shared/confirm-dialog/confirm-provider.tsx` (new):** `ConfirmDialogProvider` + `useConfirm()` hook exposing a promise-based `confirm(): Promise<boolean>` / `alert(): Promise<void>` so call sites keep their `if (await confirm(...))` shape. Hardened so a superseded dialog (a second request while one is open) and an unmounted provider resolve any pending promise as cancelled rather than hanging.
* **`src/renderer/shared/confirm-dialog/confirm-dialog.tsx` + `.css` (new):** pure presentational modal — themed via `var(--theme-*)` (only the `rgba(0,0,0,0.65)` backdrop is literal, per convention), Esc cancels / Enter confirms (capture phase, consistent with other overlays), focuses the primary button on mount, backdrop click cancels, optional destructive (`danger`) styling, z-index above existing modals.
* **`src/renderer/main.tsx`:** mounts the provider once around `<App />` so both the bootstrap campaign manager and the campaign editors are descendants.
* **`src/renderer/timeline/event-editor/useEventEditor.ts` & `EventEditorModal.tsx`:** card-context-menu delete and in-editor delete now use the in-app confirm.
* **`src/renderer/timeline/session-editor/session-editor-modal.tsx`:** session delete now uses the in-app confirm.
* **`src/renderer/views/campaigns/campaign-manager.tsx`:** campaign-creation error now shown via the in-app alert instead of `window.alert`.
* **Tests:** new `confirm-dialog.test.tsx` (12 behavioural cases incl. true/false resolution, Esc/Enter, alert mode, danger styling, multi-line message, out-of-provider guard, concurrent-dialog, backdrop click, focus-on-mount, unmount cleanup). Migration test files updated/added for the event editor, session editor, and campaign manager — each mocks `useConfirm` and asserts the delete/alert is correctly gated. Full suite: 1268 tests pass, lint + build clean.

---

## 🧪 Manual Test Cases

A human reviewer should verify and tick off the following scenarios

### 🚀 New Behavior
- [x] Right-click an event card → Delete → in-app confirm appears; OK deletes, Cancel does not.
- [x] Open an event in the editor → Delete → in-app confirm; confirm deletes the event.
- [x] Delete a session from the session editor → in-app confirm gates the deletion.
- [x] Create a campaign with an invalid/duplicate name → error shown in an in-app alert.
- [x] In any dialog, Esc cancels and Enter confirms; the primary button is focused on open.

### 🛡️ Regression Checks
- [x] After dismissing any of the above dialogs, inputs (e.g. the New Event title field) remain fully clickable/typeable — the #210 dead-input bug no longer reproduces.
- [x] The existing card-delete "changed on disk" conflict overlay still works.
- [x] Dialogs render correctly against the Dark Pathfinder theme (no unstyled/hardcoded colours).

Closes #210

https://claude.ai/code/session_016ShJ1Ze5QV9FQKAGeqjNJo

---
_Generated by [Claude Code](https://claude.ai/code/session_016ShJ1Ze5QV9FQKAGeqjNJo)_