### PR TITLE
#143 Campaign Settings menu (stub)

### DIFF
--- a/src/main/ipcHandlers.ts
+++ b/src/main/ipcHandlers.ts
@@ -42,6 +42,15 @@ export function registerIpcHandlers() {
     return result.filePaths[0];
   });
 
+  // File Selection
+  ipcMain.handle('dialog:selectFile', async () => {
+    const result = await dialog.showOpenDialog({
+      properties: ['openFile'],
+    });
+    if (result.canceled) return null;
+    return result.filePaths[0];
+  });
+
   // Settings
   ipcMain.handle('settings:getRootDir', async () => {
     return getSettings().rootDir || null;

--- a/src/preload/index.cts
+++ b/src/preload/index.cts
@@ -5,6 +5,7 @@ contextBridge.exposeInMainWorld('fsApi', {
   getRootDir: () => ipcRenderer.invoke('settings:getRootDir'),
   setRootDir: (path: string) => ipcRenderer.invoke('settings:setRootDir', path),
   selectDirectory: () => ipcRenderer.invoke('dialog:selectDirectory'),
+  selectFile: () => ipcRenderer.invoke('dialog:selectFile'),
 
   // Campaign Management
   scanCampaigns: (rootDir: string) => ipcRenderer.invoke('campaign:scan', rootDir),

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -247,6 +247,7 @@ export default function App() {
           onChangeView={setCurrentView}
           onBackToCampaigns={handleCloseCampaign}
           onOpenSettings={() => setSettingsOpen(true)}
+          settingsOpen={settingsOpen}
         />
         <SearchOverlay
           isOpen={isSearchOpen}

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -8,6 +8,7 @@ import { CampaignManager } from './views/campaigns/campaign-manager';
 import { useCampaigns } from './hooks/useCampaigns';
 import { ThemeProvider } from './theme';
 import { SearchOverlay } from './components/search-overlay';
+import { CampaignSettingsModal } from './views/settings/campaign-settings-modal';
 import { CampaignLoadOverlay } from './components/campaign-load-overlay';
 import { notesData } from './notes/data';
 import { timelinePort } from './timeline/data/ports';
@@ -24,6 +25,7 @@ import '../../src/index.css';
 export default function App() {
   const [currentView, setCurrentView] = useState<ViewType>('timeline');
   const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [pendingJumpFilename, setPendingJumpFilename] = useState<string | null>(null);
   const [pendingOpenNotePath, setPendingOpenNotePath] = useState<string | null>(null);
   const [pendingNoteMatchOffset, setPendingNoteMatchOffset] = useState<number | null>(null);
@@ -244,6 +246,7 @@ export default function App() {
           currentView={currentView}
           onChangeView={setCurrentView}
           onBackToCampaigns={handleCloseCampaign}
+          onOpenSettings={() => setSettingsOpen(true)}
         />
         <SearchOverlay
           isOpen={isSearchOpen}
@@ -252,6 +255,12 @@ export default function App() {
           onJumpToEvent={handleJumpToEvent}
           onOpenNote={handleOpenNote}
         />
+        {settingsOpen && (
+          <CampaignSettingsModal
+            campaignName={activeCampaign.name}
+            onClose={() => setSettingsOpen(false)}
+          />
+        )}
       </div>
     );
   };

--- a/src/renderer/components/footer-portal.tsx
+++ b/src/renderer/components/footer-portal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-export type FooterSlot = 'left' | 'center' | 'right' | 'far-left';
+export type FooterSlot = 'left' | 'center' | 'right' | 'far-left' | 'settings';
 
 interface FooterPortalProps {
   children: React.ReactNode;

--- a/src/renderer/components/footer.tsx
+++ b/src/renderer/components/footer.tsx
@@ -6,9 +6,15 @@ interface FooterProps {
   currentView: ViewType;
   onChangeView: (view: ViewType) => void;
   onBackToCampaigns: () => void;
+  onOpenSettings: () => void;
 }
 
-export function Footer({ currentView, onChangeView, onBackToCampaigns }: FooterProps) {
+export function Footer({
+  currentView,
+  onChangeView,
+  onBackToCampaigns,
+  onOpenSettings,
+}: FooterProps) {
   const [menuOpen, setMenuOpen] = useState(false);
 
   const viewNames: Record<ViewType, string> = {
@@ -119,6 +125,33 @@ export function Footer({ currentView, onChangeView, onBackToCampaigns }: FooterP
                 margin: '4px 8px',
               }}
             />
+
+            <button
+              onClick={() => {
+                onOpenSettings();
+                setMenuOpen(false);
+              }}
+              style={{
+                background: 'transparent',
+                color: 'var(--theme-text-primary)',
+                border: 'none',
+                padding: '10px 12px',
+                borderRadius: '2px',
+                textAlign: 'left',
+                cursor: 'pointer',
+                fontWeight: 500,
+                fontSize: '14px',
+                transition: 'background 0.1s',
+              }}
+              onMouseOver={(e) => {
+                e.currentTarget.style.background = 'var(--theme-panel)';
+              }}
+              onMouseOut={(e) => {
+                e.currentTarget.style.background = 'transparent';
+              }}
+            >
+              ⚙ Settings
+            </button>
 
             <button
               onClick={() => {

--- a/src/renderer/components/footer.tsx
+++ b/src/renderer/components/footer.tsx
@@ -7,6 +7,7 @@ interface FooterProps {
   onChangeView: (view: ViewType) => void;
   onBackToCampaigns: () => void;
   onOpenSettings: () => void;
+  settingsOpen: boolean;
 }
 
 export function Footer({
@@ -14,6 +15,7 @@ export function Footer({
   onChangeView,
   onBackToCampaigns,
   onOpenSettings,
+  settingsOpen,
 }: FooterProps) {
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -225,6 +227,27 @@ export function Footer({
           }}
         />
       </div>
+
+      {/* Settings masking bar — covers burger menu and view buttons when settings modal is open */}
+      {settingsOpen && (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            backgroundColor: 'var(--theme-panel)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'flex-end',
+            padding: '0 20px',
+            zIndex: 1,
+          }}
+        >
+          <div
+            id="footer-slot-settings"
+            style={{ display: 'flex', alignItems: 'center', gap: '8px' }}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/renderer/views/settings/__tests__/campaign-settings-modal.test.tsx
+++ b/src/renderer/views/settings/__tests__/campaign-settings-modal.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+import { CampaignSettingsModal } from '../campaign-settings-modal';
+
+// happy-dom has no scrollIntoView — stub it globally
+Element.prototype.scrollIntoView = vi.fn();
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setup() {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+}
+
+function teardown() {
+  act(() => root.unmount());
+  container.remove();
+}
+
+const defaultProps = {
+  campaignName: 'Test Campaign',
+  onClose: vi.fn(),
+};
+
+describe('CampaignSettingsModal', () => {
+  beforeEach(() => {
+    defaultProps.onClose = vi.fn();
+  });
+
+  afterEach(() => {
+    teardown();
+  });
+
+  it('renders all four sidebar section headers', () => {
+    setup();
+    act(() => root.render(<CampaignSettingsModal {...defaultProps} />));
+    const sidebar = container.querySelector('nav[aria-label="Settings sections"]');
+    expect(sidebar).not.toBeNull();
+    const buttons = sidebar!.querySelectorAll('button');
+    const labels = Array.from(buttons).map((b) => b.textContent?.trim());
+    expect(labels).toContain('Timeline');
+    expect(labels).toContain('Theme');
+    expect(labels).toContain('Templates');
+    expect(labels).toContain('Keybindings');
+  });
+
+  it('renders the campaign name in the header', () => {
+    setup();
+    act(() =>
+      root.render(<CampaignSettingsModal campaignName="My Cool Campaign" onClose={vi.fn()} />),
+    );
+    expect(container.textContent).toContain('My Cool Campaign');
+  });
+
+  it('pressing Escape calls onClose', () => {
+    setup();
+    const onClose = vi.fn();
+    act(() => root.render(<CampaignSettingsModal campaignName="Test" onClose={onClose} />));
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('clicking the backdrop calls onClose; clicking inside the panel does NOT', () => {
+    setup();
+    const onClose = vi.fn();
+    act(() => root.render(<CampaignSettingsModal campaignName="Test" onClose={onClose} />));
+
+    // Click on the overlay element itself (backdrop)
+    const overlay = container.querySelector('.campaign-settings-overlay') as HTMLElement;
+    act(() => {
+      overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledOnce();
+
+    onClose.mockClear();
+
+    // Click inside the panel — should NOT call onClose
+    const modal = container.querySelector('.campaign-settings-modal') as HTMLElement;
+    act(() => {
+      modal.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('clicking the footer Close button calls onClose', () => {
+    setup();
+    const onClose = vi.fn();
+    act(() => root.render(<CampaignSettingsModal campaignName="Test" onClose={onClose} />));
+
+    const footer = container.querySelector('.campaign-settings-footer') as HTMLElement;
+    const closeBtn = footer.querySelector('button') as HTMLButtonElement;
+    act(() => {
+      closeBtn.click();
+    });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('clicking a sidebar header calls scrollIntoView on the matching section', () => {
+    setup();
+    act(() => root.render(<CampaignSettingsModal {...defaultProps} />));
+
+    const scrollSpy = Element.prototype.scrollIntoView as ReturnType<typeof vi.fn>;
+    scrollSpy.mockClear();
+
+    // Find the "Templates" sidebar button and click it
+    const sidebar = container.querySelector('nav[aria-label="Settings sections"]')!;
+    const templatesBtn = Array.from(sidebar.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'Templates',
+    ) as HTMLButtonElement;
+
+    act(() => {
+      templatesBtn.click();
+    });
+
+    expect(scrollSpy).toHaveBeenCalledOnce();
+    expect(scrollSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+  });
+});

--- a/src/renderer/views/settings/__tests__/campaign-settings-modal.test.tsx
+++ b/src/renderer/views/settings/__tests__/campaign-settings-modal.test.tsx
@@ -91,16 +91,25 @@ describe('CampaignSettingsModal', () => {
   });
 
   it('clicking the footer Close button calls onClose', () => {
-    setup();
-    const onClose = vi.fn();
-    act(() => root.render(<CampaignSettingsModal campaignName="Test" onClose={onClose} />));
+    // The Close button portals into #footer-slot-settings which only exists when
+    // the real Footer is mounted. Create and tear down the target div in isolation.
+    const slotDiv = document.createElement('div');
+    slotDiv.id = 'footer-slot-settings';
+    document.body.appendChild(slotDiv);
 
-    const footer = container.querySelector('.campaign-settings-footer') as HTMLElement;
-    const closeBtn = footer.querySelector('button') as HTMLButtonElement;
+    setup();
+    const onCloseFn = vi.fn();
+    act(() => root.render(<CampaignSettingsModal campaignName="Test" onClose={onCloseFn} />));
+
+    const closeBtn = document
+      .getElementById('footer-slot-settings')!
+      .querySelector('button') as HTMLButtonElement;
     act(() => {
       closeBtn.click();
     });
-    expect(onClose).toHaveBeenCalledOnce();
+    expect(onCloseFn).toHaveBeenCalledOnce();
+
+    slotDiv.remove();
   });
 
   it('clicking a sidebar header calls scrollIntoView on the matching section', () => {

--- a/src/renderer/views/settings/__tests__/campaign-settings-modal.test.tsx
+++ b/src/renderer/views/settings/__tests__/campaign-settings-modal.test.tsx
@@ -132,4 +132,28 @@ describe('CampaignSettingsModal', () => {
     expect(scrollSpy).toHaveBeenCalledOnce();
     expect(scrollSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
   });
+
+  it('Templates section renders dummy template titles; clicking the first reveals the markdown editor', () => {
+    setup();
+    act(() => root.render(<CampaignSettingsModal {...defaultProps} />));
+
+    const templatesSection = container.querySelector('#templates')!;
+    expect(templatesSection).not.toBeNull();
+
+    // All three template titles should appear as accordion headers
+    const accordionHeaders = templatesSection.querySelectorAll('.accordion__header');
+    expect(accordionHeaders.length).toBeGreaterThanOrEqual(3);
+
+    // No editor mounted yet
+    expect(templatesSection.querySelector('.markdown-editor-container')).toBeNull();
+
+    // Click the first accordion header
+    const firstHeader = accordionHeaders[0] as HTMLButtonElement;
+    act(() => {
+      firstHeader.click();
+    });
+
+    // The markdown editor container should now be in the DOM
+    expect(templatesSection.querySelector('.markdown-editor-container')).not.toBeNull();
+  });
 });

--- a/src/renderer/views/settings/campaign-settings-modal.css
+++ b/src/renderer/views/settings/campaign-settings-modal.css
@@ -131,12 +131,12 @@
 }
 
 .campaign-settings-section__title {
-  margin: 0 0 4px;
-  font-size: 14px;
+  margin: 0 -28px;
+  padding: 10px 28px;
+  font-size: 20px;
   font-weight: 600;
   color: var(--theme-text-primary);
-  border-bottom: 1px solid var(--theme-border);
-  padding-bottom: 8px;
+  background: var(--theme-panel);
 }
 
 /* Templates subheading */

--- a/src/renderer/views/settings/campaign-settings-modal.css
+++ b/src/renderer/views/settings/campaign-settings-modal.css
@@ -1,0 +1,162 @@
+.campaign-settings-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.campaign-settings-modal {
+  background: var(--theme-surface);
+  border: 1px solid var(--theme-border-strong);
+  border-radius: 6px;
+  width: min(900px, 92vw);
+  height: min(680px, 88vh);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Header */
+.campaign-settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--theme-border);
+  flex-shrink: 0;
+  background: var(--theme-panel);
+}
+
+.campaign-settings-header__titles {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.campaign-settings-header__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--theme-accent-gold);
+}
+
+.campaign-settings-header__subtitle {
+  margin: 0;
+  font-size: 12px;
+  color: var(--theme-text-secondary);
+}
+
+.campaign-settings-close {
+  background: none;
+  border: none;
+  color: var(--theme-text-secondary);
+  font-size: 22px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.campaign-settings-close:hover {
+  color: var(--theme-text-primary);
+}
+
+/* Body (sidebar + content) */
+.campaign-settings-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+/* Sidebar */
+.campaign-settings-sidebar {
+  width: 200px;
+  flex-shrink: 0;
+  background: var(--theme-panel);
+  border-right: 1px solid var(--theme-border);
+  display: flex;
+  flex-direction: column;
+  padding: 12px 0;
+  overflow-y: auto;
+}
+
+.campaign-settings-sidebar__btn {
+  background: none;
+  border: none;
+  text-align: left;
+  padding: 10px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--theme-text-secondary);
+  cursor: pointer;
+  border-left: 3px solid transparent;
+  width: 100%;
+  transition: color 0.1s, background 0.1s;
+}
+
+.campaign-settings-sidebar__btn:hover {
+  color: var(--theme-text-primary);
+  background: var(--theme-panel-accent);
+}
+
+.campaign-settings-sidebar__btn--active {
+  color: var(--theme-accent-gold);
+  border-left-color: var(--theme-accent-gold);
+  background: var(--theme-panel-accent);
+}
+
+/* Content area */
+.campaign-settings-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+/* Individual sections */
+.campaign-settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.campaign-settings-section__title {
+  margin: 0 0 4px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--theme-text-primary);
+  border-bottom: 1px solid var(--theme-border);
+  padding-bottom: 8px;
+}
+
+/* Footer */
+.campaign-settings-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 12px 20px;
+  border-top: 1px solid var(--theme-border);
+  flex-shrink: 0;
+  background: var(--theme-panel);
+}
+
+.campaign-settings-footer__close-btn {
+  background: var(--theme-panel-accent);
+  border: 1px solid var(--theme-border);
+  color: var(--theme-text-primary);
+  border-radius: 4px;
+  padding: 7px 20px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.campaign-settings-footer__close-btn:hover {
+  border-color: var(--theme-border-strong);
+  color: var(--theme-accent-warm);
+}

--- a/src/renderer/views/settings/campaign-settings-modal.css
+++ b/src/renderer/views/settings/campaign-settings-modal.css
@@ -1,6 +1,9 @@
 .campaign-settings-overlay {
   position: fixed;
-  inset: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 50px;
   background: rgba(0, 0, 0, 0.7);
   z-index: 2000;
   display: flex;
@@ -12,8 +15,10 @@
   background: var(--theme-surface);
   border: 1px solid var(--theme-border-strong);
   border-radius: 6px;
-  width: min(900px, 92vw);
-  height: min(680px, 88vh);
+  width: min(1100px, 94vw);
+  height: calc(100vh - 50px - 32px);
+  max-height: calc(100vh - 50px - 32px);
+  max-width: 94vw;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -134,29 +139,3 @@
   padding-bottom: 8px;
 }
 
-/* Footer */
-.campaign-settings-footer {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  padding: 12px 20px;
-  border-top: 1px solid var(--theme-border);
-  flex-shrink: 0;
-  background: var(--theme-panel);
-}
-
-.campaign-settings-footer__close-btn {
-  background: var(--theme-panel-accent);
-  border: 1px solid var(--theme-border);
-  color: var(--theme-text-primary);
-  border-radius: 4px;
-  padding: 7px 20px;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-}
-
-.campaign-settings-footer__close-btn:hover {
-  border-color: var(--theme-border-strong);
-  color: var(--theme-accent-warm);
-}

--- a/src/renderer/views/settings/campaign-settings-modal.css
+++ b/src/renderer/views/settings/campaign-settings-modal.css
@@ -139,3 +139,26 @@
   padding-bottom: 8px;
 }
 
+/* Templates subheading */
+.campaign-settings-templates-subheading {
+  margin: 16px 0 8px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--theme-text-muted);
+}
+
+/* Template editor host (accordion body) */
+.campaign-settings-template-editor {
+  height: 320px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.campaign-settings-template-editor .markdown-editor-container {
+  flex: 1;
+  overflow: auto;
+}
+

--- a/src/renderer/views/settings/campaign-settings-modal.tsx
+++ b/src/renderer/views/settings/campaign-settings-modal.tsx
@@ -6,6 +6,8 @@ import { SelectField } from './controls/select-field';
 import { SliderField } from './controls/slider-field';
 import { TextField } from './controls/text-field';
 import { FilePickerField } from './controls/file-picker-field';
+import { FooterPortal } from '../../components/footer-portal';
+import { FooterButton } from '../../components/footer-button';
 import './campaign-settings-modal.css';
 
 export interface CampaignSettingsModalProps {
@@ -72,207 +74,205 @@ export function CampaignSettingsModal({ campaignName, onClose }: CampaignSetting
   };
 
   return (
-    <div
-      className="campaign-settings-overlay"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-    >
-      <div className="campaign-settings-modal">
-        {/* Header */}
-        <div className="campaign-settings-header">
-          <div className="campaign-settings-header__titles">
-            <h2 className="campaign-settings-header__title">Campaign Settings</h2>
-            <p className="campaign-settings-header__subtitle">{campaignName}</p>
+    <>
+      <div
+        className="campaign-settings-overlay"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) onClose();
+        }}
+      >
+        <div className="campaign-settings-modal">
+          {/* Header */}
+          <div className="campaign-settings-header">
+            <div className="campaign-settings-header__titles">
+              <h2 className="campaign-settings-header__title">Campaign Settings</h2>
+              <p className="campaign-settings-header__subtitle">{campaignName}</p>
+            </div>
+            <button
+              type="button"
+              className="campaign-settings-close"
+              aria-label="Close"
+              onClick={onClose}
+            >
+              ×
+            </button>
           </div>
-          <button
-            type="button"
-            className="campaign-settings-close"
-            aria-label="Close"
-            onClick={onClose}
-          >
-            ×
-          </button>
-        </div>
 
-        {/* Body */}
-        <div className="campaign-settings-body">
-          {/* Sidebar */}
-          <nav className="campaign-settings-sidebar" aria-label="Settings sections">
-            {SETTINGS_SECTIONS.map((section) => (
-              <button
-                key={section.id}
-                type="button"
-                className={`campaign-settings-sidebar__btn${activeSection === section.id ? ' campaign-settings-sidebar__btn--active' : ''}`}
-                onClick={() => handleSidebarClick(section.id)}
-              >
-                {section.label}
-              </button>
-            ))}
-          </nav>
+          {/* Body */}
+          <div className="campaign-settings-body">
+            {/* Sidebar */}
+            <nav className="campaign-settings-sidebar" aria-label="Settings sections">
+              {SETTINGS_SECTIONS.map((section) => (
+                <button
+                  key={section.id}
+                  type="button"
+                  className={`campaign-settings-sidebar__btn${activeSection === section.id ? ' campaign-settings-sidebar__btn--active' : ''}`}
+                  onClick={() => handleSidebarClick(section.id)}
+                >
+                  {section.label}
+                </button>
+              ))}
+            </nav>
 
-          {/* Content */}
-          <div className="campaign-settings-content" ref={contentRef}>
-            {/* Timeline section */}
-            <section
-              id="timeline"
-              className="campaign-settings-section"
-              ref={(el) => {
-                sectionRefs.current['timeline'] = el;
-              }}
-            >
-              <h3 className="campaign-settings-section__title">Timeline</h3>
-              <SettingRow
-                label="Show future events as dotted"
-                description="Render events after today with a dashed border on the timeline."
-                htmlFor="timeline-future-events"
+            {/* Content */}
+            <div className="campaign-settings-content" ref={contentRef}>
+              {/* Timeline section */}
+              <section
+                id="timeline"
+                className="campaign-settings-section"
+                ref={(el) => {
+                  sectionRefs.current['timeline'] = el;
+                }}
               >
-                <Toggle
-                  id="timeline-future-events"
-                  checked={showFutureEvents}
-                  onChange={setShowFutureEvents}
-                />
-              </SettingRow>
-              <SettingRow
-                label="Default calendar"
-                description="The calendar system used for in-game dates."
-                htmlFor="timeline-calendar"
-              >
-                <SelectField
-                  id="timeline-calendar"
-                  value={defaultCalendar}
-                  options={[
-                    { value: 'gregorian', label: 'Gregorian' },
-                    { value: 'golarian', label: 'Golarian' },
-                    { value: 'harptos', label: 'Harptos (Faerûn)' },
-                  ]}
-                  onChange={setDefaultCalendar}
-                />
-              </SettingRow>
-              <SettingRow
-                label="Default zoom level"
-                description="The initial zoom when opening a campaign (0 = zoomed out, 100 = zoomed in)."
-                htmlFor="timeline-zoom"
-              >
-                <SliderField
-                  id="timeline-zoom"
-                  value={defaultZoom}
-                  min={0}
-                  max={100}
-                  step={5}
-                  onChange={setDefaultZoom}
-                />
-              </SettingRow>
-            </section>
+                <h3 className="campaign-settings-section__title">Timeline</h3>
+                <SettingRow
+                  label="Show future events as dotted"
+                  description="Render events after today with a dashed border on the timeline."
+                  htmlFor="timeline-future-events"
+                >
+                  <Toggle
+                    id="timeline-future-events"
+                    checked={showFutureEvents}
+                    onChange={setShowFutureEvents}
+                  />
+                </SettingRow>
+                <SettingRow
+                  label="Default calendar"
+                  description="The calendar system used for in-game dates."
+                  htmlFor="timeline-calendar"
+                >
+                  <SelectField
+                    id="timeline-calendar"
+                    value={defaultCalendar}
+                    options={[
+                      { value: 'gregorian', label: 'Gregorian' },
+                      { value: 'golarian', label: 'Golarian' },
+                      { value: 'harptos', label: 'Harptos (Faerûn)' },
+                    ]}
+                    onChange={setDefaultCalendar}
+                  />
+                </SettingRow>
+                <SettingRow
+                  label="Default zoom level"
+                  description="The initial zoom when opening a campaign (0 = zoomed out, 100 = zoomed in)."
+                  htmlFor="timeline-zoom"
+                >
+                  <SliderField
+                    id="timeline-zoom"
+                    value={defaultZoom}
+                    min={0}
+                    max={100}
+                    step={5}
+                    onChange={setDefaultZoom}
+                  />
+                </SettingRow>
+              </section>
 
-            {/* Theme section */}
-            <section
-              id="theme"
-              className="campaign-settings-section"
-              ref={(el) => {
-                sectionRefs.current['theme'] = el;
-              }}
-            >
-              <h3 className="campaign-settings-section__title">Theme</h3>
-              <SettingRow
-                label="Theme"
-                description="The visual theme applied to the entire application."
-                htmlFor="theme-select"
+              {/* Theme section */}
+              <section
+                id="theme"
+                className="campaign-settings-section"
+                ref={(el) => {
+                  sectionRefs.current['theme'] = el;
+                }}
               >
-                <SelectField
-                  id="theme-select"
-                  value={selectedTheme}
-                  options={[{ value: 'dark-pathfinder', label: 'Dark Pathfinder' }]}
-                  onChange={setSelectedTheme}
-                />
-              </SettingRow>
-              <SettingRow
-                label="High-contrast mode"
-                description="Increase contrast for improved readability."
-                htmlFor="theme-high-contrast"
-              >
-                <Toggle
-                  id="theme-high-contrast"
-                  checked={highContrast}
-                  onChange={setHighContrast}
-                />
-              </SettingRow>
-            </section>
+                <h3 className="campaign-settings-section__title">Theme</h3>
+                <SettingRow
+                  label="Theme"
+                  description="The visual theme applied to the entire application."
+                  htmlFor="theme-select"
+                >
+                  <SelectField
+                    id="theme-select"
+                    value={selectedTheme}
+                    options={[{ value: 'dark-pathfinder', label: 'Dark Pathfinder' }]}
+                    onChange={setSelectedTheme}
+                  />
+                </SettingRow>
+                <SettingRow
+                  label="High-contrast mode"
+                  description="Increase contrast for improved readability."
+                  htmlFor="theme-high-contrast"
+                >
+                  <Toggle
+                    id="theme-high-contrast"
+                    checked={highContrast}
+                    onChange={setHighContrast}
+                  />
+                </SettingRow>
+              </section>
 
-            {/* Templates section */}
-            <section
-              id="templates"
-              className="campaign-settings-section"
-              ref={(el) => {
-                sectionRefs.current['templates'] = el;
-              }}
-            >
-              <h3 className="campaign-settings-section__title">Templates</h3>
-              <SettingRow
-                label="Templates folder name"
-                description="The subfolder within the campaign directory where templates are stored."
-                htmlFor="templates-folder"
+              {/* Templates section */}
+              <section
+                id="templates"
+                className="campaign-settings-section"
+                ref={(el) => {
+                  sectionRefs.current['templates'] = el;
+                }}
               >
-                <TextField
-                  id="templates-folder"
-                  value={templatesFolder}
-                  onChange={setTemplatesFolder}
-                  placeholder="templates"
-                />
-              </SettingRow>
-              <SettingRow
-                label="Default event template"
-                description="The template file used when creating a new event."
-                htmlFor="templates-default"
-              >
-                <FilePickerField
-                  id="templates-default"
-                  value={defaultTemplate}
-                  onChange={setDefaultTemplate}
-                  buttonLabel="Choose template…"
-                />
-              </SettingRow>
-            </section>
+                <h3 className="campaign-settings-section__title">Templates</h3>
+                <SettingRow
+                  label="Templates folder name"
+                  description="The subfolder within the campaign directory where templates are stored."
+                  htmlFor="templates-folder"
+                >
+                  <TextField
+                    id="templates-folder"
+                    value={templatesFolder}
+                    onChange={setTemplatesFolder}
+                    placeholder="templates"
+                  />
+                </SettingRow>
+                <SettingRow
+                  label="Default event template"
+                  description="The template file used when creating a new event."
+                  htmlFor="templates-default"
+                >
+                  <FilePickerField
+                    id="templates-default"
+                    value={defaultTemplate}
+                    onChange={setDefaultTemplate}
+                    buttonLabel="Choose template…"
+                  />
+                </SettingRow>
+              </section>
 
-            {/* Keybindings section */}
-            <section
-              id="keybindings"
-              className="campaign-settings-section"
-              ref={(el) => {
-                sectionRefs.current['keybindings'] = el;
-              }}
-            >
-              <h3 className="campaign-settings-section__title">Keybindings</h3>
-              <SettingRow
-                label="Quick-search shortcut"
-                description="The keyboard shortcut that opens the quick-search panel."
-                htmlFor="keybindings-search"
+              {/* Keybindings section */}
+              <section
+                id="keybindings"
+                className="campaign-settings-section"
+                ref={(el) => {
+                  sectionRefs.current['keybindings'] = el;
+                }}
               >
-                <TextField
-                  id="keybindings-search"
-                  value={quickSearchShortcut}
-                  onChange={setQuickSearchShortcut}
-                  placeholder="Ctrl+F"
-                />
-              </SettingRow>
-              <SettingRow
-                label="Enable Vim-style keys"
-                description="Use h/j/k/l navigation in lists and the timeline."
-                htmlFor="keybindings-vim"
-              >
-                <Toggle id="keybindings-vim" checked={vimKeys} onChange={setVimKeys} />
-              </SettingRow>
-            </section>
+                <h3 className="campaign-settings-section__title">Keybindings</h3>
+                <SettingRow
+                  label="Quick-search shortcut"
+                  description="The keyboard shortcut that opens the quick-search panel."
+                  htmlFor="keybindings-search"
+                >
+                  <TextField
+                    id="keybindings-search"
+                    value={quickSearchShortcut}
+                    onChange={setQuickSearchShortcut}
+                    placeholder="Ctrl+F"
+                  />
+                </SettingRow>
+                <SettingRow
+                  label="Enable Vim-style keys"
+                  description="Use h/j/k/l navigation in lists and the timeline."
+                  htmlFor="keybindings-vim"
+                >
+                  <Toggle id="keybindings-vim" checked={vimKeys} onChange={setVimKeys} />
+                </SettingRow>
+              </section>
+            </div>
           </div>
-        </div>
-
-        {/* Footer */}
-        <div className="campaign-settings-footer">
-          <button type="button" className="campaign-settings-footer__close-btn" onClick={onClose}>
-            Close
-          </button>
         </div>
       </div>
-    </div>
+      <FooterPortal slot="settings">
+        <FooterButton onClick={onClose}>Close</FooterButton>
+      </FooterPortal>
+    </>
   );
 }

--- a/src/renderer/views/settings/campaign-settings-modal.tsx
+++ b/src/renderer/views/settings/campaign-settings-modal.tsx
@@ -1,0 +1,278 @@
+import { useEffect, useRef, useState } from 'react';
+import { SETTINGS_SECTIONS } from './domain/settings-sections';
+import { SettingRow } from './controls/setting-row';
+import { Toggle } from './controls/toggle';
+import { SelectField } from './controls/select-field';
+import { SliderField } from './controls/slider-field';
+import { TextField } from './controls/text-field';
+import { FilePickerField } from './controls/file-picker-field';
+import './campaign-settings-modal.css';
+
+export interface CampaignSettingsModalProps {
+  campaignName: string;
+  onClose: () => void;
+}
+
+export function CampaignSettingsModal({ campaignName, onClose }: CampaignSettingsModalProps) {
+  const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const [activeSection, setActiveSection] = useState<string>(SETTINGS_SECTIONS[0].id);
+
+  // --- Timeline state ---
+  const [showFutureEvents, setShowFutureEvents] = useState(false);
+  const [defaultCalendar, setDefaultCalendar] = useState('gregorian');
+  const [defaultZoom, setDefaultZoom] = useState(50);
+
+  // --- Theme state ---
+  const [selectedTheme, setSelectedTheme] = useState('dark-pathfinder');
+  const [highContrast, setHighContrast] = useState(false);
+
+  // --- Templates state ---
+  const [templatesFolder, setTemplatesFolder] = useState('templates');
+  const [defaultTemplate, setDefaultTemplate] = useState<string | null>(null);
+
+  // --- Keybindings state ---
+  const [quickSearchShortcut, setQuickSearchShortcut] = useState('Ctrl+F');
+  const [vimKeys, setVimKeys] = useState(false);
+
+  // Escape closes the modal (capture phase wins over other handlers)
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', onKey, { capture: true });
+    return () => document.removeEventListener('keydown', onKey, { capture: true });
+  }, [onClose]);
+
+  // Track active section as user scrolls
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+
+    const handleScroll = () => {
+      for (const section of [...SETTINGS_SECTIONS].reverse()) {
+        const ref = sectionRefs.current[section.id];
+        if (ref && ref.getBoundingClientRect().top <= el.getBoundingClientRect().top + 80) {
+          setActiveSection(section.id);
+          return;
+        }
+      }
+    };
+
+    el.addEventListener('scroll', handleScroll, { passive: true });
+    return () => el.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const handleSidebarClick = (id: string) => {
+    sectionRefs.current[id]?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    setActiveSection(id);
+  };
+
+  return (
+    <div
+      className="campaign-settings-overlay"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="campaign-settings-modal">
+        {/* Header */}
+        <div className="campaign-settings-header">
+          <div className="campaign-settings-header__titles">
+            <h2 className="campaign-settings-header__title">Campaign Settings</h2>
+            <p className="campaign-settings-header__subtitle">{campaignName}</p>
+          </div>
+          <button
+            type="button"
+            className="campaign-settings-close"
+            aria-label="Close"
+            onClick={onClose}
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="campaign-settings-body">
+          {/* Sidebar */}
+          <nav className="campaign-settings-sidebar" aria-label="Settings sections">
+            {SETTINGS_SECTIONS.map((section) => (
+              <button
+                key={section.id}
+                type="button"
+                className={`campaign-settings-sidebar__btn${activeSection === section.id ? ' campaign-settings-sidebar__btn--active' : ''}`}
+                onClick={() => handleSidebarClick(section.id)}
+              >
+                {section.label}
+              </button>
+            ))}
+          </nav>
+
+          {/* Content */}
+          <div className="campaign-settings-content" ref={contentRef}>
+            {/* Timeline section */}
+            <section
+              id="timeline"
+              className="campaign-settings-section"
+              ref={(el) => {
+                sectionRefs.current['timeline'] = el;
+              }}
+            >
+              <h3 className="campaign-settings-section__title">Timeline</h3>
+              <SettingRow
+                label="Show future events as dotted"
+                description="Render events after today with a dashed border on the timeline."
+                htmlFor="timeline-future-events"
+              >
+                <Toggle
+                  id="timeline-future-events"
+                  checked={showFutureEvents}
+                  onChange={setShowFutureEvents}
+                />
+              </SettingRow>
+              <SettingRow
+                label="Default calendar"
+                description="The calendar system used for in-game dates."
+                htmlFor="timeline-calendar"
+              >
+                <SelectField
+                  id="timeline-calendar"
+                  value={defaultCalendar}
+                  options={[
+                    { value: 'gregorian', label: 'Gregorian' },
+                    { value: 'golarian', label: 'Golarian' },
+                    { value: 'harptos', label: 'Harptos (Faerûn)' },
+                  ]}
+                  onChange={setDefaultCalendar}
+                />
+              </SettingRow>
+              <SettingRow
+                label="Default zoom level"
+                description="The initial zoom when opening a campaign (0 = zoomed out, 100 = zoomed in)."
+                htmlFor="timeline-zoom"
+              >
+                <SliderField
+                  id="timeline-zoom"
+                  value={defaultZoom}
+                  min={0}
+                  max={100}
+                  step={5}
+                  onChange={setDefaultZoom}
+                />
+              </SettingRow>
+            </section>
+
+            {/* Theme section */}
+            <section
+              id="theme"
+              className="campaign-settings-section"
+              ref={(el) => {
+                sectionRefs.current['theme'] = el;
+              }}
+            >
+              <h3 className="campaign-settings-section__title">Theme</h3>
+              <SettingRow
+                label="Theme"
+                description="The visual theme applied to the entire application."
+                htmlFor="theme-select"
+              >
+                <SelectField
+                  id="theme-select"
+                  value={selectedTheme}
+                  options={[{ value: 'dark-pathfinder', label: 'Dark Pathfinder' }]}
+                  onChange={setSelectedTheme}
+                />
+              </SettingRow>
+              <SettingRow
+                label="High-contrast mode"
+                description="Increase contrast for improved readability."
+                htmlFor="theme-high-contrast"
+              >
+                <Toggle
+                  id="theme-high-contrast"
+                  checked={highContrast}
+                  onChange={setHighContrast}
+                />
+              </SettingRow>
+            </section>
+
+            {/* Templates section */}
+            <section
+              id="templates"
+              className="campaign-settings-section"
+              ref={(el) => {
+                sectionRefs.current['templates'] = el;
+              }}
+            >
+              <h3 className="campaign-settings-section__title">Templates</h3>
+              <SettingRow
+                label="Templates folder name"
+                description="The subfolder within the campaign directory where templates are stored."
+                htmlFor="templates-folder"
+              >
+                <TextField
+                  id="templates-folder"
+                  value={templatesFolder}
+                  onChange={setTemplatesFolder}
+                  placeholder="templates"
+                />
+              </SettingRow>
+              <SettingRow
+                label="Default event template"
+                description="The template file used when creating a new event."
+                htmlFor="templates-default"
+              >
+                <FilePickerField
+                  id="templates-default"
+                  value={defaultTemplate}
+                  onChange={setDefaultTemplate}
+                  buttonLabel="Choose template…"
+                />
+              </SettingRow>
+            </section>
+
+            {/* Keybindings section */}
+            <section
+              id="keybindings"
+              className="campaign-settings-section"
+              ref={(el) => {
+                sectionRefs.current['keybindings'] = el;
+              }}
+            >
+              <h3 className="campaign-settings-section__title">Keybindings</h3>
+              <SettingRow
+                label="Quick-search shortcut"
+                description="The keyboard shortcut that opens the quick-search panel."
+                htmlFor="keybindings-search"
+              >
+                <TextField
+                  id="keybindings-search"
+                  value={quickSearchShortcut}
+                  onChange={setQuickSearchShortcut}
+                  placeholder="Ctrl+F"
+                />
+              </SettingRow>
+              <SettingRow
+                label="Enable Vim-style keys"
+                description="Use h/j/k/l navigation in lists and the timeline."
+                htmlFor="keybindings-vim"
+              >
+                <Toggle id="keybindings-vim" checked={vimKeys} onChange={setVimKeys} />
+              </SettingRow>
+            </section>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="campaign-settings-footer">
+          <button type="button" className="campaign-settings-footer__close-btn" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/views/settings/campaign-settings-modal.tsx
+++ b/src/renderer/views/settings/campaign-settings-modal.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
 import { SETTINGS_SECTIONS } from './domain/settings-sections';
+import { DUMMY_TEMPLATES } from './domain/dummy-templates';
 import { SettingRow } from './controls/setting-row';
 import { Toggle } from './controls/toggle';
 import { SelectField } from './controls/select-field';
 import { SliderField } from './controls/slider-field';
 import { TextField } from './controls/text-field';
 import { FilePickerField } from './controls/file-picker-field';
+import { Accordion } from './controls/accordion';
+import { MarkdownEditor } from '../../shared/markdown-editor';
 import { FooterPortal } from '../../components/footer-portal';
 import { FooterButton } from '../../components/footer-button';
 import './campaign-settings-modal.css';
@@ -32,6 +35,11 @@ export function CampaignSettingsModal({ campaignName, onClose }: CampaignSetting
   // --- Templates state ---
   const [templatesFolder, setTemplatesFolder] = useState('templates');
   const [defaultTemplate, setDefaultTemplate] = useState<string | null>(null);
+  const [templates, setTemplates] = useState(DUMMY_TEMPLATES);
+
+  const updateTemplate = (id: string, content: string) => {
+    setTemplates((prev) => prev.map((t) => (t.id === id ? { ...t, content } : t)));
+  };
 
   // --- Keybindings state ---
   const [quickSearchShortcut, setQuickSearchShortcut] = useState('Ctrl+F');
@@ -235,6 +243,21 @@ export function CampaignSettingsModal({ campaignName, onClose }: CampaignSetting
                     buttonLabel="Choose template…"
                   />
                 </SettingRow>
+                <h4 className="campaign-settings-templates-subheading">Edit templates</h4>
+                <Accordion
+                  items={templates.map((t) => ({ id: t.id, title: t.name }))}
+                  renderBody={(id) => {
+                    const tpl = templates.find((t) => t.id === id)!;
+                    return (
+                      <div className="campaign-settings-template-editor">
+                        <MarkdownEditor
+                          content={tpl.content}
+                          onChange={(s) => updateTemplate(id, s)}
+                        />
+                      </div>
+                    );
+                  }}
+                />
               </section>
 
               {/* Keybindings section */}

--- a/src/renderer/views/settings/controls/__tests__/accordion.test.tsx
+++ b/src/renderer/views/settings/controls/__tests__/accordion.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+import { Accordion, type AccordionItem } from '../accordion';
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setup() {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+}
+
+function teardown() {
+  act(() => root.unmount());
+  container.remove();
+}
+
+afterEach(() => {
+  teardown();
+});
+
+const ITEMS: AccordionItem[] = [
+  { id: 'a', title: 'Item A' },
+  { id: 'b', title: 'Item B' },
+  { id: 'c', title: 'Item C' },
+];
+
+function renderBody(id: string) {
+  return <div data-testid={`body-${id}`}>body {id}</div>;
+}
+
+describe('Accordion', () => {
+  it('renders all item titles', () => {
+    setup();
+    act(() => root.render(<Accordion items={ITEMS} renderBody={renderBody} />));
+    const titleEls = container.querySelectorAll('.accordion__title');
+    const titles = Array.from(titleEls).map((el) => el.textContent?.trim());
+    expect(titles).toContain('Item A');
+    expect(titles).toContain('Item B');
+    expect(titles).toContain('Item C');
+  });
+
+  it('clicking a header opens it and its body appears in the DOM', () => {
+    setup();
+    act(() => root.render(<Accordion items={ITEMS} renderBody={renderBody} />));
+
+    // No body visible initially
+    expect(container.querySelector('[data-testid="body-a"]')).toBeNull();
+
+    const headerA = Array.from(container.querySelectorAll('.accordion__header')).find((h) =>
+      h.textContent?.includes('Item A'),
+    ) as HTMLButtonElement;
+
+    act(() => {
+      headerA.click();
+    });
+
+    expect(container.querySelector('[data-testid="body-a"]')).not.toBeNull();
+    expect(headerA.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('opening a second item closes the first (only one body in DOM)', () => {
+    setup();
+    act(() => root.render(<Accordion items={ITEMS} renderBody={renderBody} />));
+
+    const [headerA, headerB] = Array.from(
+      container.querySelectorAll('.accordion__header'),
+    ) as HTMLButtonElement[];
+
+    act(() => {
+      headerA.click();
+    });
+    expect(container.querySelector('[data-testid="body-a"]')).not.toBeNull();
+
+    act(() => {
+      headerB.click();
+    });
+
+    // A is closed, B is open
+    expect(container.querySelector('[data-testid="body-a"]')).toBeNull();
+    expect(container.querySelector('[data-testid="body-b"]')).not.toBeNull();
+
+    // Only one body in the DOM total
+    expect(container.querySelectorAll('.accordion__body').length).toBe(1);
+  });
+
+  it('clicking the open header closes it (no body in DOM)', () => {
+    setup();
+    act(() => root.render(<Accordion items={ITEMS} renderBody={renderBody} />));
+
+    const headerA = Array.from(container.querySelectorAll('.accordion__header')).find((h) =>
+      h.textContent?.includes('Item A'),
+    ) as HTMLButtonElement;
+
+    act(() => {
+      headerA.click();
+    });
+    expect(container.querySelector('[data-testid="body-a"]')).not.toBeNull();
+
+    act(() => {
+      headerA.click();
+    });
+    expect(container.querySelector('[data-testid="body-a"]')).toBeNull();
+    expect(headerA.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('renderBody is NOT called for closed items (only the open id is rendered)', () => {
+    setup();
+    const renderBodySpy = vi.fn((id: string) => <div data-testid={`body-${id}`}>body {id}</div>);
+
+    act(() => root.render(<Accordion items={ITEMS} renderBody={renderBodySpy} />));
+
+    // Nothing open yet — renderBody should not have been called
+    expect(renderBodySpy).not.toHaveBeenCalled();
+
+    const headerA = Array.from(container.querySelectorAll('.accordion__header')).find((h) =>
+      h.textContent?.includes('Item A'),
+    ) as HTMLButtonElement;
+
+    act(() => {
+      headerA.click();
+    });
+
+    // renderBody should have been called exactly once, for 'a'
+    expect(renderBodySpy).toHaveBeenCalledTimes(1);
+    expect(renderBodySpy).toHaveBeenCalledWith('a');
+  });
+});

--- a/src/renderer/views/settings/controls/__tests__/controls.test.tsx
+++ b/src/renderer/views/settings/controls/__tests__/controls.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment happy-dom
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+import { Toggle } from '../toggle';
+import { SelectField } from '../select-field';
+import { TextField } from '../text-field';
+import { SliderField } from '../slider-field';
+import { FilePickerField } from '../file-picker-field';
+import { SettingRow } from '../setting-row';
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setup() {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+}
+
+function teardown() {
+  act(() => root.unmount());
+  container.remove();
+}
+
+afterEach(() => {
+  teardown();
+});
+
+describe('Toggle', () => {
+  it('calls onChange with negated value when clicked', () => {
+    setup();
+    const onChange = vi.fn();
+    act(() => root.render(<Toggle checked={false} onChange={onChange} />));
+    act(() => {
+      (container.querySelector('button') as HTMLButtonElement).click();
+    });
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('reflects checked state via aria-checked', () => {
+    setup();
+    act(() => root.render(<Toggle checked={true} onChange={() => {}} />));
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    expect(btn.getAttribute('aria-checked')).toBe('true');
+
+    act(() => root.render(<Toggle checked={false} onChange={() => {}} />));
+    expect(btn.getAttribute('aria-checked')).toBe('false');
+  });
+});
+
+describe('SelectField', () => {
+  it('calls onChange with the chosen option value', () => {
+    setup();
+    const onChange = vi.fn();
+    const options = [
+      { value: 'a', label: 'Option A' },
+      { value: 'b', label: 'Option B' },
+    ];
+    act(() => root.render(<SelectField value="a" options={options} onChange={onChange} />));
+    const select = container.querySelector('select') as HTMLSelectElement;
+    act(() => {
+      select.value = 'b';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+});
+
+describe('TextField', () => {
+  it('calls onChange with typed value', () => {
+    setup();
+    const onChange = vi.fn();
+    act(() => root.render(<TextField value="" onChange={onChange} />));
+    const input = container.querySelector('input') as HTMLInputElement;
+    act(() => {
+      // Use the native value setter so React's synthetic event sees the new value
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      )?.set;
+      nativeInputValueSetter?.call(input, 'hello');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledWith('hello');
+  });
+});
+
+describe('SliderField', () => {
+  it('calls onChange with a numeric value', () => {
+    setup();
+    const onChange = vi.fn();
+    act(() => root.render(<SliderField value={50} onChange={onChange} />));
+    const input = container.querySelector('input[type="range"]') as HTMLInputElement;
+    act(() => {
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      )?.set;
+      nativeInputValueSetter?.call(input, '75');
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith(75);
+    expect(typeof onChange.mock.calls[0][0]).toBe('number');
+  });
+});
+
+describe('FilePickerField', () => {
+  it('calls onChange with path returned by a mocked window.fsApi.selectFile', async () => {
+    setup();
+    const onChange = vi.fn();
+    (window as unknown as { fsApi: unknown }).fsApi = {
+      selectFile: vi.fn().mockResolvedValue('/some/path'),
+    };
+    act(() => root.render(<FilePickerField value={null} onChange={onChange} />));
+    await act(async () => {
+      (container.querySelector('button') as HTMLButtonElement).click();
+    });
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith('/some/path');
+  });
+
+  it('does NOT call onChange when the dialog returns null (cancel)', async () => {
+    setup();
+    const onChange = vi.fn();
+    (window as unknown as { fsApi: unknown }).fsApi = {
+      selectFile: vi.fn().mockResolvedValue(null),
+    };
+    act(() => root.render(<FilePickerField value={null} onChange={onChange} />));
+    await act(async () => {
+      (container.querySelector('button') as HTMLButtonElement).click();
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('SettingRow', () => {
+  it('renders its label, description, and children', () => {
+    setup();
+    act(() =>
+      root.render(
+        <SettingRow label="My Setting" description="A helpful description">
+          <span data-testid="child">control</span>
+        </SettingRow>,
+      ),
+    );
+    expect(container.textContent).toContain('My Setting');
+    expect(container.textContent).toContain('A helpful description');
+    expect(container.querySelector('[data-testid="child"]')).not.toBeNull();
+  });
+});

--- a/src/renderer/views/settings/controls/accordion.css
+++ b/src/renderer/views/settings/controls/accordion.css
@@ -1,0 +1,71 @@
+.accordion {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--theme-border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.accordion__item {
+  border-bottom: 1px solid var(--theme-border);
+}
+
+.accordion__item:last-child {
+  border-bottom: none;
+}
+
+.accordion__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 10px 14px;
+  background: var(--theme-panel);
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--theme-text-secondary);
+  transition: background 0.1s, color 0.1s;
+}
+
+.accordion__header:hover {
+  background: var(--theme-panel-accent);
+  color: var(--theme-text-primary);
+}
+
+.accordion__header--open {
+  color: var(--theme-text-primary);
+  background: var(--theme-panel-accent);
+  border-bottom: 1px solid var(--theme-border);
+}
+
+.accordion__title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.accordion__chevron {
+  font-size: 18px;
+  line-height: 1;
+  color: var(--theme-text-muted);
+  transform: rotate(0deg);
+  transition: transform 0.18s ease;
+  flex-shrink: 0;
+  margin-left: 8px;
+  display: inline-block;
+}
+
+.accordion__chevron--open {
+  transform: rotate(90deg);
+  color: var(--theme-accent-gold);
+}
+
+.accordion__body {
+  background: var(--theme-surface);
+  padding: 12px 14px;
+}

--- a/src/renderer/views/settings/controls/accordion.tsx
+++ b/src/renderer/views/settings/controls/accordion.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import './accordion.css';
+
+export interface AccordionItem {
+  id: string;
+  title: string;
+}
+
+export interface AccordionProps {
+  items: AccordionItem[];
+  renderBody: (id: string) => React.ReactNode;
+  defaultOpenId?: string | null;
+}
+
+export function Accordion({ items, renderBody, defaultOpenId = null }: AccordionProps) {
+  const [openId, setOpenId] = useState<string | null>(defaultOpenId);
+
+  const handleHeaderClick = (id: string) => {
+    setOpenId((prev) => (prev === id ? null : id));
+  };
+
+  return (
+    <div className="accordion">
+      {items.map((item) => {
+        const isOpen = openId === item.id;
+        return (
+          <div key={item.id} className="accordion__item">
+            <button
+              type="button"
+              className={`accordion__header${isOpen ? ' accordion__header--open' : ''}`}
+              aria-expanded={isOpen}
+              onClick={() => handleHeaderClick(item.id)}
+            >
+              <span className="accordion__title">{item.title}</span>
+              <span
+                className={`accordion__chevron${isOpen ? ' accordion__chevron--open' : ''}`}
+                aria-hidden="true"
+              >
+                ›
+              </span>
+            </button>
+            {isOpen && <div className="accordion__body">{renderBody(item.id)}</div>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/renderer/views/settings/controls/controls.css
+++ b/src/renderer/views/settings/controls/controls.css
@@ -1,0 +1,255 @@
+/* ============================================================
+   Setting Row
+   ============================================================ */
+
+.setting-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--theme-border);
+}
+
+.setting-row:last-child {
+  border-bottom: none;
+}
+
+.setting-row__label-group {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  flex: 1;
+  min-width: 0;
+}
+
+.setting-row__label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--theme-text-primary);
+  line-height: 1.4;
+}
+
+.setting-row__description {
+  font-size: 12px;
+  color: var(--theme-text-muted);
+  line-height: 1.4;
+}
+
+.setting-row__control {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+/* ============================================================
+   Toggle
+   ============================================================ */
+
+.settings-toggle {
+  position: relative;
+  width: 38px;
+  height: 22px;
+  background: var(--theme-panel);
+  border: 1px solid var(--theme-border-strong);
+  border-radius: 11px;
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.18s ease, border-color 0.18s ease;
+  outline: none;
+}
+
+.settings-toggle:focus-visible {
+  outline: 2px solid var(--theme-accent-gold);
+  outline-offset: 2px;
+}
+
+.settings-toggle--on {
+  background: var(--theme-accent);
+  border-color: var(--theme-accent);
+}
+
+.settings-toggle:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.settings-toggle__thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--theme-text-muted);
+  transition: transform 0.18s ease, background 0.18s ease;
+}
+
+.settings-toggle--on .settings-toggle__thumb {
+  transform: translateX(16px);
+  background: var(--theme-text-primary);
+}
+
+/* ============================================================
+   Select Field
+   ============================================================ */
+
+.settings-select {
+  background: var(--theme-background);
+  border: 1px solid var(--theme-border);
+  border-radius: 3px;
+  color: var(--theme-text-primary);
+  font-size: 13px;
+  font-family: inherit;
+  padding: 5px 28px 5px 8px;
+  outline: none;
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23888'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  min-width: 120px;
+}
+
+.settings-select:focus {
+  border-color: var(--theme-accent-gold);
+}
+
+.settings-select:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* ============================================================
+   Text Field
+   ============================================================ */
+
+.settings-text-field {
+  background: var(--theme-background);
+  border: 1px solid var(--theme-border);
+  border-radius: 3px;
+  color: var(--theme-text-primary);
+  font-size: 13px;
+  font-family: inherit;
+  padding: 5px 8px;
+  outline: none;
+  width: 100%;
+  box-sizing: border-box;
+  min-width: 160px;
+}
+
+.settings-text-field:focus {
+  border-color: var(--theme-accent-gold);
+}
+
+.settings-text-field:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.settings-text-field::placeholder {
+  color: var(--theme-text-muted);
+  font-style: italic;
+}
+
+/* ============================================================
+   Slider Field
+   ============================================================ */
+
+.settings-slider-field {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.settings-slider {
+  appearance: none;
+  width: 140px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--theme-panel-accent);
+  outline: none;
+  cursor: pointer;
+}
+
+.settings-slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--theme-accent-gold);
+  cursor: pointer;
+}
+
+.settings-slider::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--theme-accent-gold);
+  cursor: pointer;
+  border: none;
+}
+
+.settings-slider:focus-visible {
+  outline: 2px solid var(--theme-accent-gold);
+  outline-offset: 2px;
+}
+
+.settings-slider:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.settings-slider-field__value {
+  font-size: 12px;
+  color: var(--theme-text-secondary);
+  min-width: 28px;
+  text-align: right;
+}
+
+/* ============================================================
+   File Picker Field
+   ============================================================ */
+
+.settings-file-picker {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.settings-file-picker__btn {
+  padding: 5px 12px;
+  border: 1px solid var(--theme-border);
+  border-radius: 3px;
+  background: var(--theme-surface);
+  color: var(--theme-text-secondary);
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.settings-file-picker__btn:hover:not(:disabled) {
+  background: var(--theme-panel-accent);
+  color: var(--theme-text-primary);
+  border-color: var(--theme-border-strong);
+}
+
+.settings-file-picker__btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.settings-file-picker__path {
+  font-size: 12px;
+  color: var(--theme-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+}
+
+.settings-file-picker__path--none {
+  color: var(--theme-text-muted);
+  font-style: italic;
+}

--- a/src/renderer/views/settings/controls/file-picker-field.tsx
+++ b/src/renderer/views/settings/controls/file-picker-field.tsx
@@ -1,0 +1,49 @@
+import './controls.css';
+
+interface Props {
+  id?: string;
+  value: string | null;
+  onChange: (path: string | null) => void;
+  buttonLabel?: string;
+  disabled?: boolean;
+}
+
+async function pickFile(onChange: (path: string | null) => void): Promise<void> {
+  const api = window.fsApi as typeof window.fsApi & {
+    selectFile: () => Promise<string | null>;
+  };
+  const path = await api.selectFile();
+  if (path !== null) {
+    onChange(path);
+  }
+}
+
+export function FilePickerField({
+  id,
+  value,
+  onChange,
+  buttonLabel = 'Choose file…',
+  disabled,
+}: Props) {
+  return (
+    <div id={id} className="settings-file-picker">
+      <button
+        type="button"
+        className="settings-file-picker__btn"
+        disabled={disabled}
+        onClick={() => void pickFile(onChange)}
+      >
+        {buttonLabel}
+      </button>
+      {value !== null ? (
+        <span className="settings-file-picker__path" title={value}>
+          {value}
+        </span>
+      ) : (
+        <span className="settings-file-picker__path settings-file-picker__path--none">
+          No file selected
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/views/settings/controls/select-field.tsx
+++ b/src/renderer/views/settings/controls/select-field.tsx
@@ -1,0 +1,32 @@
+import './controls.css';
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+interface Props {
+  id?: string;
+  value: string;
+  options: Option[];
+  onChange: (next: string) => void;
+  disabled?: boolean;
+}
+
+export function SelectField({ id, value, options, onChange, disabled }: Props) {
+  return (
+    <select
+      id={id}
+      className="settings-select"
+      value={value}
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/renderer/views/settings/controls/setting-row.tsx
+++ b/src/renderer/views/settings/controls/setting-row.tsx
@@ -1,0 +1,22 @@
+import './controls.css';
+
+interface Props {
+  label: string;
+  description?: string;
+  htmlFor?: string;
+  children: React.ReactNode;
+}
+
+export function SettingRow({ label, description, htmlFor, children }: Props) {
+  return (
+    <div className="setting-row">
+      <div className="setting-row__label-group">
+        <label className="setting-row__label" htmlFor={htmlFor}>
+          {label}
+        </label>
+        {description && <p className="setting-row__description">{description}</p>}
+      </div>
+      <div className="setting-row__control">{children}</div>
+    </div>
+  );
+}

--- a/src/renderer/views/settings/controls/slider-field.tsx
+++ b/src/renderer/views/settings/controls/slider-field.tsx
@@ -1,0 +1,38 @@
+import './controls.css';
+
+interface Props {
+  id?: string;
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  onChange: (next: number) => void;
+  disabled?: boolean;
+}
+
+export function SliderField({
+  id,
+  value,
+  min = 0,
+  max = 100,
+  step = 1,
+  onChange,
+  disabled,
+}: Props) {
+  return (
+    <div className="settings-slider-field">
+      <input
+        id={id}
+        type="range"
+        className="settings-slider"
+        value={value}
+        min={min}
+        max={max}
+        step={step}
+        disabled={disabled}
+        onChange={(e) => onChange(Number(e.target.value))}
+      />
+      <span className="settings-slider-field__value">{value}</span>
+    </div>
+  );
+}

--- a/src/renderer/views/settings/controls/text-field.tsx
+++ b/src/renderer/views/settings/controls/text-field.tsx
@@ -1,0 +1,24 @@
+import './controls.css';
+
+interface Props {
+  id?: string;
+  value: string;
+  onChange: (next: string) => void;
+  placeholder?: string;
+  type?: 'text' | 'number';
+  disabled?: boolean;
+}
+
+export function TextField({ id, value, onChange, placeholder, type = 'text', disabled }: Props) {
+  return (
+    <input
+      id={id}
+      type={type}
+      className="settings-text-field"
+      value={value}
+      placeholder={placeholder}
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  );
+}

--- a/src/renderer/views/settings/controls/toggle.tsx
+++ b/src/renderer/views/settings/controls/toggle.tsx
@@ -1,0 +1,24 @@
+import './controls.css';
+
+interface Props {
+  id?: string;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  disabled?: boolean;
+}
+
+export function Toggle({ id, checked, onChange, disabled }: Props) {
+  return (
+    <button
+      id={id}
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      className={`settings-toggle${checked ? ' settings-toggle--on' : ''}`}
+      onClick={() => onChange(!checked)}
+    >
+      <span className="settings-toggle__thumb" aria-hidden="true" />
+    </button>
+  );
+}

--- a/src/renderer/views/settings/domain/__tests__/dummy-templates.test.ts
+++ b/src/renderer/views/settings/domain/__tests__/dummy-templates.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { DUMMY_TEMPLATES } from '../dummy-templates';
+
+describe('DUMMY_TEMPLATES', () => {
+  it('contains at least 3 templates', () => {
+    expect(DUMMY_TEMPLATES.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('every template has a non-empty id, name, and content', () => {
+    for (const tpl of DUMMY_TEMPLATES) {
+      expect(tpl.id.trim()).not.toBe('');
+      expect(tpl.name.trim()).not.toBe('');
+      expect(tpl.content.trim()).not.toBe('');
+    }
+  });
+
+  it('all template ids are unique', () => {
+    const ids = DUMMY_TEMPLATES.map((t) => t.id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+});

--- a/src/renderer/views/settings/domain/__tests__/settings-sections.test.ts
+++ b/src/renderer/views/settings/domain/__tests__/settings-sections.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { SETTINGS_SECTIONS } from '../settings-sections';
+
+describe('SETTINGS_SECTIONS', () => {
+  it('contains exactly four sections in order', () => {
+    expect(SETTINGS_SECTIONS).toHaveLength(4);
+  });
+
+  it('has Timeline as the first section', () => {
+    expect(SETTINGS_SECTIONS[0]).toEqual({ id: 'timeline', label: 'Timeline' });
+  });
+
+  it('has Theme as the second section', () => {
+    expect(SETTINGS_SECTIONS[1]).toEqual({ id: 'theme', label: 'Theme' });
+  });
+
+  it('has Templates as the third section', () => {
+    expect(SETTINGS_SECTIONS[2]).toEqual({ id: 'templates', label: 'Templates' });
+  });
+
+  it('has Keybindings as the fourth section', () => {
+    expect(SETTINGS_SECTIONS[3]).toEqual({ id: 'keybindings', label: 'Keybindings' });
+  });
+});

--- a/src/renderer/views/settings/domain/dummy-templates.ts
+++ b/src/renderer/views/settings/domain/dummy-templates.ts
@@ -1,0 +1,98 @@
+export interface DummyTemplate {
+  id: string;
+  name: string;
+  content: string;
+}
+
+export const DUMMY_TEMPLATES: DummyTemplate[] = [
+  {
+    id: 'session-recap',
+    name: 'Session Recap',
+    content: `# Session Recap — [Session Number]
+
+**Date played:** [Date]
+**Players present:** [Names]
+
+## What happened
+
+- [Main plot beat]
+- [Key encounter or decision]
+- [NPC interaction]
+
+## Notable moments
+
+[Describe a memorable moment from the session]
+
+## Loose threads
+
+- **[Hook]** — [Brief description]
+
+## XP & rewards
+
+[List experience and loot awarded]
+`,
+  },
+  {
+    id: 'npc-profile',
+    name: 'NPC Profile',
+    content: `# [NPC Name]
+
+**Role:** [Merchant / Guard Captain / Villain / etc.]
+**Location:** [Where they are usually found]
+**Affiliation:** [Faction or group]
+
+## Appearance
+
+[Brief physical description — 1–2 sentences]
+
+## Personality
+
+[Key traits and mannerisms]
+
+## Motivation
+
+**Wants:** [What they are trying to achieve]
+**Fears:** [What they are trying to avoid]
+
+## Relationship to the party
+
+[How they know or feel about the players]
+
+## Notes
+
+- [Rumour or secret they hold]
+- [Plot hook attached to this NPC]
+`,
+  },
+  {
+    id: 'location',
+    name: 'Location',
+    content: `# [Location Name]
+
+**Type:** [City / Dungeon / Wilderness / etc.]
+**Region:** [Broader area it sits within]
+
+## Description
+
+[Sensory overview — what the party sees, hears, and smells on arrival]
+
+## Key areas
+
+- **[Room / District]** — [One-line summary]
+- **[Room / District]** — [One-line summary]
+
+## Inhabitants
+
+[Who or what lives here]
+
+## Hooks & secrets
+
+- [Something the players might discover]
+- [Hidden danger or treasure]
+
+## DM notes
+
+[Anything useful for running scenes here]
+`,
+  },
+];

--- a/src/renderer/views/settings/domain/settings-sections.ts
+++ b/src/renderer/views/settings/domain/settings-sections.ts
@@ -1,0 +1,11 @@
+export interface SettingsSection {
+  id: string;
+  label: string;
+}
+
+export const SETTINGS_SECTIONS: SettingsSection[] = [
+  { id: 'timeline', label: 'Timeline' },
+  { id: 'theme', label: 'Theme' },
+  { id: 'templates', label: 'Templates' },
+  { id: 'keybindings', label: 'Keybindings' },
+];

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -65,6 +65,7 @@ declare global {
 
       // Dialog
       selectDirectory: () => Promise<string | null>;
+      selectFile: () => Promise<string | null>;
 
       // Timeline
       timelineListEvents: (campaignPath: string) => Promise<EventListItem[]>;


### PR DESCRIPTION
## 📝 Description

**Issue(s):** #143

Adds a stub **Campaign Settings** menu so real settings can be slotted in cheaply later. A new **Settings** option in the footer's burger menu opens a masking modal with a sidebar of section headers (Timeline, Theme, Templates, Keybindings) that scroll-jump the body to each section. Each section is populated with **dummy** controls demonstrating every basic control type — toggle, dropdown, text input, slider and OS file picker — so adding real options later is a copy-paste.

Per discussion on the ticket: controls are **hand-rolled and theme-native** (the codebase intentionally ships no UI libraries; every control is semantic HTML styled with `var(--theme-*)`), and this is a **pure visual stub** — controls hold local React state only, with no `settings.json` persistence. The one IO touch is a minimal OS file-dialog channel so the file-picker control is actually demonstrable; it reads/writes no campaign data.

---

## 🔍 Details

* **`src/renderer/views/settings/controls/`:** New reusable, presentational control components — `toggle`, `select-field`, `text-field`, `slider-field`, `file-picker-field` and a `setting-row` layout wrapper — plus shared `controls.css` (theme variables only) and behavioural tests.
* **`src/renderer/views/settings/campaign-settings-modal.tsx` + `.css`:** The modal — masking overlay (Esc / backdrop / footer Close all dismiss), left section-nav sidebar with scroll-jump + active-section highlight, and the four sections composed from the controls above with local-state dummy values.
* **`src/renderer/views/settings/domain/settings-sections.ts`:** Pure section list (id + label) backing the sidebar, with a unit test.
* **`src/renderer/components/footer.tsx`:** Adds an `onOpenSettings` prop and a "⚙ Settings" item to the burger menu (styled like the existing menu entries).
* **`src/renderer/app.tsx`:** Holds `settingsOpen` state, wires the footer button, and renders the modal for the active campaign.
* **`src/main/ipcHandlers.ts`, `src/preload/index.cts`, `src/types/global.d.ts`:** New `dialog:selectFile` OS file-picker IPC channel (mirrors the existing `dialog:selectDirectory`), exposed as `window.fsApi.selectFile`.
* **Tests:** New tests for the controls, the modal, and the section data; existing suite, lint and build all pass.

---

## 🧪 Manual Test Cases

A human reviewer should verify and tick off the following scenarios

### 🚀 New Behavior
- [x] Open a campaign → footer ☰ → **Settings** opens a modal that masks the rest of the UI (footer included).
- [x] **Esc**, the footer **Close** button, and clicking the backdrop each dismiss the modal; clicking inside the panel does not.
- [x] Clicking each sidebar header (Timeline / Theme / Templates / Keybindings) scrolls the body to that section and highlights the active header.
- [ ] Toggle, dropdown, text input and slider all respond; the **Templates → Default event template** file picker opens the OS file browser and shows the chosen path.
- [ ] All modal colours track the active theme (no hardcoded colours).

### 🛡️ Regression Checks
- [ ] The footer burger menu still switches views and "← Back to Campaigns" still works.
- [ ] Other modals/overlays (search, event/session editors) open and close normally.

https://claude.ai/code/session_01H3fc8hn4dMNA3LkE7EYQTq

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3fc8hn4dMNA3LkE7EYQTq)_