### PR TITLE
#16 WASD keyboard navigation of the timeline

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -145,6 +145,22 @@ export default function App() {
     return () => window.removeEventListener('keydown', handleKeyDown, true);
   }, [activeCampaign]);
 
+  useEffect(() => {
+    function handleViewSwitch(e: KeyboardEvent) {
+      if (!activeCampaign) return;
+      if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
+      if (e.key === 'F1') {
+        e.preventDefault();
+        setCurrentView('timeline');
+      } else if (e.key === 'F2') {
+        e.preventDefault();
+        setCurrentView('notes');
+      }
+    }
+    window.addEventListener('keydown', handleViewSwitch, true);
+    return () => window.removeEventListener('keydown', handleViewSwitch, true);
+  }, [activeCampaign]);
+
   const handleJumpToEvent = useCallback((target: string | EventListItem) => {
     const filename = typeof target === 'string' ? target : target.filename;
     setCurrentView('timeline');

--- a/src/renderer/timeline/interactions/__tests__/event-navigation.test.ts
+++ b/src/renderer/timeline/interactions/__tests__/event-navigation.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { findAdjacentEvent } from '../event-navigation';
+import { EventListItem } from '../../data/types';
+import { toAbsoluteSeconds, parseISOString } from '../../calendar/golarian';
+
+function makeEvent(filename: string, date: string): EventListItem {
+  return { filename, date, title: filename, mtime: '2024-01-01T00:00:00Z' };
+}
+
+// Fixture: three events in ascending chronological order
+const EVENT_A = makeEvent('event-a.md', '4726-01-01');
+const EVENT_B = makeEvent('event-b.md', '4726-03-15');
+const EVENT_C = makeEvent('event-c.md', '4726-06-01');
+
+const FIXTURE = [EVENT_C, EVENT_A, EVENT_B]; // deliberately unsorted
+
+const secondsOf = (date: string) => toAbsoluteSeconds(parseISOString(date));
+
+describe('findAdjacentEvent', () => {
+  it('next from a focused event returns the following event', () => {
+    const result = findAdjacentEvent(FIXTURE, 0, 'event-b.md', 'next');
+    expect(result).toEqual({ filename: 'event-c.md', seconds: secondsOf('4726-06-01') });
+  });
+
+  it('prev from a focused event returns the preceding event', () => {
+    const result = findAdjacentEvent(FIXTURE, 0, 'event-b.md', 'prev');
+    expect(result).toEqual({ filename: 'event-a.md', seconds: secondsOf('4726-01-01') });
+  });
+
+  it('next from a bare reference time returns the first event after it', () => {
+    const ref = secondsOf('4726-02-01');
+    const result = findAdjacentEvent(FIXTURE, ref, null, 'next');
+    expect(result).toEqual({ filename: 'event-b.md', seconds: secondsOf('4726-03-15') });
+  });
+
+  it('next at the last event returns null (no wrap)', () => {
+    const result = findAdjacentEvent(FIXTURE, 0, 'event-c.md', 'next');
+    expect(result).toBeNull();
+  });
+
+  it('empty event list returns null', () => {
+    const result = findAdjacentEvent([], 0, null, 'next');
+    expect(result).toBeNull();
+  });
+});

--- a/src/renderer/timeline/interactions/__tests__/keyboard-mode.test.ts
+++ b/src/renderer/timeline/interactions/__tests__/keyboard-mode.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest';
+import { reduceKey, isTypingTarget } from '../keyboard-mode';
+
+describe('keyboard-mode', () => {
+  it('nav: w/s map to zoom in/out', () => {
+    expect(reduceKey('nav', { key: 'w', shiftKey: false })).toEqual({
+      mode: 'nav',
+      action: { type: 'zoom', dir: 'in' },
+    });
+    expect(reduceKey('nav', { key: 's', shiftKey: false })).toEqual({
+      mode: 'nav',
+      action: { type: 'zoom', dir: 'out' },
+    });
+  });
+
+  it('nav: a/d map to pan earlier/later', () => {
+    expect(reduceKey('nav', { key: 'a', shiftKey: false })).toEqual({
+      mode: 'nav',
+      action: { type: 'pan', dir: 'earlier' },
+    });
+    expect(reduceKey('nav', { key: 'd', shiftKey: false })).toEqual({
+      mode: 'nav',
+      action: { type: 'pan', dir: 'later' },
+    });
+  });
+
+  it('nav: space enters quickadd mode with quickadd-enter', () => {
+    expect(reduceKey('nav', { key: ' ', shiftKey: false })).toEqual({
+      mode: 'quickadd',
+      action: { type: 'quickadd-enter' },
+    });
+  });
+
+  it('quickadd: a/d map to quickadd-move and stay in quickadd', () => {
+    expect(reduceKey('quickadd', { key: 'a', shiftKey: false })).toEqual({
+      mode: 'quickadd',
+      action: { type: 'quickadd-move', dir: 'earlier' },
+    });
+    expect(reduceKey('quickadd', { key: 'd', shiftKey: false })).toEqual({
+      mode: 'quickadd',
+      action: { type: 'quickadd-move', dir: 'later' },
+    });
+  });
+
+  it('quickadd: space commits and returns to nav', () => {
+    expect(reduceKey('quickadd', { key: ' ', shiftKey: false })).toEqual({
+      mode: 'nav',
+      action: { type: 'quickadd-commit' },
+    });
+  });
+
+  it('quickadd: escape exits to nav with quickadd-exit', () => {
+    expect(reduceKey('quickadd', { key: 'Escape', shiftKey: false })).toEqual({
+      mode: 'nav',
+      action: { type: 'quickadd-exit' },
+    });
+  });
+
+  it('nav: Tab/Shift+Tab produce focus-cycle forward/backward', () => {
+    expect(reduceKey('nav', { key: 'Tab', shiftKey: false })).toEqual({
+      mode: 'nav',
+      action: { type: 'focus-cycle', dir: 'forward' },
+    });
+    expect(reduceKey('nav', { key: 'Tab', shiftKey: true })).toEqual({
+      mode: 'nav',
+      action: { type: 'focus-cycle', dir: 'backward' },
+    });
+  });
+
+  it('isTypingTarget true for input/textarea/contenteditable, false for a plain div', () => {
+    const input = document.createElement('input');
+    expect(isTypingTarget(input)).toBe(true);
+
+    const textarea = document.createElement('textarea');
+    expect(isTypingTarget(textarea)).toBe(true);
+
+    const ce = document.createElement('div');
+    ce.contentEditable = 'true';
+    expect(isTypingTarget(ce)).toBe(true);
+
+    const plain = document.createElement('div');
+    expect(isTypingTarget(plain)).toBe(false);
+  });
+});

--- a/src/renderer/timeline/interactions/__tests__/keyboard-steps.test.ts
+++ b/src/renderer/timeline/interactions/__tests__/keyboard-steps.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { keyboardZoom, keyboardPan } from '../keyboard-steps';
+import type { ViewState, ViewportSize } from '../../math/zoom';
+
+const size: ViewportSize = { width: 1000, height: 600 };
+
+const view: ViewState = {
+  centerSeconds: 86400 * 10, // 10 days in
+  secondsPerPixel: 500, // moderately zoomed out
+};
+
+describe('keyboardZoom', () => {
+  it('zoom in shrinks secondsPerPixel and preserves the centre seconds', () => {
+    const result = keyboardZoom(view, size, 'in');
+    expect(result.secondsPerPixel).toBeLessThan(view.secondsPerPixel);
+    // Centre-anchored zoom keeps the centre fixed
+    expect(result.centerSeconds).toBeCloseTo(view.centerSeconds, 5);
+  });
+
+  it('zoom out grows secondsPerPixel and clamps at the maximum', () => {
+    const result = keyboardZoom(view, size, 'out');
+    expect(result.secondsPerPixel).toBeGreaterThan(view.secondsPerPixel);
+
+    // Repeatedly zooming out must never exceed 30 * 86400
+    const MAX = 30 * 86400;
+    let current = view;
+    for (let i = 0; i < 200; i++) {
+      current = keyboardZoom(current, size, 'out');
+      // Also verify the factor is being applied correctly each step
+      expect(current.secondsPerPixel).toBeLessThanOrEqual(MAX);
+    }
+    expect(current.secondsPerPixel).toBeLessThanOrEqual(MAX);
+  });
+});
+
+describe('keyboardPan', () => {
+  it('pan later increases centre seconds, pan earlier decreases it', () => {
+    const later = keyboardPan(view, 'later');
+    const earlier = keyboardPan(view, 'earlier');
+    expect(later.centerSeconds).toBeGreaterThan(view.centerSeconds);
+    expect(earlier.centerSeconds).toBeLessThan(view.centerSeconds);
+  });
+
+  it('a fixed pixel pan moves fewer seconds when zoomed in', () => {
+    const zoomedIn: ViewState = { ...view, secondsPerPixel: 10 }; // small spp = zoomed in
+    const zoomedOut: ViewState = { ...view, secondsPerPixel: 1000 }; // large spp = zoomed out
+
+    const deltaIn = Math.abs(keyboardPan(zoomedIn, 'later').centerSeconds - zoomedIn.centerSeconds);
+    const deltaOut = Math.abs(
+      keyboardPan(zoomedOut, 'later').centerSeconds - zoomedOut.centerSeconds,
+    );
+
+    expect(deltaIn).toBeLessThan(deltaOut);
+  });
+});

--- a/src/renderer/timeline/interactions/__tests__/quick-add-keyboard.test.ts
+++ b/src/renderer/timeline/interactions/__tests__/quick-add-keyboard.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SNAP_SECS as SNAP_SECS_FROM_INCREMENTS } from '../time-increments';
+import { SNAP_SECS as SNAP_SECS_FROM_ZONES, createQuickAddZones } from '../quick-add-zones';
+import type { QuickAddZonesDeps } from '../quick-add-zones';
+import { secondsToX } from '../../math/zoom';
+import type { ViewState, ViewportSize } from '../../math/zoom';
+
+const WIDTH = 1000;
+const HEIGHT = 600;
+
+const VIEW: ViewState = { centerSeconds: 3600, secondsPerPixel: 60 };
+const SIZE: ViewportSize = { width: WIDTH, height: HEIGHT };
+
+function makeContainer(): HTMLElement {
+  const el = document.createElement('div');
+  Object.defineProperty(el, 'clientHeight', { get: () => HEIGHT, configurable: true });
+  el.getBoundingClientRect = () =>
+    ({
+      left: 0,
+      top: 0,
+      right: WIDTH,
+      bottom: HEIGHT,
+      width: WIDTH,
+      height: HEIGHT,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  document.body.appendChild(el);
+  return el;
+}
+
+function makeDeps(): QuickAddZonesDeps {
+  return {
+    getView: () => VIEW,
+    getViewport: () => SIZE,
+    isInteractionActive: () => false,
+    shouldSuppressClick: () => false,
+    onQuickAdd: async () => {},
+    onSetNow: async () => {},
+  };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('quick-add keyboard API', () => {
+  it('SNAP_SECS is shared between time-increments and quick-add-zones', () => {
+    expect(SNAP_SECS_FROM_INCREMENTS).toBe(600);
+    expect(SNAP_SECS_FROM_ZONES).toBe(600);
+    expect(SNAP_SECS_FROM_INCREMENTS).toBe(SNAP_SECS_FROM_ZONES);
+  });
+
+  it('controller exposes keyboardShowAt and keyboardHide', () => {
+    const container = makeContainer();
+    const controller = createQuickAddZones(container, makeDeps());
+    expect(typeof controller.keyboardShowAt).toBe('function');
+    expect(typeof controller.keyboardHide).toBe('function');
+  });
+
+  it('keyboardShowAt shows the marker at the secondsToX position', () => {
+    const container = makeContainer();
+    // Use centerSeconds as the seconds we will pass so the result is width/2 = 500px
+    const seconds = VIEW.centerSeconds;
+    const deps: QuickAddZonesDeps = {
+      getView: () => VIEW,
+      getViewport: () => SIZE,
+      isInteractionActive: () => false,
+      shouldSuppressClick: () => false,
+      onQuickAdd: async () => {},
+      onSetNow: async () => {},
+    };
+    const controller = createQuickAddZones(container, deps);
+
+    controller.keyboardShowAt(seconds);
+
+    const marker = container.querySelector('.quick-add') as HTMLElement;
+    expect(marker).not.toBeNull();
+    expect(marker.style.display).not.toBe('none');
+
+    const expectedX = secondsToX(seconds, VIEW, SIZE);
+    expect(marker.style.left).toBe(`${expectedX}px`);
+    // When seconds == centerSeconds, expectedX == width/2 == 500
+    expect(expectedX).toBe(500);
+  });
+});

--- a/src/renderer/timeline/interactions/event-navigation.ts
+++ b/src/renderer/timeline/interactions/event-navigation.ts
@@ -1,0 +1,54 @@
+import { EventListItem } from '../data/types';
+import { parseISOString, toAbsoluteSeconds } from '../calendar/golarian';
+
+export interface AdjacentEvent {
+  filename: string;
+  seconds: number;
+}
+
+interface SortedEvent {
+  filename: string;
+  seconds: number;
+}
+
+function toSortedEvents(events: EventListItem[]): SortedEvent[] {
+  return events
+    .map((e) => ({ filename: e.filename, seconds: toAbsoluteSeconds(parseISOString(e.date)) }))
+    .sort((a, b) => {
+      if (a.seconds !== b.seconds) return a.seconds - b.seconds;
+      return a.filename < b.filename ? -1 : a.filename > b.filename ? 1 : 0;
+    });
+}
+
+export function findAdjacentEvent(
+  events: EventListItem[],
+  refSeconds: number,
+  focusedFilename: string | null,
+  dir: 'prev' | 'next',
+): AdjacentEvent | null {
+  if (events.length === 0) return null;
+
+  const sorted = toSortedEvents(events);
+
+  if (focusedFilename !== null) {
+    const idx = sorted.findIndex((e) => e.filename === focusedFilename);
+    if (idx !== -1) {
+      const targetIdx = dir === 'next' ? idx + 1 : idx - 1;
+      if (targetIdx < 0 || targetIdx >= sorted.length) return null;
+      const target = sorted[targetIdx];
+      return { filename: target.filename, seconds: target.seconds };
+    }
+  }
+
+  // No focus or focused filename not found — use refSeconds
+  if (dir === 'next') {
+    const target = sorted.find((e) => e.seconds > refSeconds);
+    return target ? { filename: target.filename, seconds: target.seconds } : null;
+  } else {
+    let target: SortedEvent | null = null;
+    for (const e of sorted) {
+      if (e.seconds < refSeconds) target = e;
+    }
+    return target ? { filename: target.filename, seconds: target.seconds } : null;
+  }
+}

--- a/src/renderer/timeline/interactions/keyboard-mode.ts
+++ b/src/renderer/timeline/interactions/keyboard-mode.ts
@@ -1,0 +1,75 @@
+export type KeyboardMode = 'nav' | 'quickadd';
+
+export type KeyAction =
+  | { type: 'zoom'; dir: 'in' | 'out' }
+  | { type: 'pan'; dir: 'earlier' | 'later' }
+  | { type: 'nav-event'; dir: 'prev' | 'next' }
+  | { type: 'quickadd-enter' }
+  | { type: 'quickadd-move'; dir: 'earlier' | 'later' }
+  | { type: 'quickadd-commit' }
+  | { type: 'quickadd-exit' }
+  | { type: 'focus-cycle'; dir: 'forward' | 'backward' }
+  | { type: 'unfocus' }
+  | { type: 'none' };
+
+export interface KeyInput {
+  key: string;
+  shiftKey: boolean;
+}
+
+export function reduceKey(
+  mode: KeyboardMode,
+  input: KeyInput,
+): { mode: KeyboardMode; action: KeyAction } {
+  const k = input.key.length === 1 ? input.key.toLowerCase() : input.key;
+
+  if (mode === 'nav') {
+    switch (k) {
+      case 'w':
+        return { mode: 'nav', action: { type: 'zoom', dir: 'in' } };
+      case 's':
+        return { mode: 'nav', action: { type: 'zoom', dir: 'out' } };
+      case 'a':
+        return { mode: 'nav', action: { type: 'pan', dir: 'earlier' } };
+      case 'd':
+        return { mode: 'nav', action: { type: 'pan', dir: 'later' } };
+      case 'q':
+        return { mode: 'nav', action: { type: 'nav-event', dir: 'prev' } };
+      case 'e':
+        return { mode: 'nav', action: { type: 'nav-event', dir: 'next' } };
+      case ' ':
+        return { mode: 'quickadd', action: { type: 'quickadd-enter' } };
+      case 'Tab':
+        return {
+          mode: 'nav',
+          action: { type: 'focus-cycle', dir: input.shiftKey ? 'backward' : 'forward' },
+        };
+      case 'Escape':
+        return { mode: 'nav', action: { type: 'unfocus' } };
+      default:
+        return { mode: 'nav', action: { type: 'none' } };
+    }
+  }
+
+  // quickadd mode
+  switch (k) {
+    case 'a':
+      return { mode: 'quickadd', action: { type: 'quickadd-move', dir: 'earlier' } };
+    case 'd':
+      return { mode: 'quickadd', action: { type: 'quickadd-move', dir: 'later' } };
+    case ' ':
+      return { mode: 'nav', action: { type: 'quickadd-commit' } };
+    default:
+      return { mode: 'nav', action: { type: 'quickadd-exit' } };
+  }
+}
+
+export function isTypingTarget(el: EventTarget | null): boolean {
+  if (!(el instanceof Element)) return false;
+
+  const tag = el.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if ((el as HTMLElement).isContentEditable) return true;
+
+  return el.closest('input, textarea, select, [contenteditable="true"]') !== null;
+}

--- a/src/renderer/timeline/interactions/keyboard-steps.ts
+++ b/src/renderer/timeline/interactions/keyboard-steps.ts
@@ -1,0 +1,35 @@
+import { zoomAbout, panByPixels } from '../math/zoom';
+import type { ViewState, ViewportSize } from '../math/zoom';
+
+/** Factor applied per keypress when zooming in (shrinks secondsPerPixel). */
+export const ZOOM_STEP_IN = 0.8;
+
+/** Factor applied per keypress when zooming out (grows secondsPerPixel). */
+export const ZOOM_STEP_OUT = 1.25;
+
+/** Fixed pixels panned per keypress. */
+export const PAN_STEP_PX = 150;
+
+/**
+ * Zoom the timeline in or out, anchored at the viewport centre.
+ * Delegates entirely to `zoomAbout` — no math reimplemented here.
+ */
+export function keyboardZoom(view: ViewState, size: ViewportSize, dir: 'in' | 'out'): ViewState {
+  const anchorX = size.width / 2;
+  const factor = dir === 'in' ? ZOOM_STEP_IN : ZOOM_STEP_OUT;
+  return zoomAbout(view, size, anchorX, factor);
+}
+
+/**
+ * Pan the timeline earlier or later by a fixed pixel step.
+ *
+ * `panByPixels` computes: centerSeconds - deltaPixels * secondsPerPixel
+ * - To increase centerSeconds (later), deltaPixels must be negative.
+ * - To decrease centerSeconds (earlier), deltaPixels must be positive.
+ *
+ * Delegates entirely to `panByPixels` — no math reimplemented here.
+ */
+export function keyboardPan(view: ViewState, dir: 'earlier' | 'later'): ViewState {
+  const deltaPixels = dir === 'later' ? -PAN_STEP_PX : PAN_STEP_PX;
+  return panByPixels(view, deltaPixels);
+}

--- a/src/renderer/timeline/interactions/quick-add-zones.ts
+++ b/src/renderer/timeline/interactions/quick-add-zones.ts
@@ -7,8 +7,8 @@ import {
   type ViewState,
   type ViewportSize,
 } from '../math/zoom';
-
-export const SNAP_SECS = 600; // 10 minutes
+export { SNAP_SECS } from './time-increments';
+import { SNAP_SECS } from './time-increments';
 export const QUICK_ADD_ZONE_TOP = 4; // px below axisY where indicator activates
 export const QUICK_ADD_ZONE_BOTTOM = 68; // px below axisY where it stops
 
@@ -26,6 +26,10 @@ export interface QuickAddZonesDeps {
 export interface QuickAddZonesController {
   destroy(): void;
   hide(): void;
+  /** Show the quick-add marker at the given absolute seconds (keyboard navigation). */
+  keyboardShowAt(seconds: number): void;
+  /** Hide the quick-add marker (keyboard navigation). */
+  keyboardHide(): void;
 }
 
 export function createQuickAddZones(
@@ -60,6 +64,19 @@ export function createQuickAddZones(
     shiftPreviewSeconds = null;
   }
 
+  /** Render the quick-add marker at the given snapped seconds and x position. */
+  function renderQuickAddMarker(snapped: number, labelText: string) {
+    const view = deps.getView();
+    const size = deps.getViewport();
+    const axisY = Math.floor(container.clientHeight * 0.8);
+    const x = secondsToX(snapped, view, size);
+    const label = quickAdd.querySelector('.quick-add-label') as HTMLElement;
+    label.textContent = labelText;
+    quickAdd.style.left = `${x}px`;
+    quickAdd.style.top = `${axisY}px`;
+    quickAdd.style.display = '';
+  }
+
   function onMouseMove(e: MouseEvent) {
     if (deps.isInteractionActive()) {
       hide();
@@ -81,7 +98,6 @@ export function createQuickAddZones(
     const rawSecs = xToSeconds(x, view, size);
     const snapUnit = e.ctrlKey ? SECONDS_PER_DAY : SNAP_SECS;
     const snapped = Math.round(rawSecs / snapUnit) * snapUnit;
-    const snappedX = secondsToX(snapped, view, size);
     const date = fromAbsoluteSeconds(snapped);
 
     if (e.shiftKey) {
@@ -89,6 +105,7 @@ export function createQuickAddZones(
       quickAddSeconds = null;
       shiftPreviewSeconds = snapped;
       const [dayMonth, year, time] = formatNowMarker(date);
+      const snappedX = secondsToX(snapped, view, size);
       shiftPreview.style.left = `${snappedX}px`;
       shiftPreview.style.display = '';
       const labelsEl = shiftPreview.querySelector('.shift-now-labels') as HTMLElement;
@@ -102,13 +119,10 @@ export function createQuickAddZones(
       shiftPreview.style.display = 'none';
       shiftPreviewSeconds = null;
       quickAddSeconds = snapped;
-      const label = quickAdd.querySelector('.quick-add-label') as HTMLElement;
-      label.textContent = e.ctrlKey
+      const labelText = e.ctrlKey
         ? formatAxisDay(date)
         : `${formatAxisDay(date)} ${formatAxisHour(date)}`;
-      quickAdd.style.left = `${snappedX}px`;
-      quickAdd.style.top = `${axisY}px`;
-      quickAdd.style.display = '';
+      renderQuickAddMarker(snapped, labelText);
     }
   }
 
@@ -156,5 +170,16 @@ export function createQuickAddZones(
       shiftPreview.remove();
     },
     hide,
+    keyboardShowAt(seconds: number) {
+      quickAddSeconds = seconds;
+      const date = fromAbsoluteSeconds(seconds);
+      const labelText = `${formatAxisDay(date)} ${formatAxisHour(date)}`;
+      shiftPreview.style.display = 'none';
+      shiftPreviewSeconds = null;
+      renderQuickAddMarker(seconds, labelText);
+    },
+    keyboardHide() {
+      hide();
+    },
   };
 }

--- a/src/renderer/timeline/interactions/time-increments.ts
+++ b/src/renderer/timeline/interactions/time-increments.ts
@@ -1,0 +1,3 @@
+/** Shared snap/step granularity used by both mouse quick-add snapping and
+ *  keyboard timeline navigation. Change here to change both. */
+export const SNAP_SECS = 600; // 10 minutes

--- a/src/renderer/timeline/interactions/useQuickAddZones.ts
+++ b/src/renderer/timeline/interactions/useQuickAddZones.ts
@@ -15,6 +15,8 @@ export function useQuickAddZones(
   const innerRef = useRef<QuickAddZonesController>({
     destroy: () => {},
     hide: () => {},
+    keyboardShowAt: () => {},
+    keyboardHide: () => {},
   });
 
   const depsRef = useRef(deps);
@@ -24,6 +26,8 @@ export function useQuickAddZones(
   const stable = useRef<QuickAddZonesController>({
     destroy: () => innerRef.current.destroy(),
     hide: () => innerRef.current.hide(),
+    keyboardShowAt: (seconds: number) => innerRef.current.keyboardShowAt(seconds),
+    keyboardHide: () => innerRef.current.keyboardHide(),
   }).current;
 
   useEffect(() => {
@@ -42,7 +46,12 @@ export function useQuickAddZones(
 
     return () => {
       controller.destroy();
-      innerRef.current = { destroy: () => {}, hide: () => {} };
+      innerRef.current = {
+        destroy: () => {},
+        hide: () => {},
+        keyboardShowAt: () => {},
+        keyboardHide: () => {},
+      };
     };
     // containerRef.current is stable for the component lifetime.
     // depsRef is updated each render; the stable wrapper above delegates to depsRef.current.

--- a/src/renderer/timeline/interactions/useTimelineKeyboard.ts
+++ b/src/renderer/timeline/interactions/useTimelineKeyboard.ts
@@ -1,0 +1,145 @@
+import { useEffect, useRef } from 'react';
+import type { ViewState, ViewportSize } from '../math/zoom';
+import type { EventListItem } from '../data/types';
+import { reduceKey, isTypingTarget, type KeyboardMode } from './keyboard-mode';
+import { keyboardZoom, keyboardPan } from './keyboard-steps';
+import { findAdjacentEvent } from './event-navigation';
+import { SNAP_SECS } from './time-increments';
+
+export interface TimelineKeyboardDeps {
+  isBlocked(): boolean;
+  getView(): ViewState;
+  getSize(): ViewportSize;
+  setView(updater: (v: ViewState) => ViewState): void;
+  getEvents(): EventListItem[];
+  getFocusedFilename(): string | null;
+  expandEvent(filename: string): void;
+  collapse(): void;
+  quickAddShowAt(seconds: number): void;
+  quickAddHide(): void;
+  createEventAt(seconds: number): void;
+}
+
+export function useTimelineKeyboard(deps: TimelineKeyboardDeps): void {
+  const depsRef = useRef(deps);
+  depsRef.current = deps;
+
+  const modeRef = useRef<KeyboardMode>('nav');
+  const markerSecsRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const d = depsRef.current;
+
+      if (isTypingTarget(e.target) || d.isBlocked()) return;
+
+      const { mode, action } = reduceKey(modeRef.current, { key: e.key, shiftKey: e.shiftKey });
+      modeRef.current = mode;
+
+      let handled = false;
+
+      switch (action.type) {
+        case 'zoom':
+          d.setView((v) => keyboardZoom(v, d.getSize(), action.dir));
+          handled = true;
+          break;
+
+        case 'pan':
+          d.setView((v) => keyboardPan(v, action.dir));
+          handled = true;
+          break;
+
+        case 'nav-event': {
+          const hit = findAdjacentEvent(
+            d.getEvents(),
+            d.getView().centerSeconds,
+            d.getFocusedFilename(),
+            action.dir,
+          );
+          if (hit) {
+            d.setView((v) => ({ ...v, centerSeconds: hit.seconds }));
+            d.expandEvent(hit.filename);
+            handled = true;
+          }
+          break;
+        }
+
+        case 'quickadd-enter': {
+          const base = d.getView().centerSeconds;
+          const snapped = Math.round(base / SNAP_SECS) * SNAP_SECS;
+          markerSecsRef.current = snapped;
+          d.setView((v) => ({ ...v, centerSeconds: snapped }));
+          d.quickAddShowAt(snapped);
+          handled = true;
+          break;
+        }
+
+        case 'quickadd-move': {
+          const next =
+            (markerSecsRef.current ?? d.getView().centerSeconds) +
+            (action.dir === 'later' ? SNAP_SECS : -SNAP_SECS);
+          markerSecsRef.current = next;
+          d.setView((v) => ({ ...v, centerSeconds: next }));
+          d.quickAddShowAt(next);
+          handled = true;
+          break;
+        }
+
+        case 'quickadd-commit':
+          if (markerSecsRef.current != null) {
+            d.createEventAt(markerSecsRef.current);
+          }
+          d.quickAddHide();
+          markerSecsRef.current = null;
+          handled = true;
+          break;
+
+        case 'quickadd-exit':
+          d.quickAddHide();
+          markerSecsRef.current = null;
+          handled = true;
+          break;
+
+        case 'focus-cycle': {
+          const buttons = Array.from(
+            document.querySelectorAll<HTMLElement>(
+              '.event-card.is-expanded [data-action="edit"], .event-card.is-expanded [data-action="delete"]',
+            ),
+          );
+          if (buttons.length > 0) {
+            const activeIdx = buttons.findIndex((btn) => btn === document.activeElement);
+            if (action.dir === 'forward') {
+              const nextIdx = activeIdx === -1 ? 0 : (activeIdx + 1) % buttons.length;
+              buttons[nextIdx].focus();
+            } else {
+              const prevIdx =
+                activeIdx === -1
+                  ? buttons.length - 1
+                  : (activeIdx - 1 + buttons.length) % buttons.length;
+              buttons[prevIdx].focus();
+            }
+            handled = true;
+          }
+          break;
+        }
+
+        case 'unfocus':
+          d.collapse();
+          handled = true;
+          break;
+
+        case 'none':
+          break;
+      }
+
+      if (handled) {
+        e.preventDefault();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown, { capture: true });
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown, { capture: true });
+    };
+  }, []);
+}

--- a/src/renderer/views/timeline/timeline-view.tsx
+++ b/src/renderer/views/timeline/timeline-view.tsx
@@ -23,6 +23,7 @@ import { useCardExpansion } from '../../timeline/interactions/useCardExpansion';
 import { usePreviewSize } from '../../timeline/interactions/usePreviewSize';
 import { useReschedule } from '../../timeline/interactions/useReschedule';
 import { useQuickAddZones } from '../../timeline/interactions/useQuickAddZones';
+import { useTimelineKeyboard } from '../../timeline/interactions/useTimelineKeyboard';
 import { useEventEditor } from '../../timeline/event-editor/useEventEditor';
 import { deriveFilename } from '../../timeline/event-editor/domain';
 import { EventEditorModal } from '../../timeline/event-editor/EventEditorModal';
@@ -365,7 +366,7 @@ export function TimelineView({
 
   const editor = useEventEditor(campaignPath, refreshEvents);
 
-  useQuickAddZones(viewportRef, {
+  const quickAdd = useQuickAddZones(viewportRef, {
     getView: () => viewRef.current,
     getViewport: () => sizeRef.current,
     isInteractionActive: () =>
@@ -497,6 +498,24 @@ export function TimelineView({
     () => applyFilters(loadedData.events, filterState, loadedData.sessions),
     [loadedData.events, filterState, loadedData.sessions],
   );
+
+  const filteredEventsRef = useRef(filteredEvents);
+  filteredEventsRef.current = filteredEvents;
+
+  useTimelineKeyboard({
+    isBlocked: () => !!(editor.editorMode || editor.newEventPrompt),
+    getView: () => viewRef.current,
+    getSize: () => sizeRef.current,
+    setView: setViewState,
+    getEvents: () => filteredEventsRef.current,
+    getFocusedFilename: () => expansion?.filename ?? null,
+    expandEvent: handleCardClick,
+    collapse,
+    quickAddShowAt: quickAdd.keyboardShowAt,
+    quickAddHide: quickAdd.keyboardHide,
+    createEventAt: (seconds) =>
+      editor.openNewEventPrompt(toISOString(fromAbsoluteSeconds(seconds))),
+  });
 
   const inGameNow = loadedData.gameState?.in_game_now || null;
   const inGameNowSeconds = inGameNow ? toAbsoluteSeconds(parseISOString(inGameNow)) : Infinity;


### PR DESCRIPTION
## 📝 Description

**Issue(s):** Closes #16

Adds full keyboard navigation to the timeline so it can be driven without a mouse: WASD to pan/zoom, Q/E to step through events, Space for a keyboard-driven quick-add, Tab/Esc to act on a focused event, and F1/F2 to swap views. Built behind small, well-tested pure modules (zoom/pan steps, event lookup, a modal key reducer, a shared time increment) with a single thin hook wiring them into React state — no business logic lives in the hook itself.

---

## 🔍 Details

* **`timeline/interactions/keyboard-steps.ts`:** New pure helpers `keyboardZoom`/`keyboardPan` that delegate to the existing `zoomAbout`/`panByPixels`. Zoom is anchored at viewport centre; pan moves a fixed pixel step so the time scrolled shrinks as you zoom in ("more zoom = less scroll"). Unit-tested.
* **`timeline/interactions/event-navigation.ts`:** New pure `findAdjacentEvent` — sorts events chronologically (via the Golarian calendar helpers) and returns the prev/next event from either a focused card or a reference time, with no wrapping at the ends. Unit-tested.
* **`timeline/interactions/keyboard-mode.ts`:** New pure `reduceKey` state machine (nav ⇄ quick-add modes) plus an `isTypingTarget` guard so shortcuts never fire while typing. This is the contract both the reducer and the hook share. Unit-tested.
* **`timeline/interactions/time-increments.ts` + `quick-add-zones.ts` + `useQuickAddZones.ts`:** Extracted the 10-minute snap (`SNAP_SECS`) into one shared constant so the mouse quick-add and the keyboard step stay in lockstep; added `keyboardShowAt`/`keyboardHide` to the quick-add controller (reusing a new shared marker-render helper) so keyboard mode drives the same on-screen marker. Unit-tested; existing quick-add behaviour unchanged.
* **`timeline/interactions/useTimelineKeyboard.ts`:** New hook — a single capture-phase `keydown` listener that asks `reduceKey` what to do and sequences the result onto the pure helpers + existing controllers (zoom/pan, event stepping, quick-add marker, focus cycling, collapse). Bails while typing or while an event modal is open. No logic in the hook body; behaviour coverage lives in the pure-module tests.
* **`views/timeline/timeline-view.tsx`:** Captures the quick-add controller handle, keeps a ref to the filtered event list, and mounts `useTimelineKeyboard`.
* **`app.tsx`:** Adds a capture-phase F1→timeline / F2→notes handler (no input guard — function keys never insert text, so view-swapping works even while editing).

Tests: four new vitest suites cover the pure modules and the quick-add keyboard API. The integration hook and the F1/F2 handler are wiring-only and follow the project's pattern of not mounting the whole app in tests. Full suite: 1218 passing; `npm run build` and `npm run lint` clean.

---

## 🧪 Manual Test Cases

A human reviewer should verify and tick off the following scenarios

### 🚀 New Behavior
- [ ] `W`/`S` zoom the timeline in/out about the centre.
- [ ] `A`/`D` pan earlier/later; panning covers less time when zoomed in.
- [ ] `Q`/`E` step to the previous/next event chronologically, centring and expanding it.
- [ ] `Space` shows the quick-add marker at centre; `A`/`D` nudge it by 10 minutes; `Space` again opens the new-event prompt at that time; `Esc` cancels quick-add mode.
- [ ] With an event expanded, `Tab`/`Shift+Tab` move focus between its Edit/Delete buttons and `Enter` activates the focused one; `Esc` collapses the card.
- [ ] `F1` swaps to the timeline view, `F2` to the notes view (F1 works even while editing a note).

### 🛡️ Regression Checks
- [ ] Mouse wheel zoom, drag-to-pan, hover quick-add, and click-to-expand all still work as before.
- [ ] Typing W/A/S/D/Q/E into the event editor, note editor, search box, or any input does NOT trigger timeline shortcuts.
- [ ] The mouse quick-add still snaps to 10-minute boundaries (now sourced from the shared constant).


---
_Generated by [Claude Code](https://claude.ai/code/session_01D2F72kanQ5LYerVUYJcwfu)_